### PR TITLE
feat: US-202 - Fix all PPTX parser panics from bulk fixtures

### DIFF
--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -52,7 +52,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 3,
-      "passes": false,
+      "passes": true,
       "notes": "Common PPTX panic sources: XML attribute parsing (.attribute().unwrap()), missing slide relationships, theme color resolution, shape geometry parsing, SmartArt/chart XML navigation. The PPTX parser uses quick-xml directly so look for unchecked .unwrap() calls on attribute reads and element iteration."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -129,3 +129,17 @@ Started: 2026년  3월  1일 일요일 01시 22분 39초 KST
   - Per-element error recovery via catch_unwind (documented in codebase patterns) provides an extra safety net
   - All 45 DOCX fixtures convert successfully to PDF with no errors at all (100% success rate)
 ---
+
+## 2026-03-01 - US-202
+- Ran bulk PPTX conversion test: 45 files, 0 panics, 100% success rate
+- Audited all PPTX parser production code (pptx.rs, smartart.rs, chart.rs, metadata.rs) for unsafe unwrap()/expect() calls
+- All production code already uses safe patterns: .unwrap_or(), .unwrap_or_default(), .unwrap_or_else()
+- No bare unwrap()/expect() or panic!/unreachable!/todo! macros in any PPTX production code
+- Per-slide error recovery via warnings (documented in codebase patterns) provides additional safety
+- Files changed: `scripts/ralph/prd.json`, `scripts/ralph/progress.txt`
+- Dependencies added: none
+- **Learnings for future iterations:**
+  - The PPTX parser was already defensively programmed from previous phases (all attribute reads use unwrap_or defaults)
+  - Per-slide error recovery skips broken slides with warnings rather than panicking
+  - All 45 PPTX fixtures convert successfully to PDF with no errors at all (100% success rate)
+---


### PR DESCRIPTION
## Summary
- Ran bulk PPTX conversion test on all 45 PPTX fixtures: **0 panics, 100% success rate**
- Audited all PPTX parser production code (pptx.rs, smartart.rs, chart.rs, metadata.rs) for unsafe `unwrap()`/`expect()` calls
- All production code already uses safe patterns: `.unwrap_or()`, `.unwrap_or_default()`, `.unwrap_or_else()`
- No bare `unwrap()`/`expect()` or `panic!`/`unreachable!`/`todo!` macros in any PPTX production code

## Test plan
- [x] `cargo test -p office2pdf --test bulk_conversion test_bulk_pptx -- --nocapture --ignored` reports 0 panics
- [x] `cargo test --workspace` passes (721+ tests)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)