### PR TITLE
feat: US-085 - Extend PPTX geometry mapping beyond rect/ellipse/line

### DIFF
--- a/crates/office2pdf/src/ir/elements.rs
+++ b/crates/office2pdf/src/ir/elements.rs
@@ -312,7 +312,18 @@ pub struct Shape {
 pub enum ShapeKind {
     Rectangle,
     Ellipse,
-    Line { x2: f64, y2: f64 },
+    Line {
+        x2: f64,
+        y2: f64,
+    },
+    /// Rectangle with rounded corners. `radius_fraction` is relative to `min(width, height)`.
+    RoundedRectangle {
+        radius_fraction: f64,
+    },
+    /// Arbitrary polygon defined by vertices normalized to 0.0–1.0 relative to the bounding box.
+    Polygon {
+        vertices: Vec<(f64, f64)>,
+    },
 }
 
 #[cfg(test)]

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -20,7 +20,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 1,
-      "passes": false,
+      "passes": true,
       "notes": "Start by reading the existing shape handling in pptx.rs and typst_gen.rs. Typst supports #polygon() for arbitrary polygons and #rect(radius: ...) for rounded rectangles. For arrow shapes, a polygon with 7 vertices works well. Calculate vertex positions relative to the bounding box. Don't try to support ALL OOXML presets — focus on the most visually impactful ones."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -47,7 +47,8 @@
 - **PPTX slide XML structure**: Shapes at `<p:spTree>/<p:sp>`. Position/size: `<a:xfrm><a:off x y/><a:ext cx cy/></a:xfrm>` (EMU ÷ 12700 = points). Text: `<p:txBody>/<a:p>/<a:r>/<a:t>`. Run props: `<a:rPr b="1" i="1" u="sng" strike="sngStrike" sz="1800">` (sz in hundredths of pt). Font color: `<a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>`. Font family: `<a:latin typeface="..."/>`. Para alignment: `<a:pPr algn="ctr|l|r|just"/>`.
 - **Test PPTX creation**: Build ZIP in-memory with `zip::ZipWriter::new(Cursor::new(Vec::new()))`. Need `[Content_Types].xml`, `_rels/.rels`, `ppt/presentation.xml`, `ppt/_rels/presentation.xml.rels`, and `ppt/slides/slideN.xml`. Standard 4:3 size: 9144000 × 6858000 EMU = 720pt × 540pt.
 - **quick-xml 0.38 API**: Use `Reader::from_str(xml)`, `reader.read_event()` → `Event::Start/Empty/End/Text/Eof`. `BytesText::xml_content()` (NOT `unescape()`!) for text decoding. `BytesStart::local_name().as_ref()` for element name. Attributes: iterate `e.attributes().flatten()`, match `attr.key.as_ref()` (full name like `r:id`) or `attr.key.local_name().as_ref()` (local). `attr.unescape_value()` for string values.
-- **PPTX shapes**: `<p:sp>` without text body → Shape IR element. Geometry from `<a:prstGeom prst="rect|ellipse|line">`. Fill color: `<p:spPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>`. Border: `<a:ln w="12700"><a:solidFill>...</a:solidFill></a:ln>` (w in EMU, ÷12700 → pt). Use `SolidFillCtx` enum to distinguish shape fill vs line fill vs run fill contexts.
+- **PPTX shapes**: `<p:sp>` without text body → Shape IR element. Geometry from `<a:prstGeom prst="rect|ellipse|line|roundRect|triangle|...">`. Fill color: `<p:spPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>`. Border: `<a:ln w="12700"><a:solidFill>...</a:solidFill></a:ln>` (w in EMU, ÷12700 → pt). Use `SolidFillCtx` enum to distinguish shape fill vs line fill vs run fill contexts.
+- **Extended PPTX geometry**: `ShapeKind` enum: Rectangle, Ellipse, Line, RoundedRectangle { radius_fraction }, Polygon { vertices: Vec<(f64,f64)> }. `prst_to_shape_kind()` maps 16+ OOXML presets: roundRect→RoundedRectangle(0.1), triangle/rtTriangle/diamond→Polygon(3-4 vertices), pentagon/hexagon/octagon→regular_polygon_vertices(n), rightArrow/leftArrow/upArrow/downArrow→arrow_vertices(dir) (7 vertices), star4/star5/star6→star_vertices(n) (2n vertices). Vertices normalized 0.0-1.0, scaled by width/height at codegen. Codegen: RoundedRectangle→`#rect(..., radius: Xpt)`, Polygon→`#polygon((x1pt, y1pt), ...)`. Shadow support for both. Unsupported presets fall back to Rectangle.
 - **PPTX images**: `<p:pic>` element. Position/size from `<p:spPr><a:xfrm>`. Image ref: `<a:blip r:embed="rId3"/>`. Resolve rId via slide .rels file (`ppt/slides/_rels/slideN.xml.rels`), then read image bytes from ZIP. Image format detected from file extension.
 - **PPTX slide .rels**: Path pattern: `ppt/slides/_rels/slideN.xml.rels`. Image targets are relative paths like `../media/image1.png`. Use `resolve_relative_path()` to compute full ZIP path from slide directory.
 - **docx-rs image handling**: Images in document tree: `RunChild::Drawing(Box<Drawing>)` → `Drawing.data = Some(DrawingData::Pic(pic))`. Image binary data: stored in `Docx.images` as `Vec<(id, path, Image, Png)>` — match `pic.id` to look up data. `pic.image` is empty when reading (only used during writing). Dimensions: `pic.size = (w_emu, h_emu)` in EMU. Convert: EMU ÷ 12700 = points. All images converted to PNG by docx-rs.
@@ -78,4 +79,23 @@
 
 # Ralph Progress Log - Phase 9: Quality & Fidelity - Geometry, SmartArt/Chart, Font Substitution, Compression
 Started: 2026년  2월 28일 토요일 15시 39분 36초 KST
+---
+
+## 2026-02-28 - US-085
+- Extended PPTX shape geometry mapping from 3 presets (rect/ellipse/line) to 16+ presets
+- Added `ShapeKind::RoundedRectangle` and `ShapeKind::Polygon` IR variants
+- Implemented `regular_polygon_vertices(n)`, `arrow_vertices(dir)`, `star_vertices(n)` geometry helpers
+- Added Typst codegen: `#polygon()` for arbitrary polygons, `#rect(radius:)` for rounded rectangles
+- Shadow support for all new shape types
+- Files changed:
+  - `crates/office2pdf/src/ir/elements.rs` — extended ShapeKind enum
+  - `crates/office2pdf/src/parser/pptx.rs` — extended prst_to_shape_kind() + geometry helpers + 17 new tests
+  - `crates/office2pdf/src/render/typst_gen.rs` — polygon/rounded-rect codegen + shadow handling + 4 new tests
+  - `scripts/ralph/prd.json` — marked US-085 passes: true
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - Normalized vertex coordinates (0.0-1.0) scaled at codegen time is a clean pattern for resolution-independent shapes
+  - Arrow shapes need 7 vertices; transforming right-arrow template via coordinate mirroring/rotation handles all 4 directions
+  - Star shapes use alternating outer/inner radius vertices (2n total for n-pointed star)
+  - clippy enforces `writeln!` over `write!(...\n)` — always use writeln! for trailing newlines
 ---


### PR DESCRIPTION
## Summary
- Extended PPTX shape geometry mapping from 3 presets (rect/ellipse/line) to 16+ presets
- Added `ShapeKind::RoundedRectangle` and `ShapeKind::Polygon` IR variants to support non-rectangular shapes
- Implemented geometry helpers: `regular_polygon_vertices(n)`, `arrow_vertices(dir)`, `star_vertices(n)`
- Added Typst codegen for `#polygon()` (arbitrary polygons) and `#rect(radius:)` (rounded rectangles)
- Shadow support extended for all new shape types
- Unsupported complex presets still fall back to rectangle

Newly supported shapes: triangle, rtTriangle, diamond, roundRect, pentagon, hexagon, octagon, rightArrow, leftArrow, upArrow, downArrow, star4, star5, star6

## Test plan
- [x] 17 new parser tests: triangle, rtTriangle, roundRect, diamond, pentagon, hexagon, octagon, rightArrow, leftArrow, upArrow, downArrow, star4, star5, star6, unsupported fallback
- [x] 4 new codegen tests: triangle polygon, rounded rectangle, arrow polygon, polygon with stroke
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (893 total tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)