### PR TITLE
feat: set up workspace structure, IR types, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        rust: [stable, "1.85"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo check --workspace
+
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --workspace
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/target
+Cargo.lock
+*.pdf
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = ["crates/office2pdf", "crates/office2pdf-cli"]
+resolver = "3"
+
+[workspace.package]
+edition = "2024"
+rust-version = "1.85"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/yhkwon-nb01/office2pdf"

--- a/crates/office2pdf-cli/Cargo.toml
+++ b/crates/office2pdf-cli/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "office2pdf-cli"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "CLI tool to convert DOCX, XLSX, and PPTX files to PDF"
+
+[[bin]]
+name = "office2pdf"
+path = "src/main.rs"
+
+[dependencies]
+office2pdf = { path = "../office2pdf" }
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }

--- a/crates/office2pdf-cli/src/main.rs
+++ b/crates/office2pdf-cli/src/main.rs
@@ -1,0 +1,44 @@
+use std::path::PathBuf;
+use std::process;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(
+    name = "office2pdf",
+    version,
+    about = "Convert DOCX, XLSX, PPTX to PDF"
+)]
+struct Cli {
+    /// Input file path (.docx, .xlsx, .pptx)
+    input: PathBuf,
+
+    /// Output PDF file path (default: input with .pdf extension)
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+}
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("Error: {err:#}");
+        process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let cli = Cli::parse();
+
+    let output = cli
+        .output
+        .unwrap_or_else(|| cli.input.with_extension("pdf"));
+
+    let pdf_bytes =
+        office2pdf::convert(&cli.input).with_context(|| format!("converting {:?}", cli.input))?;
+
+    std::fs::write(&output, pdf_bytes)
+        .with_context(|| format!("writing output to {:?}", output))?;
+
+    println!("Converted: {:?} -> {:?}", cli.input, output);
+    Ok(())
+}

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "office2pdf"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Convert DOCX, XLSX, and PPTX files to PDF using pure Rust"
+
+[dependencies]
+thiserror = "2"
+
+[dev-dependencies]

--- a/crates/office2pdf/src/config.rs
+++ b/crates/office2pdf/src/config.rs
@@ -1,0 +1,40 @@
+/// Supported input document formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    Docx,
+    Pptx,
+    Xlsx,
+}
+
+impl Format {
+    /// Detect format from file extension.
+    pub fn from_extension(ext: &str) -> Option<Self> {
+        match ext.to_ascii_lowercase().as_str() {
+            "docx" => Some(Self::Docx),
+            "pptx" => Some(Self::Pptx),
+            "xlsx" => Some(Self::Xlsx),
+            _ => None,
+        }
+    }
+}
+
+/// Options controlling the conversion process.
+#[derive(Debug, Clone, Default)]
+pub struct ConvertOptions {
+    // Placeholder for future options (paper size, font paths, etc.)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_from_extension() {
+        assert_eq!(Format::from_extension("docx"), Some(Format::Docx));
+        assert_eq!(Format::from_extension("DOCX"), Some(Format::Docx));
+        assert_eq!(Format::from_extension("pptx"), Some(Format::Pptx));
+        assert_eq!(Format::from_extension("xlsx"), Some(Format::Xlsx));
+        assert_eq!(Format::from_extension("pdf"), None);
+        assert_eq!(Format::from_extension("txt"), None);
+    }
+}

--- a/crates/office2pdf/src/error.rs
+++ b/crates/office2pdf/src/error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+/// Errors that can occur during document conversion.
+#[derive(Debug, Error)]
+pub enum ConvertError {
+    #[error("unsupported file format: {0}")]
+    UnsupportedFormat(String),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("parse error: {0}")]
+    Parse(String),
+
+    #[error("render error: {0}")]
+    Render(String),
+}

--- a/crates/office2pdf/src/ir/document.rs
+++ b/crates/office2pdf/src/ir/document.rs
@@ -1,0 +1,134 @@
+use super::elements::Block;
+use super::style::StyleSheet;
+
+/// Top-level document model produced by parsers and consumed by the renderer.
+#[derive(Debug, Clone)]
+pub struct Document {
+    pub metadata: Metadata,
+    pub pages: Vec<Page>,
+    pub styles: StyleSheet,
+}
+
+/// Document metadata.
+#[derive(Debug, Clone, Default)]
+pub struct Metadata {
+    pub title: Option<String>,
+    pub author: Option<String>,
+}
+
+/// A page in the document — variant depends on source format.
+#[derive(Debug, Clone)]
+pub enum Page {
+    /// DOCX: flowing text pages.
+    Flow(FlowPage),
+    /// PPTX: fixed coordinate pages.
+    Fixed(FixedPage),
+    /// XLSX: table-based pages.
+    Table(TablePage),
+}
+
+/// Page dimensions.
+#[derive(Debug, Clone, Copy)]
+pub struct PageSize {
+    /// Width in points (1 pt = 1/72 inch).
+    pub width: f64,
+    /// Height in points.
+    pub height: f64,
+}
+
+impl Default for PageSize {
+    fn default() -> Self {
+        // A4 in points
+        Self {
+            width: 595.28,
+            height: 841.89,
+        }
+    }
+}
+
+/// Page margins in points.
+#[derive(Debug, Clone, Copy)]
+pub struct Margins {
+    pub top: f64,
+    pub bottom: f64,
+    pub left: f64,
+    pub right: f64,
+}
+
+impl Default for Margins {
+    fn default() -> Self {
+        // 1 inch = 72 points
+        Self {
+            top: 72.0,
+            bottom: 72.0,
+            left: 72.0,
+            right: 72.0,
+        }
+    }
+}
+
+/// A flowing-content page (DOCX).
+#[derive(Debug, Clone)]
+pub struct FlowPage {
+    pub size: PageSize,
+    pub margins: Margins,
+    pub content: Vec<Block>,
+}
+
+/// A fixed-layout page (PPTX slides).
+#[derive(Debug, Clone)]
+pub struct FixedPage {
+    pub size: PageSize,
+    pub elements: Vec<FixedElement>,
+}
+
+/// An element with fixed position on a page.
+#[derive(Debug, Clone)]
+pub struct FixedElement {
+    /// X position in points from left edge.
+    pub x: f64,
+    /// Y position in points from top edge.
+    pub y: f64,
+    /// Width in points.
+    pub width: f64,
+    /// Height in points.
+    pub height: f64,
+    /// The content of this element.
+    pub kind: FixedElementKind,
+}
+
+/// Types of fixed-position elements.
+#[derive(Debug, Clone)]
+pub enum FixedElementKind {
+    TextBox(Vec<Block>),
+    Image(super::elements::ImageData),
+    Shape(super::elements::Shape),
+}
+
+/// A table-based page (XLSX sheets).
+#[derive(Debug, Clone)]
+pub struct TablePage {
+    pub name: String,
+    pub size: PageSize,
+    pub margins: Margins,
+    pub table: super::elements::Table,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_page_size_is_a4() {
+        let size = PageSize::default();
+        assert!((size.width - 595.28).abs() < 0.01);
+        assert!((size.height - 841.89).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_default_margins_are_one_inch() {
+        let margins = Margins::default();
+        assert!((margins.top - 72.0).abs() < 0.01);
+        assert!((margins.left - 72.0).abs() < 0.01);
+    }
+}

--- a/crates/office2pdf/src/ir/elements.rs
+++ b/crates/office2pdf/src/ir/elements.rs
@@ -1,0 +1,149 @@
+use super::style::{Color, ParagraphStyle, TextStyle};
+
+/// Block-level content elements.
+#[derive(Debug, Clone)]
+pub enum Block {
+    Paragraph(Paragraph),
+    Table(Table),
+    Image(ImageData),
+    PageBreak,
+}
+
+/// A paragraph consisting of styled text runs.
+#[derive(Debug, Clone)]
+pub struct Paragraph {
+    pub style: ParagraphStyle,
+    pub runs: Vec<Run>,
+}
+
+/// A run of text with uniform formatting.
+#[derive(Debug, Clone)]
+pub struct Run {
+    pub text: String,
+    pub style: TextStyle,
+}
+
+/// A table.
+#[derive(Debug, Clone)]
+pub struct Table {
+    pub rows: Vec<TableRow>,
+    pub column_widths: Vec<f64>,
+}
+
+/// A table row.
+#[derive(Debug, Clone)]
+pub struct TableRow {
+    pub cells: Vec<TableCell>,
+    pub height: Option<f64>,
+}
+
+/// A table cell.
+#[derive(Debug, Clone)]
+pub struct TableCell {
+    pub content: Vec<Block>,
+    pub col_span: u32,
+    pub row_span: u32,
+    pub border: Option<CellBorder>,
+    pub background: Option<Color>,
+}
+
+impl Default for TableCell {
+    fn default() -> Self {
+        Self {
+            content: Vec::new(),
+            col_span: 1,
+            row_span: 1,
+            border: None,
+            background: None,
+        }
+    }
+}
+
+/// Cell border specification.
+#[derive(Debug, Clone)]
+pub struct CellBorder {
+    pub top: Option<BorderSide>,
+    pub bottom: Option<BorderSide>,
+    pub left: Option<BorderSide>,
+    pub right: Option<BorderSide>,
+}
+
+/// A single border side.
+#[derive(Debug, Clone)]
+pub struct BorderSide {
+    pub width: f64,
+    pub color: Color,
+}
+
+/// Image data.
+#[derive(Debug, Clone)]
+pub struct ImageData {
+    pub data: Vec<u8>,
+    pub format: ImageFormat,
+    pub width: Option<f64>,
+    pub height: Option<f64>,
+}
+
+/// Supported image formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImageFormat {
+    Png,
+    Jpeg,
+    Gif,
+    Bmp,
+    Tiff,
+}
+
+/// Basic geometric shape.
+#[derive(Debug, Clone)]
+pub struct Shape {
+    pub kind: ShapeKind,
+    pub fill: Option<Color>,
+    pub stroke: Option<BorderSide>,
+}
+
+/// Shape types.
+#[derive(Debug, Clone)]
+pub enum ShapeKind {
+    Rectangle,
+    Ellipse,
+    Line { x2: f64, y2: f64 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_table_cell_default() {
+        let cell = TableCell::default();
+        assert_eq!(cell.col_span, 1);
+        assert_eq!(cell.row_span, 1);
+        assert!(cell.content.is_empty());
+        assert!(cell.border.is_none());
+        assert!(cell.background.is_none());
+    }
+
+    #[test]
+    fn test_paragraph_with_runs() {
+        let para = Paragraph {
+            style: ParagraphStyle::default(),
+            runs: vec![
+                Run {
+                    text: "Hello ".to_string(),
+                    style: TextStyle::default(),
+                },
+                Run {
+                    text: "world".to_string(),
+                    style: TextStyle {
+                        bold: Some(true),
+                        ..TextStyle::default()
+                    },
+                },
+            ],
+        };
+        assert_eq!(para.runs.len(), 2);
+        assert_eq!(para.runs[0].text, "Hello ");
+        assert_eq!(para.runs[1].style.bold, Some(true));
+    }
+}

--- a/crates/office2pdf/src/ir/mod.rs
+++ b/crates/office2pdf/src/ir/mod.rs
@@ -1,0 +1,7 @@
+mod document;
+mod elements;
+mod style;
+
+pub use document::*;
+pub use elements::*;
+pub use style::*;

--- a/crates/office2pdf/src/ir/style.rs
+++ b/crates/office2pdf/src/ir/style.rs
@@ -1,0 +1,108 @@
+/// Collection of named styles in the document.
+#[derive(Debug, Clone, Default)]
+pub struct StyleSheet {
+    pub styles: Vec<NamedStyle>,
+}
+
+/// A named style that can be referenced by paragraphs/runs.
+#[derive(Debug, Clone)]
+pub struct NamedStyle {
+    pub id: String,
+    pub name: String,
+    pub paragraph: Option<ParagraphStyle>,
+    pub text: Option<TextStyle>,
+}
+
+/// Paragraph-level formatting.
+#[derive(Debug, Clone, Default)]
+pub struct ParagraphStyle {
+    pub alignment: Option<Alignment>,
+    pub indent_left: Option<f64>,
+    pub indent_right: Option<f64>,
+    pub indent_first_line: Option<f64>,
+    pub line_spacing: Option<LineSpacing>,
+    pub space_before: Option<f64>,
+    pub space_after: Option<f64>,
+}
+
+/// Text alignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Alignment {
+    Left,
+    Center,
+    Right,
+    Justify,
+}
+
+/// Line spacing specification.
+#[derive(Debug, Clone, Copy)]
+pub enum LineSpacing {
+    /// Multiplier (e.g. 1.0 = single, 1.5, 2.0 = double).
+    Proportional(f64),
+    /// Exact spacing in points.
+    Exact(f64),
+}
+
+/// Character-level formatting.
+#[derive(Debug, Clone, Default)]
+pub struct TextStyle {
+    pub font_family: Option<String>,
+    pub font_size: Option<f64>,
+    pub bold: Option<bool>,
+    pub italic: Option<bool>,
+    pub underline: Option<bool>,
+    pub strikethrough: Option<bool>,
+    pub color: Option<Color>,
+}
+
+/// RGB color.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Color {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+impl Color {
+    pub fn new(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b }
+    }
+
+    pub fn black() -> Self {
+        Self { r: 0, g: 0, b: 0 }
+    }
+
+    pub fn white() -> Self {
+        Self {
+            r: 255,
+            g: 255,
+            b: 255,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_color_constructors() {
+        let black = Color::black();
+        assert_eq!(black, Color { r: 0, g: 0, b: 0 });
+        let white = Color::white();
+        assert_eq!(
+            white,
+            Color {
+                r: 255,
+                g: 255,
+                b: 255,
+            }
+        );
+    }
+
+    #[test]
+    fn test_stylesheet_default_is_empty() {
+        let ss = StyleSheet::default();
+        assert!(ss.styles.is_empty());
+    }
+}

--- a/crates/office2pdf/src/lib.rs
+++ b/crates/office2pdf/src/lib.rs
@@ -1,0 +1,77 @@
+pub mod config;
+pub mod error;
+pub mod ir;
+pub mod parser;
+pub mod render;
+
+use std::path::Path;
+
+use config::{ConvertOptions, Format};
+use error::ConvertError;
+use parser::Parser;
+
+/// Convert a file at the given path to PDF bytes.
+pub fn convert(path: impl AsRef<Path>) -> Result<Vec<u8>, ConvertError> {
+    convert_with_options(path, &ConvertOptions::default())
+}
+
+/// Convert a file at the given path to PDF bytes with options.
+pub fn convert_with_options(
+    path: impl AsRef<Path>,
+    options: &ConvertOptions,
+) -> Result<Vec<u8>, ConvertError> {
+    let path = path.as_ref();
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .ok_or_else(|| ConvertError::UnsupportedFormat("no file extension".to_string()))?;
+
+    let format = Format::from_extension(ext)
+        .ok_or_else(|| ConvertError::UnsupportedFormat(ext.to_string()))?;
+
+    let data = std::fs::read(path)?;
+    convert_bytes(&data, format, options)
+}
+
+/// Convert raw bytes of a known format to PDF bytes.
+pub fn convert_bytes(
+    data: &[u8],
+    format: Format,
+    _options: &ConvertOptions,
+) -> Result<Vec<u8>, ConvertError> {
+    let parser: Box<dyn Parser> = match format {
+        Format::Docx => Box::new(parser::docx::DocxParser),
+        Format::Pptx => Box::new(parser::pptx::PptxParser),
+        Format::Xlsx => Box::new(parser::xlsx::XlsxParser),
+    };
+
+    let doc = parser.parse(data)?;
+    let typst_source = render::typst_gen::generate_typst(&doc)?;
+    render::pdf::compile_to_pdf(&typst_source)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_unsupported_format() {
+        let result = convert("test.txt");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, ConvertError::UnsupportedFormat(_)));
+    }
+
+    #[test]
+    fn test_convert_no_extension() {
+        let result = convert("test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_convert_bytes_docx_not_yet_implemented() {
+        let result = convert_bytes(b"fake", Format::Docx, &ConvertOptions::default());
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ConvertError::Parse(_)));
+    }
+}

--- a/crates/office2pdf/src/parser/docx.rs
+++ b/crates/office2pdf/src/parser/docx.rs
@@ -1,0 +1,13 @@
+use crate::error::ConvertError;
+use crate::ir::Document;
+use crate::parser::Parser;
+
+pub struct DocxParser;
+
+impl Parser for DocxParser {
+    fn parse(&self, _data: &[u8]) -> Result<Document, ConvertError> {
+        Err(ConvertError::Parse(
+            "DOCX parser not yet implemented".to_string(),
+        ))
+    }
+}

--- a/crates/office2pdf/src/parser/mod.rs
+++ b/crates/office2pdf/src/parser/mod.rs
@@ -1,0 +1,12 @@
+pub mod docx;
+pub mod pptx;
+pub mod xlsx;
+
+use crate::error::ConvertError;
+use crate::ir::Document;
+
+/// Trait for parsing an input file format into the IR.
+pub trait Parser {
+    /// Parse raw file bytes into a Document IR.
+    fn parse(&self, data: &[u8]) -> Result<Document, ConvertError>;
+}

--- a/crates/office2pdf/src/parser/pptx.rs
+++ b/crates/office2pdf/src/parser/pptx.rs
@@ -1,0 +1,13 @@
+use crate::error::ConvertError;
+use crate::ir::Document;
+use crate::parser::Parser;
+
+pub struct PptxParser;
+
+impl Parser for PptxParser {
+    fn parse(&self, _data: &[u8]) -> Result<Document, ConvertError> {
+        Err(ConvertError::Parse(
+            "PPTX parser not yet implemented".to_string(),
+        ))
+    }
+}

--- a/crates/office2pdf/src/parser/xlsx.rs
+++ b/crates/office2pdf/src/parser/xlsx.rs
@@ -1,0 +1,13 @@
+use crate::error::ConvertError;
+use crate::ir::Document;
+use crate::parser::Parser;
+
+pub struct XlsxParser;
+
+impl Parser for XlsxParser {
+    fn parse(&self, _data: &[u8]) -> Result<Document, ConvertError> {
+        Err(ConvertError::Parse(
+            "XLSX parser not yet implemented".to_string(),
+        ))
+    }
+}

--- a/crates/office2pdf/src/render/mod.rs
+++ b/crates/office2pdf/src/render/mod.rs
@@ -1,0 +1,2 @@
+pub mod pdf;
+pub mod typst_gen;

--- a/crates/office2pdf/src/render/pdf.rs
+++ b/crates/office2pdf/src/render/pdf.rs
@@ -1,0 +1,8 @@
+use crate::error::ConvertError;
+
+/// Compile Typst markup to PDF bytes.
+pub fn compile_to_pdf(_typst_source: &str) -> Result<Vec<u8>, ConvertError> {
+    Err(ConvertError::Render(
+        "PDF compilation not yet implemented".to_string(),
+    ))
+}

--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -1,0 +1,9 @@
+use crate::error::ConvertError;
+use crate::ir::Document;
+
+/// Generate Typst markup from a Document IR.
+pub fn generate_typst(_doc: &Document) -> Result<String, ConvertError> {
+    Err(ConvertError::Render(
+        "Typst codegen not yet implemented".to_string(),
+    ))
+}


### PR DESCRIPTION
## Summary
- Establish Cargo workspace with `office2pdf` library crate and `office2pdf-cli` binary crate
- Define the core Intermediate Representation (IR) types: Document, Page (Flow/Fixed/Table), Block, Paragraph, Table, Image, Style, etc.
- Implement public API surface: `convert()`, `convert_with_options()`, `convert_bytes()`
- Set up GitHub Actions CI with check, test, clippy, and fmt across Windows/macOS/Linux + MSRV 1.85

## Key Changes
- **Workspace**: edition 2024, MSRV 1.85, dual MIT/Apache-2.0 license
- **IR types**: Format-independent document model supporting DOCX (FlowPage), PPTX (FixedPage), XLSX (TablePage)
- **Parser trait**: Common interface with stub implementations for DOCX/PPTX/XLSX
- **Render stubs**: Typst codegen and PDF compilation placeholders
- **CLI**: clap v4 derive with input file and `-o` output option
- **CI**: Multi-OS matrix with stable + MSRV toolchains

## Test Plan
- [x] 10 unit tests covering IR types, config, and API surface
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)