### PR TITLE
Fix remaining 4 DOCX failures from issue #84

### DIFF
--- a/crates/office2pdf/tests/bulk_conversion.rs
+++ b/crates/office2pdf/tests/bulk_conversion.rs
@@ -35,8 +35,6 @@ const DENYLIST: &[&str] = &[
     "clusterfuzz-testcase-minimized-POIXWPFFuzzer-6733884933668864.docx",
     // Crash reporter — corrupted zip
     "crash-517626e815e0afa9decd0ebb6d1dee63fb9907dd.docx",
-    // Deeply nested table cells — stack overflow risk
-    "deep-table-cell.docx",
     // Truncated archive — incomplete zip
     "truncated62886.docx",
     // ── PPTX — fuzzer-generated / corrupted zip structures ───────────

--- a/crates/office2pdf/tests/docx_fixtures.rs
+++ b/crates/office2pdf/tests/docx_fixtures.rs
@@ -645,3 +645,13 @@ docx_fixture_tests!(
     sdt_after_section_break,
     "libreoffice/sdt_after_section_break.docx"
 );
+
+// ODT files with .docx extension — clean parse error (not panic)
+docx_fixture_tests!(tdf171025_page_after, "libreoffice/tdf171025_pageAfter.docx");
+docx_fixture_tests!(tdf171038_page_after, "libreoffice/tdf171038_pageAfter.docx");
+
+// Intentionally malformed XML — clean parse error (not panic)
+docx_fixture_tests!(math_malformed_xml, "libreoffice/math-malformed_xml.docx");
+
+// Deeply nested tables (5000+ levels) — clean error after depth-limit fix (not stack overflow)
+docx_fixture_tests!(deep_table_cell, "poi/deep-table-cell.docx");


### PR DESCRIPTION
## Summary

- Fix stack overflow on deeply nested tables (5000+ levels) in the docx-rs fork by adding a thread-local depth counter with RAII guard pattern (`MAX_TABLE_DEPTH = 32`)
- Add `ReaderError::TableDepthExceeded` error variant to distinguish depth-limit errors from other XML parse errors
- Propagate depth-exceeded errors from `TableCell::read()` while keeping tolerance for other table parse errors
- Add fixture tests for all 4 remaining DOCX files from issue #84:
  - `tdf171025_pageAfter.docx` — ODT file with .docx extension (clean parse error)
  - `tdf171038_pageAfter.docx` — ODT file with .docx extension (clean parse error)
  - `math-malformed_xml.docx` — intentionally malformed XML (clean parse error)
  - `deep-table-cell.docx` — 5000+ nested tables (clean error via depth limit, no stack overflow)
- Remove `deep-table-cell.docx` from the bulk conversion DENYLIST

## Test plan

- [x] All 4 new fixture tests pass (smoke + structure for each)
- [x] `cargo test --workspace` passes (all tests green)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] docx-rs fork unit tests pass (271 tests, including 2 new depth-limit tests)

Related: #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)