### PR TITLE
test: add fixture tests for upstream parse failures

### DIFF
--- a/crates/office2pdf/tests/docx_fixtures.rs
+++ b/crates/office2pdf/tests/docx_fixtures.rs
@@ -653,5 +653,8 @@ docx_fixture_tests!(tdf171038_page_after, "libreoffice/tdf171038_pageAfter.docx"
 // Intentionally malformed XML — clean parse error (not panic)
 docx_fixture_tests!(math_malformed_xml, "libreoffice/math-malformed_xml.docx");
 
+// XML external entity references — docx-rs correctly rejects for security
+docx_fixture_tests!(external_entity_in_text, "poi/ExternalEntityInText.docx");
+
 // Deeply nested tables (5000+ levels) — clean error after depth-limit fix (not stack overflow)
 docx_fixture_tests!(deep_table_cell, "poi/deep-table-cell.docx");

--- a/crates/office2pdf/tests/xlsx_fixtures.rs
+++ b/crates/office2pdf/tests/xlsx_fixtures.rs
@@ -382,6 +382,47 @@ xlsx_fixture_tests!(
     "SH108-SimpleFormattedCell.xlsx"
 );
 
+// --- Upstream parse failures (umya-spreadsheet) ------------------------------
+// Related: #97
+// These files fail with parse errors in umya-spreadsheet. All are handled
+// gracefully — no panics, no crashes. Documented as known upstream limitations.
+
+// ZipError: specified file not found in archive
+xlsx_fixture_tests!(tdf121887, "libreoffice/tdf121887.xlsx");
+xlsx_fixture_tests!(tdf131575, "libreoffice/tdf131575.xlsx");
+xlsx_fixture_tests!(tdf76115, "libreoffice/tdf76115.xlsx");
+xlsx_fixture_tests!(poi_49609, "poi/49609.xlsx");
+xlsx_fixture_tests!(poi_56278, "poi/56278.xlsx");
+xlsx_fixture_tests!(poi_59021, "poi/59021.xlsx");
+
+// IoError: Invalid checksum
+xlsx_fixture_tests!(forcepoint107, "libreoffice/forcepoint107.xlsx");
+
+// ZipError: invalid Zip archive (Could not find EOCD)
+xlsx_fixture_tests!(deep_data, "poi/deep-data.xlsx");
+
+// --- Upstream panics caught by catch_unwind (umya-spreadsheet) ----------------
+// Related: #97
+// These files trigger panics inside umya-spreadsheet (arithmetic overflow,
+// unwrap on None). catch_unwind prevents process crashes. Documented as
+// known upstream limitations.
+
+// attempt to subtract with overflow
+xlsx_fixture_tests!(
+    functions_excel_2010,
+    "libreoffice/functions-excel-2010.xlsx"
+);
+xlsx_fixture_tests!(poi_51710, "poi/51710.xlsx");
+
+// called Option::unwrap() on a None value
+xlsx_fixture_tests!(poi_64450, "poi/64450.xlsx");
+
+// attempt to multiply with overflow
+xlsx_fixture_tests!(
+    formula_eval_test_data_copy,
+    "poi/FormulaEvalTestData_Copy.xlsx"
+);
+
 // --- Upstream panic safety (patched umya-spreadsheet) ------------------------
 // Related: #83
 


### PR DESCRIPTION
## Summary

- Add fixture test for `poi/ExternalEntityInText.docx` — docx-rs correctly rejects XML external entity references (related: #96)
- Add 12 XLSX fixture tests for upstream umya-spreadsheet failures — 8 parse errors (zip/checksum issues) and 4 upstream panics caught by `catch_unwind` (related: #97)
- All failures are handled gracefully: clean `ConvertError::Parse` errors, no panics or crashes
- 3 of the 4 DOCX files from #96 already had tests (`math-malformed_xml.docx`, `tdf171025_pageAfter.docx`, `tdf171038_pageAfter.docx`)

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] Bulk conversion tests pass with 0 panics (99.6% success rate across 2792 files)
- [x] All 13 new fixture tests produce clean errors (not panics)

Related: #96, #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)