### PR TITLE
chore: bump version to 0.3.0 and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ No LibreOffice, no Chromium, no Docker — just a single binary powered by [Typs
 ## Features
 
 - **DOCX** — paragraphs, inline formatting (bold/italic/underline/color), tables, images, lists, headers/footers, page setup
-- **PPTX** — slides, text boxes, shapes, images, slide masters, speaker notes
-- **XLSX** — sheets, cell formatting, merged cells, column widths, row heights
+- **PPTX** — slides, text boxes, shapes, images, slide masters, speaker notes, gradient backgrounds, shadow/reflection effects
+- **XLSX** — sheets, cell formatting, merged cells, column widths, row heights, conditional formatting (DataBar, IconSet)
 - **PDF/A-2b** — archival-compliant output via `--pdf-a`
+- **WASM** — runs in browsers and Node.js via WebAssembly (optional `wasm` feature)
 - **Zero external dependencies** — runs as a standalone executable
 
 ## Installation
@@ -23,7 +24,7 @@ No LibreOffice, no Chromium, no Docker — just a single binary powered by [Typs
 
 ```toml
 [dependencies]
-office2pdf = "0.1"
+office2pdf = "0.3"
 ```
 
 ### CLI
@@ -82,6 +83,30 @@ office2pdf document.docx --pdf-a
 office2pdf report.docx --font-path /usr/share/fonts/custom
 ```
 
+### WASM (Browser / Node.js)
+
+Build with `wasm-pack`:
+
+```sh
+wasm-pack build crates/office2pdf --target web --features wasm
+```
+
+Use from JavaScript:
+
+```js
+import init, { convertDocxToPdf, convertToPdf } from './pkg/office2pdf.js';
+
+await init();
+
+const docxBytes = new Uint8Array(await file.arrayBuffer());
+const pdfBytes = convertDocxToPdf(docxBytes);
+
+// Or use the generic API with a format string
+const pdfBytes2 = convertToPdf(xlsxBytes, "xlsx");
+```
+
+Available functions: `convertToPdf(data, format)`, `convertDocxToPdf(data)`, `convertPptxToPdf(data)`, `convertXlsxToPdf(data)`.
+
 ## CLI Options
 
 | Flag | Description |
@@ -100,8 +125,8 @@ office2pdf report.docx --font-path /usr/share/fonts/custom
 | Format | Status | Key Features |
 |--------|--------|-------------|
 | DOCX | Supported | Text, tables, images, lists, headers/footers, page setup |
-| PPTX | Supported | Slides, text boxes, shapes, images, masters |
-| XLSX | Supported | Sheets, formatting, merged cells, column/row sizing |
+| PPTX | Supported | Slides, text boxes, shapes, images, masters, gradients, effects |
+| XLSX | Supported | Sheets, formatting, merged cells, column/row sizing, conditional formatting |
 
 ## License
 

--- a/crates/office2pdf-cli/Cargo.toml
+++ b/crates/office2pdf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf-cli"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -15,7 +15,7 @@ name = "office2pdf"
 path = "src/main.rs"
 
 [dependencies]
-office2pdf = { version = "0.2.0", path = "../office2pdf" }
+office2pdf = { version = "0.3.0", path = "../office2pdf" }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- Bump `office2pdf` and `office2pdf-cli` versions from 0.2.0 to 0.3.0
- Update README with WASM/JavaScript usage section (browser & Node.js)
- Update feature descriptions: PPTX gradient backgrounds, shadow/reflection effects; XLSX conditional formatting (DataBar, IconSet)
- Fix library version in installation example from `0.1` to `0.3`

## Key Changes

- `crates/office2pdf/Cargo.toml` — version 0.2.0 → 0.3.0
- `crates/office2pdf-cli/Cargo.toml` — version 0.2.0 → 0.3.0, dependency 0.2.0 → 0.3.0
- `README.md` — WASM Quick Start section, updated feature list, updated Supported Formats table

## Test plan

- [ ] CI passes (cargo check, cargo test, cargo fmt, cargo clippy)
- [ ] Verify `cargo publish --dry-run -p office2pdf` succeeds
- [ ] Verify `cargo publish --dry-run -p office2pdf-cli` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)