### PR TITLE
feat: US-089 - PDF output size optimization via stream compression and font subsetting

### DIFF
--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -99,7 +99,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 5,
-      "passes": false,
+      "passes": true,
       "notes": "This story is more investigative than coding-heavy. Start by examining the typst-pdf API and its PdfOptions/export settings. Check if there's a compression level setting. Then measure actual output sizes for existing fixtures and compare to expected sizes. The Typst team maintains typst-pdf so compression should already be good — but verify. If typst-pdf handles everything well, the story becomes mostly about adding size regression tests."
     }
   ]

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -181,3 +181,33 @@ Started: 2026년  2월 28일 토요일 15시 39분 36초 KST
   - `to_ascii_lowercase()` is sufficient for case-insensitive matching of font names (ASCII-only)
   - clippy enforces inner doc comments (`//!`) for module-level docs, not `///` followed by blank line
 ---
+
+## 2026-02-28 - US-089
+- Verified PDF output size optimization: typst-pdf (via krilla) applies all key optimizations by default
+- Confirmed FLATE content stream compression is active (FlateDecode in PDF output)
+- Confirmed font subsetting is active (fewer glyphs → smaller PDF)
+- Confirmed images are passed through without unnecessary re-encoding
+- Added 6 PDF optimization unit tests in `render/pdf.rs`:
+  - `test_pdf_uses_flate_compression` — verifies FlateDecode filter presence
+  - `test_font_subsetting_reduces_size` — fewer glyphs produce smaller PDF
+  - `test_multipage_text_pdf_size_reasonable` — 10-page text < 500KB
+  - `test_pdf_with_image_size_proportional` — image PDF proportional to input
+  - `test_empty_page_pdf_baseline_size` — baseline overhead under 100KB
+  - `test_compression_effective_for_repetitive_content` — 100x content < 10x PDF size
+- Added 2 end-to-end IR pipeline size tests in `lib.rs`:
+  - `test_render_multipage_document_size` — 10-page FlowPage IR < 500KB
+  - `test_render_pptx_style_document_size` — 5-slide FixedPage IR < 500KB
+- Documented compression behavior in `compile_to_pdf()` doc comments
+- Files changed:
+  - `crates/office2pdf/src/render/pdf.rs` — 6 new tests + compression documentation
+  - `crates/office2pdf/src/lib.rs` — 2 new end-to-end size tests
+  - `scripts/ralph/prd.json` — marked US-089 passes: true
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - typst-pdf delegates to krilla for PDF generation; krilla defaults: `compress_content_streams: true`
+  - Font subsetting via `subsetter` crate is automatic — no configuration needed
+  - Images embedded as-is (pass-through); no re-encoding overhead
+  - Typical PDF sizes: empty page ~10-30KB, 10-page text ~30-60KB
+  - `PdfOptions` in typst-pdf 0.14 exposes: ident, timestamp, page_ranges, standards, tagged
+  - No user-facing compression toggle needed since all optimizations are always active
+---


### PR DESCRIPTION
## Summary

- Verified and documented that typst-pdf (via krilla) applies all key PDF output size optimizations by default:
  - FLATE content stream compression (`compress_content_streams: true`)
  - Automatic font subsetting (only used glyphs embedded)
  - Image pass-through (no re-encoding overhead)
- Added 6 PDF optimization unit tests in `render/pdf.rs` verifying compression, subsetting, and size bounds
- Added 2 end-to-end IR pipeline size regression tests in `lib.rs` for multi-page and slide documents
- Documented compression behavior and expected output sizes in `compile_to_pdf()` doc comments

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (all 619+ tests)
- [x] `cargo check --workspace` passes
- [x] FlateDecode filter verified in PDF output
- [x] Font subsetting demonstrated (fewer glyphs → smaller PDF)
- [x] 10-page text PDF under 500KB
- [x] Image PDF proportional to input size
- [x] Compression effective for repetitive content (100x content < 10x size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)