### PR TITLE
feat: US-062 - wasm-bindgen JavaScript API module

### DIFF
--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../../README.md"
 keywords = ["pdf", "docx", "xlsx", "pptx", "converter"]
 categories = ["text-processing"]
 
+[features]
+wasm = ["wasm-bindgen"]
+
 [dependencies]
 thiserror = "2"
 typst = "0.14"
@@ -22,6 +25,7 @@ serde_json = "1"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 quick-xml = "0.38"
 umya-spreadsheet = "2"
+wasm-bindgen = { version = "0.2", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }

--- a/crates/office2pdf/src/lib.rs
+++ b/crates/office2pdf/src/lib.rs
@@ -42,6 +42,8 @@ pub mod error;
 pub mod ir;
 pub mod parser;
 pub mod render;
+#[cfg(feature = "wasm")]
+pub mod wasm;
 
 use config::{ConvertOptions, Format};
 use error::{ConvertError, ConvertResult};

--- a/crates/office2pdf/src/wasm.rs
+++ b/crates/office2pdf/src/wasm.rs
@@ -1,0 +1,254 @@
+//! WebAssembly bindings for office2pdf via `wasm-bindgen`.
+//!
+//! This module is only available when the `wasm` feature is enabled.
+//! It exports JavaScript-callable functions for converting Office documents
+//! to PDF in browser or Node.js environments.
+
+use wasm_bindgen::prelude::*;
+
+use crate::config::{ConvertOptions, Format};
+use crate::convert_bytes;
+
+/// Internal: convert with format string, returning a `String` error (testable on native).
+fn convert_to_pdf_inner(data: &[u8], format: &str) -> Result<Vec<u8>, String> {
+    let fmt =
+        Format::from_extension(format).ok_or_else(|| format!("unsupported format: {format}"))?;
+    let result = convert_bytes(data, fmt, &ConvertOptions::default()).map_err(|e| e.to_string())?;
+    Ok(result.pdf)
+}
+
+/// Internal: convert with a known `Format`, returning a `String` error (testable on native).
+fn convert_format_inner(data: &[u8], format: Format) -> Result<Vec<u8>, String> {
+    let result =
+        convert_bytes(data, format, &ConvertOptions::default()).map_err(|e| e.to_string())?;
+    Ok(result.pdf)
+}
+
+/// Convert an Office document to PDF.
+///
+/// `data` is the raw bytes of the input document (DOCX, PPTX, or XLSX).
+/// `format` is one of `"docx"`, `"pptx"`, or `"xlsx"` (case-insensitive).
+///
+/// Returns the PDF bytes on success, or throws a JS error string on failure.
+#[wasm_bindgen(js_name = "convertToPdf")]
+pub fn convert_to_pdf(data: &[u8], format: &str) -> Result<Vec<u8>, JsValue> {
+    convert_to_pdf_inner(data, format).map_err(|e| JsValue::from_str(&e))
+}
+
+/// Convert a DOCX document to PDF.
+///
+/// `data` is the raw bytes of a `.docx` file.
+///
+/// Returns the PDF bytes on success, or throws a JS error string on failure.
+#[wasm_bindgen(js_name = "convertDocxToPdf")]
+pub fn convert_docx_to_pdf(data: &[u8]) -> Result<Vec<u8>, JsValue> {
+    convert_format_inner(data, Format::Docx).map_err(|e| JsValue::from_str(&e))
+}
+
+/// Convert a PPTX document to PDF.
+///
+/// `data` is the raw bytes of a `.pptx` file.
+///
+/// Returns the PDF bytes on success, or throws a JS error string on failure.
+#[wasm_bindgen(js_name = "convertPptxToPdf")]
+pub fn convert_pptx_to_pdf(data: &[u8]) -> Result<Vec<u8>, JsValue> {
+    convert_format_inner(data, Format::Pptx).map_err(|e| JsValue::from_str(&e))
+}
+
+/// Convert an XLSX document to PDF.
+///
+/// `data` is the raw bytes of a `.xlsx` file.
+///
+/// Returns the PDF bytes on success, or throws a JS error string on failure.
+#[wasm_bindgen(js_name = "convertXlsxToPdf")]
+pub fn convert_xlsx_to_pdf(data: &[u8]) -> Result<Vec<u8>, JsValue> {
+    convert_format_inner(data, Format::Xlsx).map_err(|e| JsValue::from_str(&e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Write};
+
+    /// Helper: create a minimal valid DOCX via docx-rs builder.
+    fn make_minimal_docx() -> Vec<u8> {
+        let doc = docx_rs::Docx::new().add_paragraph(
+            docx_rs::Paragraph::new().add_run(docx_rs::Run::new().add_text("Hello WASM")),
+        );
+        let mut buf = Cursor::new(Vec::new());
+        doc.build().pack(&mut buf).unwrap();
+        buf.into_inner()
+    }
+
+    /// Helper: create a minimal valid PPTX.
+    fn make_minimal_pptx() -> Vec<u8> {
+        let buf = Vec::new();
+        let cursor = Cursor::new(buf);
+        let mut zip = zip::ZipWriter::new(cursor);
+        let options =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+        zip.start_file("[Content_Types].xml", options).unwrap();
+        zip.write_all(br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+  <Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>
+</Types>"#)
+        .unwrap();
+
+        zip.start_file("_rels/.rels", options).unwrap();
+        zip.write_all(br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+</Relationships>"#)
+        .unwrap();
+
+        zip.start_file("ppt/presentation.xml", options).unwrap();
+        zip.write_all(
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:sldSz cx="9144000" cy="6858000"/>
+  <p:sldIdLst>
+    <p:sldId id="256" r:id="rId2"/>
+  </p:sldIdLst>
+</p:presentation>"#,
+        )
+        .unwrap();
+
+        zip.start_file("ppt/_rels/presentation.xml.rels", options)
+            .unwrap();
+        zip.write_all(br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+</Relationships>"#)
+        .unwrap();
+
+        zip.start_file("ppt/slides/slide1.xml", options).unwrap();
+        zip.write_all(
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="2" name="Title"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm><a:off x="0" y="0"/><a:ext cx="9144000" cy="1000000"/></a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:p><a:r><a:t>Hello WASM</a:t></a:r></a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>"#,
+        )
+        .unwrap();
+
+        zip.finish().unwrap().into_inner()
+    }
+
+    /// Helper: create a minimal valid XLSX.
+    fn make_minimal_xlsx() -> Vec<u8> {
+        let mut book = umya_spreadsheet::new_file();
+        let sheet = book.get_sheet_mut(&0).unwrap();
+        sheet.get_cell_mut("A1").set_value("Hello WASM");
+        let mut cursor = Cursor::new(Vec::new());
+        umya_spreadsheet::writer::xlsx::write_writer(&book, &mut cursor).unwrap();
+        cursor.into_inner()
+    }
+
+    // --- Tests for convert_to_pdf_inner (generic format string API) ---
+
+    #[test]
+    fn test_convert_to_pdf_inner_docx() {
+        let docx = make_minimal_docx();
+        let result = convert_to_pdf_inner(&docx, "docx");
+        assert!(result.is_ok(), "failed: {:?}", result.err());
+        assert!(result.unwrap().starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn test_convert_to_pdf_inner_pptx() {
+        let pptx = make_minimal_pptx();
+        let result = convert_to_pdf_inner(&pptx, "pptx");
+        assert!(result.is_ok(), "failed: {:?}", result.err());
+        assert!(result.unwrap().starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn test_convert_to_pdf_inner_xlsx() {
+        let xlsx = make_minimal_xlsx();
+        let result = convert_to_pdf_inner(&xlsx, "xlsx");
+        assert!(result.is_ok(), "failed: {:?}", result.err());
+        assert!(result.unwrap().starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn test_convert_to_pdf_inner_case_insensitive() {
+        let docx = make_minimal_docx();
+        assert!(convert_to_pdf_inner(&docx, "DOCX").is_ok());
+        assert!(convert_to_pdf_inner(&docx, "Docx").is_ok());
+    }
+
+    #[test]
+    fn test_convert_to_pdf_inner_unsupported_format() {
+        let result = convert_to_pdf_inner(b"dummy", "txt");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("unsupported format"));
+    }
+
+    #[test]
+    fn test_convert_to_pdf_inner_invalid_data() {
+        let result = convert_to_pdf_inner(b"not a docx", "docx");
+        assert!(result.is_err());
+    }
+
+    // --- Tests for convert_format_inner (typed format API) ---
+
+    #[test]
+    fn test_convert_format_inner_docx() {
+        let docx = make_minimal_docx();
+        let result = convert_format_inner(&docx, Format::Docx);
+        assert!(result.is_ok(), "failed: {:?}", result.err());
+        assert!(result.unwrap().starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn test_convert_format_inner_pptx() {
+        let pptx = make_minimal_pptx();
+        let result = convert_format_inner(&pptx, Format::Pptx);
+        assert!(result.is_ok(), "failed: {:?}", result.err());
+        assert!(result.unwrap().starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn test_convert_format_inner_xlsx() {
+        let xlsx = make_minimal_xlsx();
+        let result = convert_format_inner(&xlsx, Format::Xlsx);
+        assert!(result.is_ok(), "failed: {:?}", result.err());
+        assert!(result.unwrap().starts_with(b"%PDF"));
+    }
+
+    #[test]
+    fn test_convert_format_inner_docx_invalid() {
+        assert!(convert_format_inner(b"bad", Format::Docx).is_err());
+    }
+
+    #[test]
+    fn test_convert_format_inner_pptx_invalid() {
+        assert!(convert_format_inner(b"bad", Format::Pptx).is_err());
+    }
+
+    #[test]
+    fn test_convert_format_inner_xlsx_invalid() {
+        assert!(convert_format_inner(b"bad", Format::Xlsx).is_err());
+    }
+}

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -52,7 +52,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 3,
-      "passes": false,
+      "passes": true,
       "notes": "Add to Cargo.toml: [features] wasm = [\"wasm-bindgen\"] and [dependencies] wasm-bindgen = { version = \"0.2\", optional = true }. In lib.rs: #[cfg(feature = \"wasm\")] pub mod wasm; The wasm module should use convert_bytes internally. Use #[wasm_bindgen] attribute on exported functions. For &[u8] parameters, wasm-bindgen uses js_sys::Uint8Array — use #[wasm_bindgen(js_name = convertToPdf)] for JS-friendly naming."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -1,5 +1,6 @@
 ## Codebase Patterns
 - **WASM conditional compilation**: Filesystem-dependent functions (`convert`, `convert_with_options`) use `#[cfg(not(target_arch = "wasm32"))]`. In-memory functions (`convert_bytes`, `render_document`) have no guards. `pdf.rs` has dual `compile_to_pdf` — native uses `MinimalWorld::new(fonts+system)`, wasm32 uses `MinimalWorld::new_embedded_only(embedded fonts only)`. Shared logic in `compile_to_pdf_inner()`. Use `#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]` for functions used only on WASM but tested on native.
+- **WASM wasm-bindgen module**: `src/wasm.rs` behind `#[cfg(feature = "wasm")]`. Feature: `wasm = ["wasm-bindgen"]` (not default). Exported functions: `convertToPdf(data, format)`, `convertDocxToPdf(data)`, `convertPptxToPdf(data)`, `convertXlsxToPdf(data)`. Core logic in `convert_to_pdf_inner()` / `convert_format_inner()` returning `Result<Vec<u8>, String>` — testable on native. `#[wasm_bindgen]` functions are thin wrappers converting `String` → `JsValue`. `JsValue::from_str()` panics on non-wasm32, so never test wasm_bindgen functions directly on native.
 - **WASM dependency fixes**: `zip` must use `default-features = false, features = ["deflate"]` (default pulls in bzip2-sys/zstd-sys C libs). `getrandom` v0.2 needs `js` feature, v0.3 needs `wasm_js` feature — both in `[target.'cfg(target_arch = "wasm32")'.dependencies]`. Use `getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }` for the v0.2 rename trick. All three parsers (DOCX/PPTX/XLSX) and their deps compile on WASM without exclusions.
 - **XLSX embedded charts**: `extract_charts_from_zip(data: &[u8]) -> Vec<Chart>` scans `xl/charts/chart*.xml` entries in ZIP archive via `zip::ZipArchive`. Parses each with `chart::parse_chart_xml()`. Charts appended as `Page::Flow(FlowPage { content: vec![Block::Chart(chart)] })` after all TablePages. Test: `build_xlsx_with_chart()` creates XLSX via umya-spreadsheet, re-opens ZIP to inject chart XML entry at `xl/charts/chart1.xml`.
 - **PDF/A output**: `compile_to_pdf(source, images, pdf_standard: Option<PdfStandard>)`. When `Some(PdfStandard::PdfA2b)`, creates `typst_pdf::PdfStandards::new(&[typst_pdf::PdfStandard::A_2b])` and provides `typst_pdf::Timestamp::new_utc(Datetime)` (PDF/A requires a document date). `ConvertOptions.pdf_standard` threaded from `convert_bytes()` to `compile_to_pdf()`. `render_document()` always passes `None` (backward compat). CLI: `--pdf-a` flag sets `PdfStandard::PdfA2b`. Verify: PDF/A output contains `pdfaid` in XMP metadata.
@@ -121,4 +122,30 @@ Started: 2026년  2월 28일 토요일 01시 35분 02초 KST
   - Use `package = "getrandom"` rename in Cargo.toml when you need to add the same crate twice with different major versions
   - `[target.'cfg(target_arch = "wasm32")'.dependencies]` section ensures WASM deps don't affect native builds
   - `docx-rs`, `umya-spreadsheet`, and all other deps compile fine on WASM after these fixes — no parser exclusions needed
+---
+
+## 2026-02-28 - US-062
+- What was implemented: wasm-bindgen JavaScript API module
+  - Added `wasm` feature flag to `Cargo.toml` with `wasm = ["wasm-bindgen"]`
+  - Added `wasm-bindgen = { version = "0.2", optional = true }` as dependency
+  - Created `src/wasm.rs` module, conditionally compiled with `#[cfg(feature = "wasm")]`
+  - Exported 4 functions with `#[wasm_bindgen]`: `convertToPdf`, `convertDocxToPdf`, `convertPptxToPdf`, `convertXlsxToPdf`
+  - Each function takes `&[u8]` and returns `Result<Vec<u8>, JsValue>`
+  - Internal logic extracted into `convert_to_pdf_inner` and `convert_format_inner` (return `Result<Vec<u8>, String>`) for native-testable core logic
+  - `#[wasm_bindgen]` functions are thin wrappers converting `String` errors to `JsValue`
+  - 12 tests covering all format conversions, error cases, and case-insensitivity
+  - `wasm` feature is NOT enabled by default — native builds unaffected
+  - `cargo check --target wasm32-unknown-unknown -p office2pdf --features wasm` succeeds
+- Files changed:
+  - `crates/office2pdf/Cargo.toml` — added [features] section and wasm-bindgen dependency
+  - `crates/office2pdf/src/lib.rs` — added `#[cfg(feature = "wasm")] pub mod wasm;`
+  - `crates/office2pdf/src/wasm.rs` — new module with wasm-bindgen bindings and tests
+  - `scripts/ralph/prd.json` — marked US-062 passes: true
+- Dependencies added:
+  - `wasm-bindgen` 0.2 (optional, only with `wasm` feature)
+- **Learnings for future iterations:**
+  - `JsValue::from_str()` panics on non-wasm32 targets — cannot test `#[wasm_bindgen]` functions directly on native
+  - Pattern: extract core logic into internal functions returning `Result<T, String>`, wrap with thin `#[wasm_bindgen]` functions that convert to `JsValue`
+  - Use `docx_rs::Docx::new().build().pack()` for test DOCX creation (not manual ZIP) — docx-rs reader requires specific ZIP structure
+  - `wasm-bindgen` `js_name` attribute controls the JS function name: `#[wasm_bindgen(js_name = "convertToPdf")]`
 ---


### PR DESCRIPTION
## Summary
- Add `wasm` feature flag (`wasm = ["wasm-bindgen"]`) to office2pdf library crate
- Add `wasm-bindgen` as optional dependency (v0.2)
- Create `src/wasm.rs` module with `#[wasm_bindgen]` exported functions:
  - `convertToPdf(data, format)` — generic conversion by format string
  - `convertDocxToPdf(data)` — DOCX shortcut
  - `convertPptxToPdf(data)` — PPTX shortcut  
  - `convertXlsxToPdf(data)` — XLSX shortcut
- Feature is NOT enabled by default — native builds completely unaffected
- `cargo check --target wasm32-unknown-unknown -p office2pdf --features wasm` succeeds
- 12 new tests covering all format conversions, error cases, and case-insensitivity

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (507 existing tests unaffected)
- [x] `cargo test --workspace --features wasm` passes (519 total including 12 new)
- [x] `cargo check --target wasm32-unknown-unknown -p office2pdf --features wasm` succeeds
- [x] `cargo check --target wasm32-unknown-unknown -p office2pdf` succeeds (without wasm feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)