### PR TITLE
feat: US-081 - Replace hardcoded PDF/A timestamp with actual conversion time

### DIFF
--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -41,7 +41,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": "Check if typst-pdf handles timestamps internally. The fix may be in how we construct the PdfOptions or PdfStandard configuration passed to typst_pdf::pdf(). Look at how typst-pdf's API accepts metadata — it may have a creation_date field. Prefer std::time::SystemTime over adding chrono as a dependency."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -98,3 +98,17 @@ Started: 2026년  2월 28일 토요일 13시 48분 17초 KST
   - `zip::write::FileOptions` in zip 0.6 does NOT take generic parameters (unlike zip 2.x)
   - Empty property strings from umya-spreadsheet need to be converted to None
 ---
+
+## 2026-02-28 - US-081
+- Replaced hardcoded PDF/A timestamp (2024-01-01) with actual conversion time
+- Added ISO 8601 date parsing for metadata created dates → emitted as `#set document(date: datetime(...))`
+- Files changed:
+  - `crates/office2pdf/src/render/pdf.rs` — Added `current_utc_datetime()` using `std::time::SystemTime` + Hinnant's algorithm; replaced hardcoded `Datetime::from_ymd_hms(2024, 1, 1, ...)` with `current_utc_datetime()`
+  - `crates/office2pdf/src/render/typst_gen.rs` — Added `parse_iso8601_date()` parser; updated `generate_document_metadata()` to emit `date: datetime(...)` when metadata has a created date
+- Dependencies added: None (used `std::time::SystemTime` and `std::time::UNIX_EPOCH`)
+- **Learnings for future iterations:**
+  - `typst_pdf::PdfOptions.timestamp` is a single `Option<Timestamp>` used for both CreationDate and ModDate — can't set them independently
+  - `typst_pdf` uses the `timestamp` only when `#set document(date: ..)` is not explicitly set (Smart::Auto)
+  - Howard Hinnant's civil date algorithm is the standard way to convert Unix timestamps to Y/M/D without chrono
+  - Metadata dates from OOXML are ISO 8601 format (e.g., `2024-06-15T10:30:00Z`) — simple substring parsing works reliably
+---


### PR DESCRIPTION
## Summary
- Replaced hardcoded `2024-01-01` PDF/A timestamp with actual conversion time using `std::time::SystemTime`
- Added `current_utc_datetime()` helper that converts system time to UTC `Datetime` via Howard Hinnant's civil date algorithm
- Added ISO 8601 date parsing (`parse_iso8601_date()`) for metadata created dates
- Updated Typst codegen to emit `#set document(date: datetime(...))` when document metadata includes a created date
- No new external dependencies — uses only `std::time`

## Key Changes
- `crates/office2pdf/src/render/pdf.rs`: `current_utc_datetime()` function + replaced hardcoded timestamp
- `crates/office2pdf/src/render/typst_gen.rs`: `parse_iso8601_date()` + updated `generate_document_metadata()` to emit date

## Test plan
- [x] `test_pdfa_timestamp_is_not_hardcoded` — verifies PDF/A output no longer contains `2024-01-01T00:00:00`
- [x] `test_pdfa_timestamp_has_recent_date` — verifies XMP metadata has creation date, not hardcoded
- [x] `test_current_utc_datetime_is_valid` — verifies helper produces valid Datetime
- [x] `test_generate_typst_with_metadata_created_date` — verifies codegen emits date from metadata
- [x] `test_generate_typst_with_metadata_date_only` — verifies date emitted even without title/author
- [x] `test_generate_typst_with_invalid_created_date` — verifies invalid dates are silently ignored
- [x] `test_parse_iso8601_date_full/date_only/invalid` — unit tests for ISO 8601 parser
- [x] All 122 tests passing, cargo fmt/clippy/check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)