### PR TITLE
fix: preserve PPTX text box paragraph breaks

### DIFF
--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -511,7 +511,10 @@ fn generate_fixed_element(
                 format_f64(elem.width),
                 format_f64(elem.height),
             );
-            for block in blocks {
+            for (index, block) in blocks.iter().enumerate() {
+                if index > 0 {
+                    out.push('\n');
+                }
                 generate_block(out, block, ctx)?;
             }
             out.push_str("]\n");
@@ -1900,7 +1903,10 @@ fn generate_floating_text_box_content(
         format_f64(ftb.width),
         format_f64(ftb.height)
     );
-    for block in &ftb.content {
+    for (index, block) in ftb.content.iter().enumerate() {
+        if index > 0 {
+            out.push('\n');
+        }
         generate_block(out, block, ctx)?;
     }
     out.push_str("]\n");
@@ -3087,6 +3093,10 @@ mod tests {
         let result = generate_typst(&doc).unwrap().source;
         assert!(result.contains("First paragraph"));
         assert!(result.contains("Second paragraph"));
+        assert!(
+            result.contains("First paragraph\n\nSecond paragraph"),
+            "Expected paragraph break between flow paragraphs in: {result}"
+        );
     }
 
     #[test]
@@ -4339,6 +4349,46 @@ mod tests {
         assert!(
             output.source.contains("200pt"),
             "Expected y position in: {}",
+            output.source
+        );
+    }
+
+    #[test]
+    fn test_fixed_page_text_box_multiple_paragraphs_preserve_breaks() {
+        let doc = make_doc(vec![make_fixed_page(
+            960.0,
+            540.0,
+            vec![FixedElement {
+                x: 100.0,
+                y: 200.0,
+                width: 300.0,
+                height: 100.0,
+                kind: FixedElementKind::TextBox(vec![
+                    Block::Paragraph(Paragraph {
+                        style: ParagraphStyle::default(),
+                        runs: vec![Run {
+                            text: "First item".to_string(),
+                            style: TextStyle::default(),
+                            href: None,
+                            footnote: None,
+                        }],
+                    }),
+                    Block::Paragraph(Paragraph {
+                        style: ParagraphStyle::default(),
+                        runs: vec![Run {
+                            text: "Second item".to_string(),
+                            style: TextStyle::default(),
+                            href: None,
+                            footnote: None,
+                        }],
+                    }),
+                ]),
+            }],
+        )]);
+        let output = generate_typst(&doc).unwrap();
+        assert!(
+            output.source.contains("First item\n\nSecond item"),
+            "Expected paragraph break inside fixed text box in: {}",
             output.source
         );
     }


### PR DESCRIPTION
## What changed
- preserve paragraph separation when generating fixed-position PPTX text boxes
- preserve paragraph separation for floating text box content as well
- add regression coverage for multi-paragraph fixed text boxes and explicit flow paragraph separation

## Why
Slide 2 of the classified PPTX stores the contents list as multiple real paragraphs inside a single text box. The Typst generator emitted those paragraphs without an extra container-level separator, so Typst collapsed them into a continuous block.

## Key changes
- insert an extra newline between text-box blocks in fixed-page generation
- insert the same separator for floating text box content
- verify the output source contains paragraph breaks for both flow and fixed text boxes

Related: #111