### PR TITLE
feat: US-203 - Fix all XLSX parser panics from bulk fixtures

### DIFF
--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -69,7 +69,7 @@
         "cargo clippy --workspace -- -D warnings passes"
       ],
       "priority": 4,
-      "passes": false,
+      "passes": true,
       "notes": "Common XLSX panic sources: umya-spreadsheet API calls returning unexpected None, cell type mismatches, shared string index out of bounds, date/number format parsing, conditional formatting evaluation. The XLSX parser wraps umya-spreadsheet so most panics will be in the boundary code between umya and our IR."
     },
     {

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -143,3 +143,15 @@ Started: 2026년  3월  1일 일요일 01시 22분 39초 KST
   - Per-slide error recovery skips broken slides with warnings rather than panicking
   - All 45 PPTX fixtures convert successfully to PDF with no errors at all (100% success rate)
 ---
+
+## 2026-03-01 - US-203
+- XLSX parser already had zero panics across all 56 fixture files (100% success rate)
+- Audited all production code in xlsx.rs (lines 1-1270) and cond_fmt.rs: zero unwrap()/expect() calls
+- All error handling uses ?, map_err(), unwrap_or_default(), and_then(), and Option/Result combinators
+- No code changes required — parser was already robust
+- Files reviewed: crates/office2pdf/src/parser/xlsx.rs, crates/office2pdf/src/parser/cond_fmt.rs
+- **Learnings for future iterations:**
+  - The XLSX parser was already well-written with defensive error handling from the start
+  - umya-spreadsheet API returns Option types that the parser correctly handles with unwrap_or_default()
+  - Chart extraction via ZIP uses Ok/Err pattern with early returns, preventing panics
+---


### PR DESCRIPTION
## Summary
- Verified zero panics across all 56 XLSX fixture files (100% success rate)
- Audited all production code in `xlsx.rs` (lines 1-1270) and `cond_fmt.rs`: zero `unwrap()`/`expect()` calls
- All error handling uses `?`, `map_err()`, `unwrap_or_default()`, `and_then()`, and Option/Result combinators
- No code changes required — the XLSX parser was already robust

## Test plan
- [x] Bulk XLSX test: `cargo test -p office2pdf --test bulk_conversion test_bulk_xlsx -- --nocapture --ignored` → 0 panics, 56/56 success
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (all tests green)
- [x] `cargo check --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)