### PR TITLE
feat: US-071 - Fix nested list double-content-block in Typst codegen

### DIFF
--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -36,7 +36,7 @@
         "Verify: cargo run -p office2pdf-cli -- tests/fixtures/docx/numberings.docx -o /tmp/test.pdf succeeds"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": "The key insight: `list.item[body]` takes exactly one positional (body) argument. Two `[...]` blocks means two positional args which Typst rejects as 'unexpected argument'. The fix is to keep the content block open while emitting nested lists."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -90,3 +90,16 @@ Started: 2026년  2월 28일 토요일 09시 05분 04초 KST
   - Typst's `rgb()` function accepts both 3 args (r,g,b) and 4 args (r,g,b,a) — there is no separate `rgba()` function
   - Simple string replacements like this can be done confidently across format strings and test assertions
 ---
+
+## 2026-02-28 - US-071
+- Fixed nested list double-content-block bug in `generate_list_items()`
+- Previous code emitted `list.item[text][#list(...)]` (two body arguments) which Typst rejected
+- Fix: keep content block open when nested items exist, emit `list.item[text #list(...)]` (single body)
+- Added test `test_nested_list_single_content_block` to assert no `][#list` pattern in output
+- Files changed: `crates/office2pdf/src/render/typst_gen.rs`
+- Dependencies added: none
+- Verified all 4 affected fixtures: `ComplexNumberedLists.docx`, `numberings.docx`, `unit_test_formatting.docx`, `unit_test_lists.docx`
+- **Learnings for future iterations:**
+  - Typst's `list.item`/`enum.item` accept exactly ONE positional body argument — two `[...]` blocks means two args which is an error
+  - The fix was moving the closing `]` bracket after the nested list emission, not before
+---


### PR DESCRIPTION
## Summary
- Fixed `generate_list_items()` in Typst codegen to emit a single content block per list item when nested sub-lists are present
- Previously emitted `list.item[text][#list(...)]` (two body arguments), which Typst rejected as "unexpected argument"
- Now correctly emits `list.item[text #list(...)]` (single body argument with nested list inside)
- Added unit test `test_nested_list_single_content_block` to prevent regression

## Test plan
- [x] New test `test_nested_list_single_content_block` asserts no `][#list` pattern in output
- [x] Existing `test_generate_nested_list` still passes
- [x] All 508 workspace tests pass
- [x] Verified fixture conversion: `ComplexNumberedLists.docx`, `numberings.docx`, `unit_test_formatting.docx`, `unit_test_lists.docx`
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)