### PR TITLE
feat: US-053 - XLSX DataBar and IconSet conditional formatting

### DIFF
--- a/crates/office2pdf/src/ir/elements.rs
+++ b/crates/office2pdf/src/ir/elements.rs
@@ -162,6 +162,15 @@ pub struct TableRow {
     pub height: Option<f64>,
 }
 
+/// A data bar rendering within a cell (conditional formatting).
+#[derive(Debug, Clone)]
+pub struct DataBarInfo {
+    /// Bar color.
+    pub color: Color,
+    /// Fill percentage from 0.0 to 1.0.
+    pub fill_pct: f64,
+}
+
 /// A table cell.
 #[derive(Debug, Clone)]
 pub struct TableCell {
@@ -170,6 +179,10 @@ pub struct TableCell {
     pub row_span: u32,
     pub border: Option<CellBorder>,
     pub background: Option<Color>,
+    /// DataBar conditional formatting render info.
+    pub data_bar: Option<DataBarInfo>,
+    /// IconSet text symbol prepended to cell content.
+    pub icon_text: Option<String>,
 }
 
 impl Default for TableCell {
@@ -180,6 +193,8 @@ impl Default for TableCell {
             row_span: 1,
             border: None,
             background: None,
+            data_bar: None,
+            icon_text: None,
         }
     }
 }

--- a/crates/office2pdf/src/parser/docx.rs
+++ b/crates/office2pdf/src/parser/docx.rs
@@ -1463,6 +1463,8 @@ fn resolve_vmerge_and_build_rows(raw_rows: &[Vec<RawCell>]) -> Vec<TableRow> {
                         row_span,
                         border: raw_cell.border.clone(),
                         background: raw_cell.background,
+                        data_bar: None,
+                        icon_text: None,
                     });
                 }
                 _ => {
@@ -1473,6 +1475,8 @@ fn resolve_vmerge_and_build_rows(raw_rows: &[Vec<RawCell>]) -> Vec<TableRow> {
                         row_span: 1,
                         border: raw_cell.border.clone(),
                         background: raw_cell.background,
+                        data_bar: None,
+                        icon_text: None,
                     });
                 }
             }

--- a/crates/office2pdf/src/parser/pptx.rs
+++ b/crates/office2pdf/src/parser/pptx.rs
@@ -1392,6 +1392,8 @@ fn parse_pptx_table(reader: &mut Reader<&[u8]>, theme: &ThemeData) -> Result<Tab
                                 None
                             },
                             background: cell_background.take(),
+                            data_bar: None,
+                            icon_text: None,
                         });
                         in_cell = false;
                         in_tc_pr = false;

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -52,8 +52,8 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 3,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Already implemented with collect_row_breaks(), row splitting logic, and 4 comprehensive tests"
     },
     {
       "id": "US-053",
@@ -69,8 +69,8 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 4,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Implemented DataBar as colored box with fill percentage, IconSet as arrow symbols based on value thresholds"
     },
     {
       "id": "US-054",

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -122,3 +122,27 @@ Started: 2026년  2월 27일 금요일 19시 19분 06초 KST
   - Typst has no native shadow support — must approximate with offset duplicate shape
   - Shadow offset calculated via trigonometry: dx = dist * cos(dir_rad), dy = dist * sin(dir_rad)
 ---
+
+## 2026-02-27 - US-053: XLSX DataBar and IconSet conditional formatting
+- What was implemented:
+  - Added `DataBarInfo` IR type (color, fill_pct) in `ir/elements.rs`
+  - Added `data_bar: Option<DataBarInfo>` and `icon_text: Option<String>` to `TableCell`
+  - Extended `CondFmtOverride` to carry data_bar and icon_text
+  - Implemented DataBar parsing: calculates fill percentage from value range min/max
+  - Implemented IconSet parsing: evaluates thresholds to select arrow icons (↓→↑)
+  - DataBar codegen: `#box(width: 100%, fill: gray)[#box(width: N%, fill: color)]` in cell
+  - IconSet codegen: prepends icon text symbol before cell content
+  - Note: umya-spreadsheet has bug in IconSet write (writes `<dataBar>` tags) — handled with default thresholds fallback
+- Files changed:
+  - `crates/office2pdf/src/ir/elements.rs` - DataBarInfo, new fields on TableCell
+  - `crates/office2pdf/src/parser/cond_fmt.rs` - DataBar/IconSet match arms, evaluate_icon_index()
+  - `crates/office2pdf/src/parser/xlsx.rs` - wire data_bar/icon_text from overrides, 2 new tests
+  - `crates/office2pdf/src/render/typst_gen.rs` - DataBar/IconSet rendering in generate_table_cell(), 2 new codegen tests
+  - Also updated `crates/office2pdf/src/parser/docx.rs` and `pptx.rs` for new TableCell fields
+- Dependencies added: None
+- **Learnings for future iterations:**
+  - umya-spreadsheet IconSet struct has a bug: write_to() writes `<dataBar>` instead of `<iconSet>` tags
+  - For IconSet, fall back to default equal-thirds thresholds if cfvos unavailable
+  - ConditionalFormatValueObjectValues: Min/Max/Percent/Percentile/Number/Formula
+  - DataBar fill_pct = (value - min) / (max - min) * 100
+---


### PR DESCRIPTION
## Summary
- Parse DataBar conditional formatting rules from XLSX: calculate fill percentage from min/max value range
- Parse IconSet conditional formatting rules: evaluate thresholds to select arrow symbols (↓→↑)
- Add `DataBarInfo` IR type and `icon_text` field to `TableCell` for rendering
- Render DataBar as colored box with proportional fill in Typst output
- Render IconSet as arrow text symbols prepended to cell content
- Workaround for umya-spreadsheet IconSet serialization bug (writes `<dataBar>` instead of `<iconSet>`)

## Key Changes
- `crates/office2pdf/src/ir/elements.rs` — Added `DataBarInfo` struct, `data_bar`/`icon_text` fields to `TableCell`
- `crates/office2pdf/src/parser/cond_fmt.rs` — DataBar/IconSet parsing with `evaluate_icon_index()` helper
- `crates/office2pdf/src/parser/xlsx.rs` — Wire data_bar/icon_text from overrides to TableCell + 2 parser tests
- `crates/office2pdf/src/render/typst_gen.rs` — DataBar/IconSet Typst codegen + 2 codegen tests
- `crates/office2pdf/src/parser/docx.rs` / `pptx.rs` — Updated TableCell constructors

## Test plan
- [x] 2 new parser tests: `test_cond_fmt_data_bar`, `test_cond_fmt_icon_set`
- [x] 2 new codegen tests: `test_data_bar_codegen`, `test_icon_set_codegen`
- [x] All 505 tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)