### PR TITLE
fix: resolve Typst codegen failures for math, BiDi, and PPTX text

### DIFF
--- a/crates/office2pdf/src/parser/omml.rs
+++ b/crates/office2pdf/src/parser/omml.rs
@@ -170,7 +170,12 @@ fn parse_superscript(reader: &mut Reader<&[u8]>, out: &mut String) {
         }
     }
 
-    out.push_str(&base);
+    // Empty base needs a placeholder to avoid bare `^` in Typst math
+    if base.is_empty() {
+        out.push_str("\"\"");
+    } else {
+        out.push_str(&base);
+    }
     let _ = std::fmt::Write::write_fmt(out, format_args!("^{}", wrap_if_needed(&sup)));
 }
 
@@ -192,7 +197,12 @@ fn parse_subscript(reader: &mut Reader<&[u8]>, out: &mut String) {
         }
     }
 
-    out.push_str(&base);
+    // Empty base needs a placeholder to avoid bare `_` in Typst math
+    if base.is_empty() {
+        out.push_str("\"\"");
+    } else {
+        out.push_str(&base);
+    }
     let _ = std::fmt::Write::write_fmt(out, format_args!("_{}", wrap_if_needed(&sub)));
 }
 
@@ -216,7 +226,12 @@ fn parse_sub_superscript(reader: &mut Reader<&[u8]>, out: &mut String) {
         }
     }
 
-    out.push_str(&base);
+    // Empty base needs a placeholder to avoid bare `_` in Typst math
+    if base.is_empty() {
+        out.push_str("\"\"");
+    } else {
+        out.push_str(&base);
+    }
     let _ = std::fmt::Write::write_fmt(
         out,
         format_args!("_{}^{}", wrap_if_needed(&sub), wrap_if_needed(&sup)),
@@ -459,7 +474,16 @@ fn map_math_text(input: &str) -> String {
                 flush_non_ascii_text(&mut result, &non_ascii_buf, &mut last_was_name);
                 non_ascii_buf.clear();
             }
-            result.push(ch);
+            // Parentheses from <m:t> are literal characters, not Typst math
+            // grouping. Quote them to prevent breaking function call syntax
+            // (e.g., `sqrt()` when radicand contains `)` from OMML text).
+            if ch == '(' || ch == ')' {
+                result.push('"');
+                result.push(ch);
+                result.push('"');
+            } else {
+                result.push(ch);
+            }
             last_was_name = false;
         }
     }
@@ -1534,5 +1558,62 @@ mod tests {
         // Single non-ASCII char that maps to a Typst symbol should pass through
         let xml = r#"<m:r><m:t>α</m:t></m:r>"#;
         assert_eq!(omml_to_typst(xml), "alpha");
+    }
+
+    // --- US-380: subscript/superscript with empty base ---
+
+    #[test]
+    fn test_subscript_empty_base() {
+        // When base is empty (e.g., <m:e/> or <m:e></m:e>), the output must
+        // not start with bare `_` which is invalid in Typst math.
+        let xml = r#"<m:sSub><m:e></m:e><m:sub><m:r><m:t>2</m:t></m:r></m:sub></m:sSub>"#;
+        let result = omml_to_typst(xml);
+        assert!(
+            !result.starts_with('_'),
+            "Empty base subscript must not start with bare '_': got '{result}'"
+        );
+        assert!(
+            result.contains("_2"),
+            "Should still contain subscript: got '{result}'"
+        );
+    }
+
+    #[test]
+    fn test_superscript_empty_base() {
+        let xml = r#"<m:sSup><m:e></m:e><m:sup><m:r><m:t>1</m:t></m:r></m:sup></m:sSup>"#;
+        let result = omml_to_typst(xml);
+        assert!(
+            !result.starts_with('^'),
+            "Empty base superscript must not start with bare '^': got '{result}'"
+        );
+        assert!(
+            result.contains("^1"),
+            "Should still contain superscript: got '{result}'"
+        );
+    }
+
+    #[test]
+    fn test_sub_superscript_empty_base() {
+        let xml = r#"<m:sSubSup><m:e></m:e><m:sub><m:r><m:t>2</m:t></m:r></m:sub><m:sup><m:r><m:t>1</m:t></m:r></m:sup></m:sSubSup>"#;
+        let result = omml_to_typst(xml);
+        assert!(
+            !result.starts_with('_'),
+            "Empty base sub-superscript must not start with bare '_': got '{result}'"
+        );
+    }
+
+    // --- US-381: literal parens in math run text ---
+
+    #[test]
+    fn test_math_text_literal_parens() {
+        // Literal ( and ) in <m:t> should not break Typst math function calls
+        let xml = r#"<m:rad><m:radPr><m:degHide m:val="on"/></m:radPr><m:deg/><m:e><m:r><m:t>)2(</m:t></m:r></m:e></m:rad>"#;
+        let result = omml_to_typst(xml);
+        // Must produce valid Typst: sqrt() must have its radicand argument
+        // The result must not be "sqrt()2()" which would fail compilation
+        assert!(
+            !result.contains("sqrt()"),
+            "Literal parens in radicand must not produce empty sqrt(): got '{result}'"
+        );
     }
 }

--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -1730,7 +1730,21 @@ fn generate_run(out: &mut String, run: &Run) {
         out.push_str(&escaped);
         out.push(']');
     } else {
-        out.push_str(&escaped);
+        // Prevent `](` pattern: when previous output ends with an
+        // unescaped `]` and this text starts with `(`, `.`, or `[`,
+        // Typst would interpret it as function arguments / method call /
+        // trailing content.  Wrap in `#[...]` to keep it in content mode.
+        let needs_wrap = !escaped.is_empty()
+            && out.ends_with(']')
+            && !out.ends_with("\\]")
+            && matches!(escaped.as_bytes()[0], b'(' | b'.' | b'[');
+        if needs_wrap {
+            out.push_str("#[");
+            out.push_str(&escaped);
+            out.push(']');
+        } else {
+            out.push_str(&escaped);
+        }
     }
 
     if needs_underline {
@@ -6779,6 +6793,46 @@ mod tests {
             output.source.contains("gradient.linear"),
             "Two-stop gradient should still produce gradient.linear: {}",
             output.source,
+        );
+    }
+
+    // --- US-382/383: unstyled run after styled run must not create `](` pattern ---
+
+    #[test]
+    fn test_unstyled_run_with_parens_after_styled_run() {
+        // When a styled run is followed by an unstyled run starting with `(`,
+        // the `](` pattern must not be interpreted as Typst function arguments.
+        let doc = make_doc(vec![make_flow_page(vec![Block::Paragraph(Paragraph {
+            style: ParagraphStyle::default(),
+            runs: vec![
+                Run {
+                    text: "bold text".to_string(),
+                    style: TextStyle {
+                        bold: Some(true),
+                        ..TextStyle::default()
+                    },
+                    href: None,
+                    footnote: None,
+                },
+                Run {
+                    text: "(parenthetical note)".to_string(),
+                    style: TextStyle::default(),
+                    href: None,
+                    footnote: None,
+                },
+            ],
+        })])]);
+        let result = generate_typst(&doc).unwrap().source;
+        // The result must not contain `](` directly — it would be interpreted
+        // as function arguments in Typst
+        assert!(
+            !result.contains("](\\(") || !result.contains("]("),
+            "Unstyled text with parens after styled run must be wrapped safely. Got: {result}"
+        );
+        // Verify the output uses #[...] wrapper or other safe pattern
+        assert!(
+            result.contains("#[") || result.contains("\\("),
+            "Unstyled text should be wrapped in #[...] to prevent syntax issues. Got: {result}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fix four Typst compilation errors caused by codegen edge cases (Phase 22):

- **OMML subscript/superscript with empty base** (`math-subscripts.docx`): emit `""` placeholder to avoid bare `_` or `^` invalid in Typst math mode
- **OMML math run text with literal parentheses** (`tdf158023_import.docx`): quote `(` and `)` from `<m:t>` elements as `"("` / `")"` to prevent breaking function call syntax like `sqrt()`
- **Unstyled text after styled runs** (`tdf87533_bidi.docx`, `at.ecodesign...elektronik.pptx`): wrap in `#[...]` content block when text starts with `(` after `]` to prevent Typst interpreting it as function arguments

## Files fixed
| File | Previous error | Root cause |
|------|---------------|------------|
| `math-subscripts.docx` | `unexpected underscore` | Empty base in OMML subscript |
| `tdf158023_import.docx` | `missing argument: radicand` | Literal `()` in `<m:t>` breaking `sqrt()` |
| `tdf87533_bidi.docx` | 15× `expected comma` | `](` pattern in RTL text |
| `at.ecodesign...elektronik.pptx` | `invalid number suffix: Cent` | `](` pattern in PPTX text |

## Test plan
- [x] New unit tests for empty-base subscript/superscript (3 tests)
- [x] New unit test for literal parens in math run text
- [x] New unit test for `](` pattern in run generation
- [x] All 50 existing OMML tests pass
- [x] `cargo test --workspace` — all 766 tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Bulk conversion: 2792 files, 0 panics (DOCX 99.7%, PPTX 100%, XLSX 99.7%)

Related: #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)