### PR TITLE
feat: US-092 - Enable multi-threaded PDF compression via rayon

### DIFF
--- a/crates/office2pdf-cli/Cargo.toml
+++ b/crates/office2pdf-cli/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 office2pdf = { version = "0.3.0", path = "../office2pdf" }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+rayon = "1"
 
 [dev-dependencies]
 docx-rs = "0.4"

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -59,7 +59,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 3,
-      "passes": false,
+      "passes": true,
       "notes": "Rayon is a well-known Rust parallelism crate and is justified as a dependency for this use case. Check if rayon is already in the dependency tree (typst may depend on it). The key insight is that each file conversion is fully independent — no shared state — so par_iter() is straightforward. Be careful with error handling in parallel context — use rayon's error collection patterns."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -129,3 +129,23 @@ Started: 2026년  2월 28일 토요일 17시 23분 18초 KST
   - XLSX compile time is higher than DOCX/PPTX even with warm cache (~220ms vs ~12ms) likely due to more complex Typst output (many tables).
   - Consolidating ZIP opens is a structural improvement but has minimal absolute impact when parse stage is already fast (<30ms).
 ---
+
+## 2026-02-28 - US-092
+- What was implemented: Multi-threaded batch conversion via rayon
+  - Added `rayon = "1"` as direct dependency in `office2pdf-cli` (already transitive via typst)
+  - `--jobs N` (`-j N`) CLI flag to control parallelism (default: 0 = all CPU cores)
+  - `convert_batch()` now accepts a `jobs` parameter; when `jobs > 1` and multiple inputs, creates a local rayon `ThreadPool` with `num_threads(jobs)` and uses `par_iter()` for parallel file conversion
+  - Single-file or `jobs=1` falls back to sequential iteration (no rayon overhead)
+  - Each conversion is fully independent (no shared mutable state), so `par_iter()` is straightforward
+- Files changed:
+  - `crates/office2pdf-cli/Cargo.toml` — Added `rayon = "1"` dependency
+  - `crates/office2pdf-cli/src/main.rs` — Added `--jobs` CLI flag, modified `convert_batch()` signature and implementation with rayon parallel support, added 5 new tests (parallel jobs=2, parallel partial failure, parallel outdir, single file with jobs, sequential jobs=1), updated existing tests to pass `jobs` parameter
+  - `scripts/ralph/prd.json` — Marked US-092 as passes: true
+- Dependencies added: `rayon = "1"` (already in dependency tree via typst, justified for parallel batch conversion)
+- **Learnings for future iterations:**
+  - Local `rayon::ThreadPool` via `ThreadPoolBuilder::new().num_threads(n).build()` is preferred over `build_global()` — allows tests to create independent pools without global state conflicts
+  - `pool.install(|| inputs.par_iter().map(...).collect())` is the clean pattern for scoped parallel work
+  - `std::thread::available_parallelism()` is the stdlib equivalent of `num_cpus` — no extra crate needed for defaults
+  - `ConvertOptions` is automatically `Send + Sync` since all fields are owned value types — no special handling needed for parallel use
+  - When `jobs=0`, resolve to available_parallelism at runtime; rayon's `num_threads(0)` also uses this default
+---


### PR DESCRIPTION
## Summary
- Added `rayon` dependency to CLI crate for parallel batch conversion
- New `--jobs N` (`-j N`) CLI flag to control number of parallel conversion threads (default: all CPU cores)
- `convert_batch()` uses rayon's `par_iter()` with a local thread pool for multi-file conversions
- Falls back to sequential mode for single-file or `--jobs 1` cases

## Key Changes
- `crates/office2pdf-cli/Cargo.toml` — Added `rayon = "1"` (already transitive via typst)
- `crates/office2pdf-cli/src/main.rs` — `--jobs` flag, parallel `convert_batch()`, 5 new tests
- Updated PRD and progress log

## Test plan
- [x] `test_batch_convert_parallel_jobs_2` — 4 files converted in parallel with jobs=2
- [x] `test_batch_convert_parallel_partial_failure` — Mixed success/failure in parallel
- [x] `test_batch_convert_parallel_with_outdir` — Parallel with output directory
- [x] `test_batch_convert_single_file_with_jobs` — Single file with jobs > 1
- [x] `test_batch_convert_sequential_jobs_1` — Sequential fallback with jobs=1
- [x] All existing tests still pass (13 CLI tests, full workspace)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)