### PR TITLE
feat: [US-044] PPTX parser - embedded charts (basic)

### DIFF
--- a/crates/office2pdf/src/ir/document.rs
+++ b/crates/office2pdf/src/ir/document.rs
@@ -109,6 +109,7 @@ pub enum FixedElementKind {
     Shape(super::elements::Shape),
     Table(super::elements::Table),
     SmartArt(super::elements::SmartArt),
+    Chart(super::elements::Chart),
 }
 
 /// A table-based page (XLSX sheets).

--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -211,6 +211,9 @@ fn generate_fixed_element(
         FixedElementKind::SmartArt(smartart) => {
             generate_smartart(out, smartart, elem.width, elem.height);
         }
+        FixedElementKind::Chart(chart) => {
+            generate_chart(out, chart);
+        }
     }
 
     out.push_str("]\n");


### PR DESCRIPTION
## Summary
- Add chart support for PPTX presentations by scanning slide XML for `c:chart` references in graphicFrame elements
- Load and parse chart data from `ppt/charts/chart*.xml` via slide relationship files
- Add `FixedElementKind::Chart` variant for positioning charts on fixed-layout slides
- Reuse existing `chart::parse_chart_xml()` and `generate_chart()` for parsing and Typst rendering

## Test plan
- [x] 2 unit tests for chart ref scanning (basic detection, no-chart slide)
- [x] 3 PPTX integration tests (chart produces element with correct position/data, mixed with text box, no chart)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (464 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)