### PR TITLE
feat: US-101 - Add Unicode NFC normalization to the text pipeline

### DIFF
--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 quick-xml = "0.38"
 umya-spreadsheet = "2"
+unicode-normalization = "0.1"
 wasm-bindgen = { version = "0.2", optional = true }
 ts-rs = { version = "12", optional = true }
 

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -37,7 +37,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": "Check if unicode-normalization is already a transitive dependency via typst or typst-kit. If so, just add it as a direct dependency without version conflict. The simplest approach is to normalize in escape_typst() as a single chokepoint — all text passes through there. Alternatively normalize in each parser when constructing Run structs. Prefer the chokepoint approach for maintainability."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -109,3 +109,18 @@ Started: 2026년  2월 28일 토요일 22시 20분 56초 KST
   - Text content assertions should check for presence of key markers (not exact layout) to avoid false positives from font encoding or layout differences
   - Use `||` in assertions for PPTX/XLSX where extracted text might vary slightly due to master slide placeholders or font rendering
 ---
+
+## 2026-02-28 - US-101
+- Implemented Unicode NFC normalization in the text pipeline
+- Added `unicode-normalization = "0.1"` as a direct dependency (already transitive via typst)
+- Modified `escape_typst()` in `typst_gen.rs` to iterate via `.nfc()` instead of `.chars()` — single chokepoint ensures all text is NFC-normalized before Typst codegen
+- Added 6 tests: Korean NFD→NFC, combining diacritics→NFC, NFD+special chars, pipeline Korean, pipeline diacritics, already-NFC passthrough
+- Files changed: `crates/office2pdf/Cargo.toml`, `crates/office2pdf/src/render/typst_gen.rs`
+- Dependencies added: `unicode-normalization = "0.1"` (already transitive, now explicit)
+- **Learnings for future iterations:**
+  - `unicode-normalization` v0.1.25 is already a transitive dep via typst — adding as direct dep causes no version conflict
+  - The `.nfc()` iterator on `&str` (from `UnicodeNormalization` trait) is a drop-in replacement for `.chars()` — minimal code change
+  - `escape_typst()` is the single chokepoint for all text in codegen — normalizing here covers all parsers (DOCX, PPTX, XLSX) without per-parser changes
+  - Korean NFD uses Hangul Jamo (U+1100–U+11FF), NFC composes them to Hangul Syllables (U+AC00–U+D7AF)
+  - Combining diacritics (e.g., U+0301 COMBINING ACUTE ACCENT) compose with preceding base chars to form precomposed NFC characters
+---


### PR DESCRIPTION
## Summary
- Add Unicode NFC normalization to `escape_typst()` as a single chokepoint, ensuring all text from any parser (DOCX, PPTX, XLSX) is NFC-normalized before Typst codegen
- Add `unicode-normalization` as a direct dependency (already a transitive dep via typst, no version conflict)
- Replace `.chars()` with `.nfc()` iterator in `escape_typst()` — minimal, zero-overhead change
- Add 6 tests covering Korean NFD→NFC, combining diacritics→NFC, special chars + NFD, full pipeline tests, and already-NFC passthrough

## Test plan
- [x] Korean NFD input (decomposed jamo) produces composed hangul in output
- [x] Combining diacritics (café with combining accent) produces NFC characters
- [x] NFD text with Typst special chars is both normalized and escaped
- [x] Full pipeline tests: NFD Korean and diacritics in paragraphs
- [x] Already-NFC text passes through unchanged
- [x] No regression in existing 1029 tests
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo check --workspace` passes

Related: #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)