### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/crates/office2pdf-cli/Cargo.toml
+++ b/crates/office2pdf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,7 +15,7 @@ name = "office2pdf"
 path = "src/main.rs"
 
 [dependencies]
-office2pdf = { version = "0.1.0", path = "../office2pdf" }
+office2pdf = { version = "0.2.0", path = "../office2pdf" }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- Bump `office2pdf` and `office2pdf-cli` versions from 0.1.0 to 0.2.0
- Update CLI dependency on lib crate to 0.2.0
- Prepares for crates.io publish matching GitHub release v0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)