### PR TITLE
fix: handle new Block variants in docx_fixtures match

### DIFF
--- a/crates/office2pdf/tests/docx_fixtures.rs
+++ b/crates/office2pdf/tests/docx_fixtures.rs
@@ -91,7 +91,11 @@ fn collect_runs_from_block<'a>(block: &'a Block, out: &mut Vec<&'a Run>) {
                 }
             }
         }
-        Block::Image(_) | Block::PageBreak => {}
+        Block::Image(_)
+        | Block::FloatingImage(_)
+        | Block::MathEquation(_)
+        | Block::Chart(_)
+        | Block::PageBreak => {}
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix CI failure on `main` caused by non-exhaustive `match` in `collect_runs_from_block` (`crates/office2pdf/tests/docx_fixtures.rs:76`)
- `Block` enum gained `FloatingImage`, `MathEquation`, and `Chart` variants (PRs #11–#16), but the integration tests merged in PR #5 were written against the old enum
- Added the three missing variants to the no-op match arm (they don't contain `Run` data)

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)