### PR TITLE
feat: integrate patched docx-rs fork to fix DOCX parse failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ repository = "https://github.com/developer0hye/office2pdf"
 
 [patch.crates-io]
 umya-spreadsheet = { git = "https://github.com/developer0hye/umya-spreadsheet.git", branch = "fix/panic-safety-v2" }
+docx-rs = { git = "https://github.com/developer0hye/docx-rs.git", branch = "fix/parse-tolerance" }

--- a/crates/office2pdf/tests/docx_fixtures.rs
+++ b/crates/office2pdf/tests/docx_fixtures.rs
@@ -619,3 +619,29 @@ encrypted_docx_tests!(
     password_is_solrcell,
     "poi/bug53475-password-is-solrcell.docx"
 );
+
+// --- LibreOffice DOCX fixtures (previously failing due to docx-rs limitations) ---
+// Fixed by patched docx-rs fork (developer0hye/docx-rs, branch fix/parse-tolerance).
+// See: https://github.com/developer0hye/office2pdf/issues/84
+
+// Previously panicked — Strict OOXML dxa unit suffix in width values
+docx_fixture_tests!(tdf79272_strict_dxa, "libreoffice/tdf79272_strictDxa.docx");
+
+// Previously "Failed to read from zip" — minimal DOCX without document rels
+docx_fixture_tests!(tdf108350, "libreoffice/tdf108350.docx");
+docx_fixture_tests!(tdf108408, "libreoffice/tdf108408.docx");
+docx_fixture_tests!(tdf108714, "libreoffice/tdf108714.docx");
+docx_fixture_tests!(tdf108806, "libreoffice/tdf108806.docx");
+docx_fixture_tests!(tdf108849, "libreoffice/tdf108849.docx");
+docx_fixture_tests!(tdf109306, "libreoffice/tdf109306.docx");
+docx_fixture_tests!(tdf109524, "libreoffice/tdf109524.docx");
+docx_fixture_tests!(tdf111550, "libreoffice/tdf111550.docx");
+docx_fixture_tests!(tdf111964, "libreoffice/tdf111964.docx");
+docx_fixture_tests!(tdf124670, "libreoffice/tdf124670.docx");
+docx_fixture_tests!(tdf129659, "libreoffice/tdf129659.docx");
+docx_fixture_tests!(cloud, "libreoffice/cloud.docx");
+docx_fixture_tests!(xml_space, "libreoffice/xml_space.docx");
+docx_fixture_tests!(
+    sdt_after_section_break,
+    "libreoffice/sdt_after_section_break.docx"
+);


### PR DESCRIPTION
## Summary

- Fork and patch docx-rs to fix 1 panic and 15 parse errors on valid DOCX files
- Integrate the patched fork into office2pdf via `[patch.crates-io]`
- Add 30 new integration tests (15 smoke + 15 structure) for previously-failing files

## Changes in docx-rs fork (developer0hye/docx-rs, branch fix/parse-tolerance)

### Fix 1: Width parsing panic (US-350)
The width parser called `unwrap()` on `f64::from_str()`, which panicked on Strict OOXML documents using 'dxa' unit values (e.g. `1440dxa`). Fixed by parsing the numeric prefix and ignoring trailing unit suffixes.

### Fix 2: Missing document rels tolerance (US-351)
`read_document_rels()` returned `ZipError(FileNotFound)` when `word/_rels/document.xml.rels` was missing. Many minimal DOCX files (especially from LibreOffice's test suite) omit this optional file. Fixed by returning empty rels instead of failing.

### Fix 3: Missing optional parts tolerance (US-351)
Styles, numberings, settings, and web settings reads now skip gracefully when referenced files are missing or unparseable, rather than failing the entire document. This fixes tdf129659.docx where numbering.xml was referenced in rels but absent from the zip.

### Fix 4: Font size unit suffix tolerance (US-351)
Font size values like "20pt" (with unit suffix) caused `ParseFloatError`. Fixed by stripping known suffixes before parsing.

## Results

| Before | After | Delta |
|--------|-------|-------|
| 1 panic | 0 panics | -1 |
| 16 parse errors | 2 expected errors | -14 fixed |
| 0/19 files parse | 15/19 files parse | +15 |

### Remaining expected errors (4 files)
- `tdf171025_pageAfter.docx`, `tdf171038_pageAfter.docx` — ODF files with `.docx` extension (not real DOCX)
- `math-malformed_xml.docx` — intentionally malformed XML (expected error)
- `deep-table-cell.docx` — on denylist (stack overflow risk from deeply nested tables)

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] 30 new integration tests for previously-failing DOCX files all pass
- [x] docx-rs fork's own test suite passes (pre-existing snapshot failures unchanged)

Related: #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)