### PR TITLE
feat: expand OMML math symbol coverage

### DIFF
--- a/crates/office2pdf/src/parser/omml.rs
+++ b/crates/office2pdf/src/parser/omml.rs
@@ -770,6 +770,9 @@ fn map_nary_operator(chr: &str) -> &str {
         "\u{222E}" => "integral.cont",
         "\u{22C3}" => "union.big",
         "\u{22C2}" => "sect.big",
+        "\u{2210}" => "product.co",
+        "\u{22C0}" => "and.big",
+        "\u{22C1}" => "or.big",
         _ => "sum",
     }
 }
@@ -1811,5 +1814,26 @@ mod tests {
     fn test_grave_accent_via_omml() {
         let xml = r#"<m:acc><m:accPr><m:chr m:val="̀"/></m:accPr><m:e><m:r><m:t>a</m:t></m:r></m:e></m:acc>"#;
         assert_eq!(omml_to_typst(xml), "grave(a)");
+    }
+
+    // --- Additional n-ary operator mappings ---
+
+    #[test]
+    fn test_additional_nary_operators() {
+        assert_eq!(map_nary_operator("\u{2210}"), "product.co");
+        assert_eq!(map_nary_operator("\u{22C0}"), "and.big");
+        assert_eq!(map_nary_operator("\u{22C1}"), "or.big");
+    }
+
+    #[test]
+    fn test_coproduct_via_omml() {
+        let xml = r#"<m:nary><m:naryPr><m:chr m:val="∐"/></m:naryPr><m:sub><m:r><m:t>i</m:t></m:r></m:sub><m:sup/><m:e><m:r><m:t>A</m:t></m:r></m:e></m:nary>"#;
+        assert_eq!(omml_to_typst(xml), "product.co_i A");
+    }
+
+    #[test]
+    fn test_big_and_via_omml() {
+        let xml = r#"<m:nary><m:naryPr><m:chr m:val="⋀"/></m:naryPr><m:sub><m:r><m:t>i</m:t></m:r></m:sub><m:sup/><m:e><m:r><m:t>p</m:t></m:r></m:e></m:nary>"#;
+        assert_eq!(omml_to_typst(xml), "and.big_i p");
     }
 }


### PR DESCRIPTION
## Summary

- Add 54 new symbol mappings to the OMML-to-Typst converter, closing the gap with the texmath reference project
- **Blackboard bold** (7): ℂℍℕℙℚℝℤ → CC, HH, NN, PP, QQ, RR, ZZ — previously incorrectly wrapped in `upright()`
- **Extended relations** (10): ≡∼≅≪≫⊆⊇∝∴∵ → equiv, tilde.op, tilde.eq, etc.
- **Arrows** (12): ←↑→↓↔↦↪↼⇀⇐⇒⇔ → arrow.l, arrow.t, arrow.r, etc.
- **Operators** (14): ∠∧∨∘⋅∓¬⊕⊗⊙⊢⊣⊤⊥ → angle, and, or, compose, etc.
- **Floor/ceiling delimiters** (4): ⌈⌉⌊⌋ — explicit arms for regression safety
- **Accents** (4): U+0301/0300/0305/030A → acute, grave, macron, circle — previously defaulting to "hat"
- **N-ary operators** (3): ∐⋀⋁ → product.co, and.big, or.big — previously defaulting to "sum"

## Test plan

- [x] Each category has unit tests for `unicode_to_typst()`/`map_math_text()`/`map_accent()`/`map_nary_operator()`/`map_delimiter()`
- [x] Integration tests via `omml_to_typst()` with XML fragments for key symbols
- [x] All 756 existing + new tests pass (`cargo test -p office2pdf`)
- [x] No clippy warnings (`cargo clippy -p office2pdf`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)