### PR TITLE
feat: US-073 - Sort gradient stops by position before rendering

### DIFF
--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -72,7 +72,7 @@
         "Verify: cargo run -p office2pdf-cli -- tests/fixtures/pptx/backgrounds.pptx -o /tmp/test.pdf succeeds"
       ],
       "priority": 4,
-      "passes": false,
+      "passes": true,
       "notes": "The GradientStop struct has a `position: f64` field. Sort by this before generating the Typst gradient.linear() call. The GradientFill and GradientStop types are in ir/ module — check if they derive Clone. If not, you'll need to collect into a new Vec of references and sort that."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -123,3 +123,16 @@ Started: 2026년  2월 28일 토요일 09시 05분 04초 KST
   - When `column_widths` is empty, Typst defaults to 1 column. Must emit `columns: N` to specify the correct count.
   - Rowspan tracking requires careful timing: set `rowspan_remaining = rowspan` (full value), decrement at START of each row.
 ---
+
+## 2026-02-28 - US-073
+- Sorted gradient stops by position before rendering in `write_gradient_fill()`
+- Also clamped first stop to 0% and last stop to 100% (Typst requires boundary constraints)
+- Added test `test_gradient_unsorted_stops_rendered_in_sorted_order` verifying reverse-ordered stops render correctly
+- Files changed: `crates/office2pdf/src/render/typst_gen.rs`
+- Dependencies added: none
+- Verified fixture: `backgrounds.pptx` converts successfully
+- **Learnings for future iterations:**
+  - Typst gradient requirements are strict: stops must be in monotonic order AND first stop must be at 0%, last at 100%
+  - Sorting alone isn't enough — boundary clamping is also needed as a safety net
+  - The `GradientStop` struct derives `Clone`, so cloning and sorting is straightforward
+---


### PR DESCRIPTION
## Summary
- Sort gradient stops by position before rendering in `write_gradient_fill()` to satisfy Typst's monotonic offset requirement
- Clamp first stop to 0% and last stop to 100% as Typst requires boundary constraints
- Added unit test verifying reverse-ordered stops render in sorted order

## Test plan
- [x] Unit test: `test_gradient_unsorted_stops_rendered_in_sorted_order` — verifies reverse-ordered stops are sorted
- [x] Fixture verification: `backgrounds.pptx` converts to PDF successfully
- [x] All 512+ existing tests pass
- [x] `cargo fmt`, `cargo clippy`, `cargo check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)