### PR TITLE
feat: US-064 - WASM integration test with wasm-pack

### DIFF
--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -31,6 +31,9 @@ wasm-bindgen = { version = "0.2", optional = true }
 getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 paste = "1"

--- a/crates/office2pdf/src/wasm.rs
+++ b/crates/office2pdf/src/wasm.rs
@@ -3,6 +3,25 @@
 //! This module is only available when the `wasm` feature is enabled.
 //! It exports JavaScript-callable functions for converting Office documents
 //! to PDF in browser or Node.js environments.
+//!
+//! # Running WASM integration tests
+//!
+//! WASM integration tests use `wasm-bindgen-test` and require `wasm-pack`:
+//!
+//! ```bash
+//! # Install wasm-pack (one-time setup)
+//! cargo install wasm-pack
+//!
+//! # Run WASM tests in Node.js
+//! cd crates/office2pdf
+//! wasm-pack test --node --features wasm
+//!
+//! # Or run in a headless browser
+//! wasm-pack test --headless --chrome --features wasm
+//! ```
+//!
+//! These tests verify end-to-end WASM conversion by building the library as
+//! a WASM module, loading it, and calling the exported functions.
 
 use wasm_bindgen::prelude::*;
 
@@ -250,5 +269,176 @@ mod tests {
     #[test]
     fn test_convert_format_inner_xlsx_invalid() {
         assert!(convert_format_inner(b"bad", Format::Xlsx).is_err());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WASM integration tests (run via `wasm-pack test --node --features wasm`)
+//
+// These tests compile ONLY when targeting wasm32 and are executed inside a
+// real WASM runtime (Node.js or headless browser). They call the actual
+// `#[wasm_bindgen]`-exported functions and verify end-to-end conversion.
+// ---------------------------------------------------------------------------
+#[cfg(all(target_arch = "wasm32", test))]
+mod wasm_tests {
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    /// Helper: create a minimal valid DOCX via docx-rs builder.
+    fn make_minimal_docx() -> Vec<u8> {
+        use std::io::Cursor;
+        let doc = docx_rs::Docx::new().add_paragraph(
+            docx_rs::Paragraph::new().add_run(docx_rs::Run::new().add_text("Hello WASM")),
+        );
+        let mut buf = Cursor::new(Vec::new());
+        doc.build().pack(&mut buf).unwrap();
+        buf.into_inner()
+    }
+
+    /// Helper: create a minimal valid PPTX.
+    fn make_minimal_pptx() -> Vec<u8> {
+        use std::io::{Cursor, Write};
+        let cursor = Cursor::new(Vec::new());
+        let mut zip = zip::ZipWriter::new(cursor);
+        let options =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+        zip.start_file("[Content_Types].xml", options).unwrap();
+        zip.write_all(br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+  <Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>
+</Types>"#)
+        .unwrap();
+
+        zip.start_file("_rels/.rels", options).unwrap();
+        zip.write_all(br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+</Relationships>"#)
+        .unwrap();
+
+        zip.start_file("ppt/presentation.xml", options).unwrap();
+        zip.write_all(
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:sldSz cx="9144000" cy="6858000"/>
+  <p:sldIdLst>
+    <p:sldId id="256" r:id="rId2"/>
+  </p:sldIdLst>
+</p:presentation>"#,
+        )
+        .unwrap();
+
+        zip.start_file("ppt/_rels/presentation.xml.rels", options)
+            .unwrap();
+        zip.write_all(br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+</Relationships>"#)
+        .unwrap();
+
+        zip.start_file("ppt/slides/slide1.xml", options).unwrap();
+        zip.write_all(
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="2" name="Title"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm><a:off x="0" y="0"/><a:ext cx="9144000" cy="1000000"/></a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:p><a:r><a:t>Hello WASM</a:t></a:r></a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>"#,
+        )
+        .unwrap();
+
+        zip.finish().unwrap().into_inner()
+    }
+
+    /// Helper: create a minimal valid XLSX.
+    fn make_minimal_xlsx() -> Vec<u8> {
+        use std::io::Cursor;
+        let mut book = umya_spreadsheet::new_file();
+        let sheet = book.get_sheet_mut(&0).unwrap();
+        sheet.get_cell_mut("A1").set_value("Hello WASM");
+        let mut cursor = Cursor::new(Vec::new());
+        umya_spreadsheet::writer::xlsx::write_writer(&book, &mut cursor).unwrap();
+        cursor.into_inner()
+    }
+
+    #[wasm_bindgen_test]
+    fn wasm_convert_docx_to_pdf_produces_valid_pdf() {
+        let docx = make_minimal_docx();
+        let result = convert_docx_to_pdf(&docx);
+        assert!(result.is_ok(), "DOCX to PDF conversion failed in WASM");
+        let pdf = result.unwrap();
+        assert!(
+            pdf.starts_with(b"%PDF"),
+            "Output should start with %PDF magic bytes"
+        );
+        assert!(pdf.len() > 100, "PDF output should have meaningful size");
+    }
+
+    #[wasm_bindgen_test]
+    fn wasm_convert_to_pdf_with_docx_format_string() {
+        let docx = make_minimal_docx();
+        let result = convert_to_pdf(&docx, "docx");
+        assert!(
+            result.is_ok(),
+            "convert_to_pdf with 'docx' format failed in WASM"
+        );
+        let pdf = result.unwrap();
+        assert!(pdf.starts_with(b"%PDF"));
+    }
+
+    #[wasm_bindgen_test]
+    fn wasm_convert_pptx_to_pdf_produces_valid_pdf() {
+        let pptx = make_minimal_pptx();
+        let result = convert_pptx_to_pdf(&pptx);
+        assert!(result.is_ok(), "PPTX to PDF conversion failed in WASM");
+        let pdf = result.unwrap();
+        assert!(
+            pdf.starts_with(b"%PDF"),
+            "Output should start with %PDF magic bytes"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn wasm_convert_xlsx_to_pdf_produces_valid_pdf() {
+        let xlsx = make_minimal_xlsx();
+        let result = convert_xlsx_to_pdf(&xlsx);
+        assert!(result.is_ok(), "XLSX to PDF conversion failed in WASM");
+        let pdf = result.unwrap();
+        assert!(
+            pdf.starts_with(b"%PDF"),
+            "Output should start with %PDF magic bytes"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn wasm_convert_to_pdf_invalid_data_returns_error() {
+        let result = convert_docx_to_pdf(b"not a valid docx");
+        assert!(result.is_err(), "Should fail on invalid input data");
+    }
+
+    #[wasm_bindgen_test]
+    fn wasm_convert_to_pdf_unsupported_format_returns_error() {
+        let result = convert_to_pdf(b"dummy", "txt");
+        assert!(result.is_err(), "Should fail on unsupported format string");
     }
 }

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -87,7 +87,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 5,
-      "passes": false,
+      "passes": true,
       "notes": "Add dev-dependencies: wasm-bindgen-test = \"0.3\" (behind cfg). Create tests in src/wasm.rs or a separate test file. The test fixture can be a minimal valid DOCX (ZIP file with [Content_Types].xml and a minimal document.xml). If creating a real DOCX programmatically is too complex, use the smallest fixture from tests/fixtures/docx/. wasm-bindgen-test requires: cargo install wasm-pack, then wasm-pack test --node. If wasm-pack is unavailable in the CI environment, add the test as a separate optional CI step or document it."
     }
   ]

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -166,3 +166,28 @@ Started: 2026년  2월 28일 토요일 01시 35분 02초 KST
   - WASM check only needs to run on one OS since WASM compilation is platform-independent
   - Two separate `cargo check` commands ensure both base library and wasm-bindgen feature compile for WASM
 ---
+
+## 2026-02-28 - US-064
+- What was implemented: WASM integration test with wasm-bindgen-test
+  - Added `wasm-bindgen-test = "0.3"` as a wasm32-target-specific dev-dependency
+  - Created 6 `#[wasm_bindgen_test]` integration tests in `src/wasm.rs::wasm_tests` module
+  - Tests verify end-to-end WASM conversion for all 3 formats: DOCX, PPTX, XLSX
+  - Tests call actual `#[wasm_bindgen]`-exported functions (`convert_docx_to_pdf`, `convert_pptx_to_pdf`, `convert_xlsx_to_pdf`, `convert_to_pdf`)
+  - Tests verify PDF output starts with `%PDF` magic bytes and has meaningful size
+  - Error case tests: invalid data returns error, unsupported format returns error
+  - Tests are gated by `#[cfg(all(target_arch = "wasm32", test))]` — only run in WASM test context
+  - Added module-level documentation with instructions for running WASM tests via `wasm-pack`
+  - Native tests completely unaffected (507 lib + 7 CLI tests pass)
+- Files changed:
+  - `crates/office2pdf/Cargo.toml` — added `[target.'cfg(target_arch = "wasm32")'.dev-dependencies]` with `wasm-bindgen-test`
+  - `crates/office2pdf/src/wasm.rs` — added wasm_tests module and module-level docs
+  - `scripts/ralph/prd.json` — marked US-064 passes: true
+- Dependencies added:
+  - `wasm-bindgen-test` 0.3 (dev-dependency, wasm32 target only)
+- **Learnings for future iterations:**
+  - `wasm-bindgen-test` tests use `#[wasm_bindgen_test]` attribute and are run via `wasm-pack test --node --features wasm`
+  - Tests gated by `#[cfg(all(target_arch = "wasm32", test))]` are completely invisible to `cargo test` on native — no overhead
+  - `[target.'cfg(target_arch = "wasm32")'.dev-dependencies]` keeps WASM-only test deps from affecting native builds
+  - Test helpers can reuse the same DOCX/PPTX/XLSX creation patterns as native tests since those libraries all compile on wasm32
+  - `wasm-pack test` can run in Node.js (`--node`) or headless browser (`--headless --chrome`)
+---


### PR DESCRIPTION
## Summary
- Added `wasm-bindgen-test` as a wasm32-target-specific dev-dependency
- Created 6 `#[wasm_bindgen_test]` integration tests verifying end-to-end WASM conversion for DOCX, PPTX, and XLSX formats
- Tests call actual `#[wasm_bindgen]`-exported functions and verify PDF output (%PDF magic bytes)
- Tests gated by `#[cfg(all(target_arch = "wasm32", test))]` — invisible to native `cargo test`
- Added module-level documentation with `wasm-pack test` instructions

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (507 lib + 7 CLI tests, WASM tests are cfg-gated out)
- [x] `cargo check --workspace` passes
- [x] `cargo check --target wasm32-unknown-unknown -p office2pdf --features wasm` passes
- [ ] CI pipeline passes (includes WASM check job)
- [ ] Optional: `wasm-pack test --node --features wasm` (requires wasm-pack installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)