### PR TITLE
chore: add reference projects for design decisions

### DIFF
--- a/references/INDEX.md
+++ b/references/INDEX.md
@@ -1,0 +1,58 @@
+# Reference Projects
+
+Curated open-source projects relevant to office2pdf's architecture (OOXML → IR → Typst → PDF).
+
+## OOXML Parsing
+
+| Project | Lang | Focus | Detail |
+|---------|------|-------|--------|
+| [docx4j](https://github.com/plutext/docx4j) | Java | DOCX/PPTX/XLSX parsing + PDF export | [docx4j.md](docx4j.md) |
+| [python-docx](https://github.com/python-openxml/python-docx) | Python | DOCX object model | [python-docx.md](python-docx.md) |
+| [python-pptx](https://github.com/scanny/python-pptx) | Python | PPTX slide master/layout inheritance | [python-pptx.md](python-pptx.md) |
+| [excelize](https://github.com/qax-os/excelize) | Go | XLSX (most complete impl) | [excelize.md](excelize.md) |
+| [Open-XML-SDK](https://github.com/dotnet/Open-XML-SDK) | C# | Microsoft's official OOXML SDK | [open-xml-sdk.md](open-xml-sdk.md) |
+| [docxjs](https://github.com/VolodymyrBaydalka/docxjs) | TS | DOCX → HTML renderer | [docxjs.md](docxjs.md) |
+
+## Document Conversion & IR Design
+
+| Project | Lang | Focus | Detail |
+|---------|------|-------|--------|
+| [pandoc](https://github.com/jgm/pandoc) | Haskell | Universal converter (DOCX reader + Typst writer) | [pandoc.md](pandoc.md) |
+| [mammoth.js](https://github.com/mwilliamson/mammoth.js) | JS | DOCX → semantic HTML | [mammoth.md](mammoth.md) |
+
+## Typst & PDF Generation
+
+| Project | Lang | Focus | Detail |
+|---------|------|-------|--------|
+| [typst](https://github.com/typst/typst) | Rust | Typesetting engine (our backend) | [typst.md](typst.md) |
+| [krilla](https://github.com/LaurenzV/krilla) | Rust | PDF generation (PDF/A + PDF/UA) | [krilla.md](krilla.md) |
+| [hayro](https://github.com/LaurenzV/hayro) | Rust | PDF renderer (visual comparison testing) | [hayro.md](hayro.md) |
+| [veraPDF](https://github.com/veraPDF/veraPDF-library) | Java | PDF/A and PDF/UA validation | [verapdf.md](verapdf.md) |
+
+## Math Equations
+
+| Project | Lang | Focus | Detail |
+|---------|------|-------|--------|
+| [texmath](https://github.com/jgm/texmath) | Haskell | OMML ↔ Typst math conversion | [texmath.md](texmath.md) |
+| [tex2typst](https://github.com/qwinsi/tex2typst) | TS | LaTeX ↔ Typst math mappings | [tex2typst.md](tex2typst.md) |
+
+## Font Handling
+
+| Project | Lang | Focus | Detail |
+|---------|------|-------|--------|
+| [rustybuzz](https://github.com/harfbuzz/rustybuzz) | Rust | Text shaping (used by Typst) | [rustybuzz.md](rustybuzz.md) |
+| [allsorts](https://github.com/yeslogic/allsorts) | Rust | Font parsing, shaping, subsetting | [allsorts.md](allsorts.md) |
+
+## Chart Rendering
+
+| Project | Lang | Focus | Detail |
+|---------|------|-------|--------|
+| [plotters](https://github.com/plotters-rs/plotters) | Rust | Data visualization (SVG/PNG) | [plotters.md](plotters.md) |
+| [charts-rs](https://github.com/vicanso/charts-rs) | Rust | Chart rendering (more chart types) | [charts-rs.md](charts-rs.md) |
+
+## OOXML Specification
+
+| Resource | Type |
+|----------|------|
+| [ECMA-376](https://ecma-international.org/publications-and-standards/standards/ecma-376/) | Official spec (free download) |
+| [officeopenxml.com](http://officeopenxml.com/) | Readable OOXML reference |

--- a/references/allsorts.md
+++ b/references/allsorts.md
@@ -1,0 +1,22 @@
+# allsorts
+
+- **URL:** https://github.com/yeslogic/allsorts
+- **Stars:** ~793
+- **Language:** Rust
+- **License:** Apache 2.0
+
+## What it does
+
+Font parser, shaping engine, and subsetter by YesLogic (the Prince XML team). Supports TrueType, OpenType, WOFF, WOFF2.
+
+## Why relevant
+
+- Built by the team behind Prince XML — battle-tested for document conversion.
+- Font subsetting for PDF embedding is directly relevant.
+- Font substitution and fallback logic can inform our `font_subst.rs`.
+
+## When to consult
+
+- Improving font substitution/fallback logic
+- Understanding font subsetting for PDF embedding
+- Investigating font parsing issues

--- a/references/charts-rs.md
+++ b/references/charts-rs.md
@@ -1,0 +1,21 @@
+# charts-rs
+
+- **URL:** https://github.com/vicanso/charts-rs
+- **Stars:** ~300
+- **Language:** Rust
+- **License:** Apache 2.0
+
+## What it does
+
+Pure Rust charting library supporting bar, horizontal bar, line, pie, radar, scatter, candlestick, table, heatmap, and multi-chart layouts. Outputs SVG, PNG, JPEG, WEBP.
+
+## Why relevant
+
+- Supports more chart types out of the box than plotters (radar, heatmap, candlestick).
+- Simpler API for generating charts from data.
+- The wider chart type coverage maps better to OOXML chart types.
+
+## When to consult
+
+- Evaluating chart rendering libraries for OOXML chart support
+- Rendering chart types not supported by plotters (radar, heatmap)

--- a/references/docx4j.md
+++ b/references/docx4j.md
@@ -1,0 +1,27 @@
+# docx4j
+
+- **URL:** https://github.com/plutext/docx4j
+- **Stars:** ~2.3k
+- **Language:** Java
+- **License:** Apache 2.0
+
+## What it does
+
+JAXB-based Java library for Word, PowerPoint, and Excel OOXML files. Supports DOCX-to-PDF via XSL-FO (Apache FOP). The most comprehensive open-source OOXML library in any language.
+
+## Why relevant
+
+- **Gold standard** for OOXML parsing — handles styles, numbering, sections, headers/footers, tables, images, and nearly all Word features.
+- `docx4j-export-FO` module shows how to convert parsed OOXML into a layout format for PDF rendering — architecturally similar to our IR → Typst pipeline.
+- Style resolution, numbering inheritance, and section property handling are directly applicable.
+
+## Key files to study
+
+- `org.docx4j.model.structure` — Document structure model
+- `org.docx4j.convert.out.fo` — DOCX → XSL-FO conversion (analogous to our Typst codegen)
+- `org.docx4j.wml` — Word Markup Language type definitions
+
+## When to consult
+
+- Debugging style resolution or numbering inheritance issues in DOCX parser
+- Understanding complex table, section, or header/footer OOXML structures

--- a/references/docxjs.md
+++ b/references/docxjs.md
@@ -1,0 +1,27 @@
+# docxjs (docx-preview)
+
+- **URL:** https://github.com/VolodymyrBaydalka/docxjs
+- **Stars:** ~1.9k
+- **Language:** TypeScript
+- **License:** MIT
+
+## What it does
+
+DOCX rendering library that converts DOCX documents to HTML while preserving visual layout. Published on npm as `docx-preview`.
+
+## Why relevant
+
+- **Closest analog** to what office2pdf does — DOCX to visual output, without LibreOffice.
+- Shows how to resolve styles, handle sections, page layout, headers/footers, tables, and images for visual rendering.
+- TypeScript source is readable and well-structured.
+
+## Key files to study
+
+- `src/document-parser.ts` — DOCX XML parsing
+- `src/html/` — Element-to-HTML rendering (analogous to our Typst codegen)
+- Style resolution logic
+
+## When to consult
+
+- Comparing our rendering approach with another DOCX-to-visual-output implementation
+- Debugging visual fidelity issues (margins, page breaks, table layout)

--- a/references/excelize.md
+++ b/references/excelize.md
@@ -1,0 +1,30 @@
+# excelize
+
+- **URL:** https://github.com/qax-os/excelize
+- **Stars:** ~20.4k
+- **Language:** Go
+- **License:** BSD-3-Clause
+
+## What it does
+
+Go library for reading and writing XLSX/XLSM/XLTX/XLTM. Supports streaming API, charts, images, conditional formatting, merged cells, data validation, pivot tables — nearly every Excel feature.
+
+## Why relevant
+
+- **Most complete** XLSX implementation in any language (by feature coverage).
+- Conditional formatting rule handling is among the best — DataBar, ColorScale, IconSet.
+- Merged cell rendering, column width calculation, and style resolution are thoroughly implemented.
+- Clean Go code that is straightforward to read.
+
+## Key files to study
+
+- `cell.go` — Cell value reading and type resolution
+- `styles.go` — Style resolution and number format handling
+- `condFmt.go` (or similar) — Conditional formatting rules
+- `merge.go` — Merged cell handling
+
+## When to consult
+
+- Implementing XLSX conditional formatting (DataBar, IconSet)
+- Debugging merged cell resolution or column width calculation
+- Understanding XLSX number format strings

--- a/references/hayro.md
+++ b/references/hayro.md
@@ -1,0 +1,22 @@
+# hayro
+
+- **URL:** https://github.com/LaurenzV/hayro
+- **Stars:** ~593
+- **Language:** Rust
+- **License:** MIT / Apache 2.0
+
+## What it does
+
+Pure-Rust PDF interpreter and renderer. The most feature-complete PDF renderer library in Rust. Can render PDF pages to PNG images.
+
+## Why relevant
+
+- **Visual comparison testing** — can render PDFs to PNG without external tools (Poppler, MuPDF).
+- Could replace or complement the current artifact generation pipeline for page-by-page visual comparison.
+- Pure Rust = no system dependencies, works in CI/CD environments.
+
+## When to consult
+
+- Improving visual comparison infrastructure
+- Rendering PDF output to images for automated testing
+- Replacing external PDF rendering dependencies

--- a/references/krilla.md
+++ b/references/krilla.md
@@ -1,0 +1,29 @@
+# krilla
+
+- **URL:** https://github.com/LaurenzV/krilla
+- **Stars:** ~350
+- **Language:** Rust
+- **License:** MIT / Apache 2.0
+
+## What it does
+
+High-level PDF creation library built on `pdf-writer`. Now the PDF backend for Typst (since PR #5420). Supports PDF/A-1 through PDF/A-4 and PDF/UA-1.
+
+## Why relevant
+
+- **The engine producing our PDF output** — Typst uses krilla for PDF generation.
+- Supports tagged PDF for accessibility (PDF/UA), which maps to office2pdf's accessibility features.
+- Understanding krilla's capabilities and limitations directly affects what PDF features we can offer.
+- Font subsetting, gradient fills, and PDF standard compliance are handled here.
+
+## Key areas to study
+
+- PDF/A compliance requirements
+- PDF/UA tagging (structure tags: H1-H6, P, Table, Figure)
+- Font subsetting behavior
+
+## When to consult
+
+- Debugging PDF output issues (fonts, compliance, accessibility)
+- Understanding PDF/A or PDF/UA requirements
+- Investigating PDF file size optimization

--- a/references/mammoth.md
+++ b/references/mammoth.md
@@ -1,0 +1,27 @@
+# mammoth.js
+
+- **URL:** https://github.com/mwilliamson/mammoth.js
+- **Stars:** ~6.1k
+- **Language:** JavaScript (also available in Python and Java)
+- **License:** BSD-2-Clause
+
+## What it does
+
+Converts DOCX files to clean, semantic HTML. Maps Word's semantic styles (Heading 1 → `<h1>`) rather than replicating exact visual formatting.
+
+## Why relevant
+
+- Clean separation between DOCX parsing and output generation.
+- Style-mapping DSL shows which OOXML semantic concepts matter most.
+- The approach of mapping styles to output elements is directly applicable to our IR → Typst pipeline.
+
+## Key files to study
+
+- `lib/docx/` — DOCX XML walking and element extraction
+- `lib/documents.js` — Internal document model (the IR)
+- `lib/html/` — IR → HTML generation
+
+## When to consult
+
+- Simplifying style mapping logic
+- Understanding which DOCX semantic structures to preserve vs. discard

--- a/references/open-xml-sdk.md
+++ b/references/open-xml-sdk.md
@@ -1,0 +1,27 @@
+# Open-XML-SDK
+
+- **URL:** https://github.com/dotnet/Open-XML-SDK
+- **Stars:** ~4.4k
+- **Language:** C#
+- **License:** MIT
+
+## What it does
+
+Microsoft's official SDK for working with Office Open XML documents. Strongly-typed APIs for all OOXML elements — Word, Excel, and PowerPoint.
+
+## Why relevant
+
+- **Canonical reference** for OOXML types and relationships. When in doubt about what an OOXML element means or how it's structured, this is authoritative.
+- Type hierarchy directly mirrors the ECMA-376 spec.
+- Useful for cross-checking our parser's interpretation of OOXML attributes.
+
+## Key files to study
+
+- `DocumentFormat.OpenXml/GeneratedCode/` — Auto-generated types for all OOXML elements
+- Type definitions for `WordprocessingML`, `SpreadsheetML`, `PresentationML`
+
+## When to consult
+
+- Verifying correct parsing of OOXML attributes and element structures
+- Understanding element type relationships in the OOXML schema
+- Cross-referencing with ECMA-376 spec

--- a/references/pandoc.md
+++ b/references/pandoc.md
@@ -1,0 +1,29 @@
+# pandoc
+
+- **URL:** https://github.com/jgm/pandoc
+- **Stars:** ~42.4k
+- **Language:** Haskell
+- **License:** GPL-2.0
+
+## What it does
+
+Universal markup converter. Parses input formats (including DOCX) into an internal AST, then serializes to output formats (including Typst). Supports custom filters on the AST.
+
+## Why relevant
+
+- **Gold standard** for IR-based document conversion — the same architecture as office2pdf.
+- DOCX reader (`Readers/Docx.hs`) is a battle-tested parser showing which OOXML features matter.
+- Typst writer (`Writers/Typst.hs`) is the most mature IR → Typst code generator — directly analogous to our `typst_gen.rs`.
+- AST design (`Pandoc Meta [Block]`) is a proven reference for format-agnostic document IR.
+
+## Key files to study
+
+- `src/Text/Pandoc/Readers/Docx.hs` — DOCX → AST parsing
+- `src/Text/Pandoc/Writers/Typst.hs` — AST → Typst codegen
+- `src/Text/Pandoc/Definition.hs` — The IR definition (Block, Inline types)
+
+## When to consult
+
+- Designing IR improvements or new element types
+- Implementing new Typst codegen features (table, math, list rendering)
+- Cross-checking DOCX parsing behavior

--- a/references/plotters.md
+++ b/references/plotters.md
@@ -1,0 +1,21 @@
+# plotters
+
+- **URL:** https://github.com/plotters-rs/plotters
+- **Stars:** ~4.5k
+- **Language:** Rust
+- **License:** MIT
+
+## What it does
+
+Pure Rust drawing library for data visualization. Supports SVG, PNG, and bitmap backends. WASM compatible. Supports line, bar, scatter, histogram, and area charts.
+
+## Why relevant
+
+- Most mature Rust charting library. Could render OOXML chart data (bar, line, pie, scatter) into SVG/PNG for embedding in Typst output.
+- Currently office2pdf renders charts as fallback data tables — plotters could enable actual chart rendering.
+- Pure Rust, WASM-compatible = aligns with our no-external-dependency philosophy.
+
+## When to consult
+
+- Implementing chart rendering from OOXML chart data
+- Choosing chart rendering approach (SVG embed vs. Typst native)

--- a/references/python-docx.md
+++ b/references/python-docx.md
@@ -1,0 +1,27 @@
+# python-docx
+
+- **URL:** https://github.com/python-openxml/python-docx
+- **Stars:** ~5.5k
+- **Language:** Python
+- **License:** MIT
+
+## What it does
+
+Create and modify Word 2007+ (.docx) files. Well-documented object model for paragraphs, runs, tables, styles, sections, headers/footers, and images.
+
+## Why relevant
+
+- Best-documented DOCX object model — clear mapping between OOXML elements and user-facing concepts.
+- Style inheritance resolution code is well-structured and readable.
+- Excellent companion to the ECMA-376 spec for understanding "what this XML actually means."
+
+## Key files to study
+
+- `docx/oxml/text/paragraph.py` — Paragraph element parsing
+- `docx/oxml/table.py` — Table structure
+- `docx/styles/` — Style resolution chain
+
+## When to consult
+
+- Understanding DOCX object model and style hierarchy
+- Mapping OOXML elements to semantic document concepts

--- a/references/python-pptx.md
+++ b/references/python-pptx.md
@@ -1,0 +1,28 @@
+# python-pptx
+
+- **URL:** https://github.com/scanny/python-pptx
+- **Stars:** ~3.2k
+- **Language:** Python
+- **License:** MIT
+
+## What it does
+
+Create, read, and update PowerPoint (.pptx) files. Includes detailed analysis docs for slide layouts, masters, and placeholder inheritance.
+
+## Why relevant
+
+- **Essential reference** for PPTX slide master → layout → slide inheritance chain.
+- `docs/dev/analysis/` contains rare deep-dives into how PowerPoint resolves placeholders, colors, fonts, and backgrounds across the inheritance hierarchy.
+- The analysis docs are more useful than the code itself — they reverse-engineer PowerPoint's actual behavior.
+
+## Key files to study
+
+- `docs/dev/analysis/sld-layout.rst` — Slide layout inheritance
+- `docs/dev/analysis/placeholders/` — Placeholder resolution rules
+- `pptx/oxml/shapes/` — Shape XML parsing
+
+## When to consult
+
+- Debugging PPTX slide master/layout inheritance
+- Understanding placeholder resolution and theme color application
+- Resolving shape property inheritance (fill, line, text body defaults)

--- a/references/rustybuzz.md
+++ b/references/rustybuzz.md
@@ -1,0 +1,22 @@
+# rustybuzz
+
+- **URL:** https://github.com/harfbuzz/rustybuzz
+- **Stars:** ~589
+- **Language:** Rust
+- **License:** MIT
+
+## What it does
+
+Pure Rust port of HarfBuzz's text shaping algorithm. Passes 2221 of 2252 HarfBuzz shaping tests. Handles complex scripts (Arabic, Devanagari, Thai, CJK).
+
+## Why relevant
+
+- **Used by Typst** for text shaping. Understanding its capabilities and limitations is key for diagnosing text rendering issues.
+- Complex script support (RTL, ligatures, contextual alternates) affects how office2pdf's output looks for non-Latin text.
+- Shaping failures or limitations in rustybuzz directly affect our PDF output quality.
+
+## When to consult
+
+- Debugging text rendering issues (wrong ligatures, broken Arabic/CJK text)
+- Understanding font feature support (OpenType features, variable fonts)
+- Investigating text shaping performance

--- a/references/tex2typst.md
+++ b/references/tex2typst.md
@@ -1,0 +1,21 @@
+# tex2typst
+
+- **URL:** https://github.com/qwinsi/tex2typst
+- **Stars:** ~98
+- **Language:** TypeScript
+- **License:** MIT
+
+## What it does
+
+Bidirectional conversion between TeX/LaTeX and Typst math. Web app available for interactive testing.
+
+## Why relevant
+
+- Comprehensive LaTeX ↔ Typst math symbol and construct mapping tables.
+- Covers edge cases in math conversion (nested fractions, matrices, decorations).
+- Useful as a quick-reference lookup for Typst math syntax when implementing OMML conversion.
+
+## When to consult
+
+- Looking up Typst math syntax for specific constructs
+- Cross-checking LaTeX-to-Typst symbol mappings used in our OMML converter

--- a/references/texmath.md
+++ b/references/texmath.md
@@ -1,0 +1,30 @@
+# texmath
+
+- **URL:** https://github.com/jgm/texmath
+- **Stars:** ~390
+- **Language:** Haskell
+- **License:** GPL-2.0
+
+## What it does
+
+Converts between LaTeX math, MathML, OMML, Typst math, GNU eqn, and Pandoc's native format. Used internally by Pandoc for all math conversion.
+
+## Why relevant
+
+- **The single most relevant math conversion project.** Has both an OMML reader and a Typst math writer — exactly the pipeline office2pdf needs.
+- `Text.TeXMath.Readers.OMML` parses OMML (the math format inside DOCX files).
+- `Text.TeXMath.Writers.Typst` serializes to Typst math notation.
+- Symbol mappings and conversion rules are directly portable to our `omml.rs`.
+
+## Key files to study
+
+- `src/Text/TeXMath/Readers/OMML.hs` — OMML parsing
+- `src/Text/TeXMath/Writers/Typst.hs` — Typst math output
+- `src/Text/TeXMath/Types.hs` — Internal math IR (Exp type)
+- `src/Text/TeXMath/Shared.hs` — Shared symbol mappings
+
+## When to consult
+
+- Improving OMML → Typst math conversion quality
+- Adding support for new math constructs (matrices, accents, etc.)
+- Cross-checking symbol mapping correctness

--- a/references/typst.md
+++ b/references/typst.md
@@ -1,0 +1,29 @@
+# typst
+
+- **URL:** https://github.com/typst/typst
+- **Stars:** ~51.7k
+- **Language:** Rust
+- **License:** Apache 2.0
+
+## What it does
+
+Markup-based typesetting system. Compiles `.typ` source to PDF/PNG/SVG/HTML. Embeddable as a Rust library.
+
+## Why relevant
+
+- **Our backend** — office2pdf generates Typst markup and compiles it.
+- `crates/typst-library/` defines all available Typst elements and their parameters — the definitive reference for what markup we should generate.
+- Understanding the layout engine, `World` trait, and compilation pipeline is essential for performance tuning.
+
+## Key areas to study
+
+- `crates/typst-library/src/layout/` — Page, table, grid, columns
+- `crates/typst-library/src/text/` — Text, paragraph, heading
+- `crates/typst-library/src/math/` — Math equation support
+- `crates/typst/src/compile.rs` — Compilation pipeline
+
+## When to consult
+
+- Improving Typst codegen quality or discovering new Typst features
+- Debugging layout issues in generated PDFs
+- Optimizing compilation performance

--- a/references/verapdf.md
+++ b/references/verapdf.md
@@ -1,0 +1,31 @@
+# veraPDF
+
+- **URL:** https://github.com/veraPDF/veraPDF-library
+- **Stars:** ~316
+- **Language:** Java
+- **License:** MPL-2.0 / GPL-3.0
+
+## What it does
+
+Industry-standard open-source PDF/A and PDF/UA validator. Supports PDF/A-1 through PDF/A-4 and PDF/UA-1.
+
+## Why relevant
+
+- **Validation tool** for ensuring office2pdf's PDF/A and PDF/UA output is compliant.
+- Can be integrated into CI/CD to automatically validate generated PDFs.
+- Detailed validation reports help diagnose specific compliance issues.
+
+## Usage
+
+```bash
+# Validate PDF/A compliance
+verapdf --flavour 2b output.pdf
+
+# Validate PDF/UA compliance
+verapdf --flavour ua1 output.pdf
+```
+
+## When to consult
+
+- Validating PDF/A-2b or PDF/UA-1 compliance of generated PDFs
+- Diagnosing specific PDF standard compliance failures


### PR DESCRIPTION
## Summary
- Add `references/INDEX.md` index with 18 curated reference projects organized by category
- Add detail files (under 50 lines each) for projects covering:
  - **OOXML Parsing:** docx4j, python-docx, python-pptx, excelize, Open-XML-SDK, docxjs
  - **Document Conversion & IR:** pandoc (DOCX reader + Typst writer), mammoth.js
  - **Typst & PDF:** typst, krilla, hayro, veraPDF
  - **Math Equations:** texmath (OMML → Typst), tex2typst
  - **Font Handling:** rustybuzz, allsorts
  - **Chart Rendering:** plotters, charts-rs
- Projects span Rust, Java, Python, Go, Haskell, C#, TypeScript — architectural patterns transfer across languages

Follows the Reference Projects section added to CLAUDE.md in #114.

## Test plan
- [ ] No runtime code changed — docs only, tests not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)