### PR TITLE
refactor: centralize hardcoded document defaults

### DIFF
--- a/crates/office2pdf/src/config.rs
+++ b/crates/office2pdf/src/config.rs
@@ -96,10 +96,11 @@ pub enum PaperSize {
 impl PaperSize {
     /// Returns (width, height) in points.
     pub fn dimensions(&self) -> (f64, f64) {
+        use crate::defaults;
         match self {
-            Self::A4 => (595.28, 841.89),
-            Self::Letter => (612.0, 792.0),
-            Self::Legal => (612.0, 1008.0),
+            Self::A4 => (defaults::A4_WIDTH_PT, defaults::A4_HEIGHT_PT),
+            Self::Letter => (defaults::LETTER_WIDTH_PT, defaults::LETTER_HEIGHT_PT),
+            Self::Legal => (defaults::LEGAL_WIDTH_PT, defaults::LEGAL_HEIGHT_PT),
             Self::Custom { width, height } => (*width, *height),
         }
     }

--- a/crates/office2pdf/src/defaults.rs
+++ b/crates/office2pdf/src/defaults.rs
@@ -1,0 +1,63 @@
+//! Centralized document default constants.
+//!
+//! All hardcoded numeric values for paper sizes, margins, heading styles,
+//! streaming parameters, and unit conversions live here so they are defined
+//! once and referenced everywhere.
+
+// ---------------------------------------------------------------------------
+// Paper sizes in points (1 pt = 1/72 inch)
+// ---------------------------------------------------------------------------
+
+/// A4 width: 210 mm = 595.28 pt (ISO 216).
+pub const A4_WIDTH_PT: f64 = 595.28;
+
+/// A4 height: 297 mm = 841.89 pt (ISO 216).
+pub const A4_HEIGHT_PT: f64 = 841.89;
+
+/// US Letter width: 8.5 in = 612.0 pt.
+pub const LETTER_WIDTH_PT: f64 = 612.0;
+
+/// US Letter height: 11 in = 792.0 pt.
+pub const LETTER_HEIGHT_PT: f64 = 792.0;
+
+/// US Legal width: 8.5 in = 612.0 pt.
+pub const LEGAL_WIDTH_PT: f64 = 612.0;
+
+/// US Legal height: 14 in = 1008.0 pt.
+pub const LEGAL_HEIGHT_PT: f64 = 1008.0;
+
+// ---------------------------------------------------------------------------
+// Margins
+// ---------------------------------------------------------------------------
+
+/// Default page margin: 1 inch = 72 points.
+pub const DEFAULT_MARGIN_PT: f64 = 72.0;
+
+// ---------------------------------------------------------------------------
+// Heading font sizes
+// ---------------------------------------------------------------------------
+
+/// Default font sizes for heading levels 1-6.
+/// Index 0 = Heading 1, index 5 = Heading 6.
+pub const HEADING_FONT_SIZES: [f64; 6] = [24.0, 20.0, 16.0, 14.0, 12.0, 11.0];
+
+// ---------------------------------------------------------------------------
+// Streaming
+// ---------------------------------------------------------------------------
+
+/// Default chunk size (in rows) for XLSX streaming mode.
+pub const DEFAULT_STREAMING_CHUNK_SIZE: usize = 1000;
+
+// ---------------------------------------------------------------------------
+// Unit conversion
+// ---------------------------------------------------------------------------
+
+/// Points per inch (PostScript definition).
+pub const POINTS_PER_INCH: f64 = 72.0;
+
+/// CSS reference pixels per inch.
+pub const PIXELS_PER_INCH: f64 = 96.0;
+
+#[cfg(test)]
+#[path = "defaults_tests.rs"]
+mod tests;

--- a/crates/office2pdf/src/defaults_tests.rs
+++ b/crates/office2pdf/src/defaults_tests.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+// --- Paper size constants ---
+
+#[test]
+fn a4_width_matches_iso_216_spec() {
+    // A4 = 210mm × 297mm. 210mm = 595.276pt (at 72pt/inch, 25.4mm/inch).
+    // The commonly used rounded value is 595.28pt.
+    assert!((A4_WIDTH_PT - 595.28).abs() < 0.01);
+}
+
+#[test]
+fn a4_height_matches_iso_216_spec() {
+    assert!((A4_HEIGHT_PT - 841.89).abs() < 0.01);
+}
+
+#[test]
+fn letter_width_matches_us_standard() {
+    // US Letter = 8.5in × 11in. 8.5 × 72 = 612.0pt.
+    assert!((LETTER_WIDTH_PT - 612.0).abs() < 0.01);
+}
+
+#[test]
+fn letter_height_matches_us_standard() {
+    assert!((LETTER_HEIGHT_PT - 792.0).abs() < 0.01);
+}
+
+#[test]
+fn legal_width_matches_us_standard() {
+    // US Legal = 8.5in × 14in. 8.5 × 72 = 612.0pt, 14 × 72 = 1008.0pt.
+    assert!((LEGAL_WIDTH_PT - 612.0).abs() < 0.01);
+}
+
+#[test]
+fn legal_height_matches_us_standard() {
+    assert!((LEGAL_HEIGHT_PT - 1008.0).abs() < 0.01);
+}
+
+// --- Margin constants ---
+
+#[test]
+fn default_margin_is_one_inch() {
+    // 1 inch = 72 points.
+    assert!((DEFAULT_MARGIN_PT - 72.0).abs() < 0.01);
+}
+
+// --- Heading font sizes ---
+
+#[test]
+fn heading_font_sizes_has_six_levels() {
+    assert_eq!(HEADING_FONT_SIZES.len(), 6);
+}
+
+#[test]
+fn heading_font_sizes_decrease_monotonically() {
+    for i in 0..HEADING_FONT_SIZES.len() - 1 {
+        assert!(
+            HEADING_FONT_SIZES[i] > HEADING_FONT_SIZES[i + 1],
+            "Heading level {} size ({}) should be larger than level {} size ({})",
+            i + 1,
+            HEADING_FONT_SIZES[i],
+            i + 2,
+            HEADING_FONT_SIZES[i + 1]
+        );
+    }
+}
+
+#[test]
+fn heading_1_is_24pt() {
+    assert!((HEADING_FONT_SIZES[0] - 24.0).abs() < 0.01);
+}
+
+#[test]
+fn heading_6_is_11pt() {
+    assert!((HEADING_FONT_SIZES[5] - 11.0).abs() < 0.01);
+}
+
+// --- Streaming chunk size ---
+
+#[test]
+fn default_streaming_chunk_size_is_1000() {
+    assert_eq!(DEFAULT_STREAMING_CHUNK_SIZE, 1000);
+}
+
+// --- Unit conversion constants ---
+
+#[test]
+fn points_per_inch_is_72() {
+    assert!((POINTS_PER_INCH - 72.0).abs() < 0.01);
+}
+
+#[test]
+fn pixels_per_inch_is_96() {
+    assert!((PIXELS_PER_INCH - 96.0).abs() < 0.01);
+}
+
+#[test]
+fn px_to_pt_conversion_uses_correct_ratio() {
+    // 96px = 72pt, so 1px = 0.75pt
+    let one_px_in_pt: f64 = POINTS_PER_INCH / PIXELS_PER_INCH;
+    assert!((one_px_in_pt - 0.75).abs() < 0.001);
+}

--- a/crates/office2pdf/src/ir/document.rs
+++ b/crates/office2pdf/src/ir/document.rs
@@ -42,10 +42,9 @@ pub struct PageSize {
 
 impl Default for PageSize {
     fn default() -> Self {
-        // A4 in points
         Self {
-            width: 595.28,
-            height: 841.89,
+            width: crate::defaults::A4_WIDTH_PT,
+            height: crate::defaults::A4_HEIGHT_PT,
         }
     }
 }
@@ -61,12 +60,11 @@ pub struct Margins {
 
 impl Default for Margins {
     fn default() -> Self {
-        // 1 inch = 72 points
         Self {
-            top: 72.0,
-            bottom: 72.0,
-            left: 72.0,
-            right: 72.0,
+            top: crate::defaults::DEFAULT_MARGIN_PT,
+            bottom: crate::defaults::DEFAULT_MARGIN_PT,
+            left: crate::defaults::DEFAULT_MARGIN_PT,
+            right: crate::defaults::DEFAULT_MARGIN_PT,
         }
     }
 }

--- a/crates/office2pdf/src/lib.rs
+++ b/crates/office2pdf/src/lib.rs
@@ -38,6 +38,7 @@
 //! ```
 
 pub mod config;
+pub mod defaults;
 pub mod error;
 pub mod ir;
 pub mod parser;

--- a/crates/office2pdf/src/lib_pipeline.rs
+++ b/crates/office2pdf/src/lib_pipeline.rs
@@ -212,7 +212,9 @@ fn convert_bytes_streaming_xlsx(
 ) -> Result<ConvertResult, ConvertError> {
     let total_start: Instant = Instant::now();
     let input_size_bytes = data.len() as u64;
-    let chunk_size = options.streaming_chunk_size.unwrap_or(1000);
+    let chunk_size = options
+        .streaming_chunk_size
+        .unwrap_or(crate::defaults::DEFAULT_STREAMING_CHUNK_SIZE);
 
     let xlsx_parser = parser::xlsx::XlsxParser;
 

--- a/crates/office2pdf/src/parser/docx_media.rs
+++ b/crates/office2pdf/src/parser/docx_media.rs
@@ -161,7 +161,11 @@ fn extract_vml_style_length(style: Option<&str>, key: &str) -> Option<f64> {
         return raw.trim().parse::<f64>().ok();
     }
     if let Some(raw) = value.strip_suffix("px") {
-        return raw.trim().parse::<f64>().ok().map(|px| px * 72.0 / 96.0);
+        return raw
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .map(|px| px * crate::defaults::POINTS_PER_INCH / crate::defaults::PIXELS_PER_INCH);
     }
 
     None
@@ -182,7 +186,9 @@ fn extract_vml_style_dimension(style: Option<&str>, key: &str) -> Option<f64> {
             return raw.trim().parse::<f64>().ok();
         }
         if let Some(raw) = value.strip_suffix("px") {
-            return raw.trim().parse::<f64>().ok().map(|px| px * 72.0 / 96.0);
+            return raw.trim().parse::<f64>().ok().map(|px| {
+                px * crate::defaults::POINTS_PER_INCH / crate::defaults::PIXELS_PER_INCH
+            });
         }
         if let Ok(points) = value.parse::<f64>() {
             return Some(points);

--- a/crates/office2pdf/src/parser/docx_styles.rs
+++ b/crates/office2pdf/src/parser/docx_styles.rs
@@ -29,9 +29,7 @@ pub(super) type StyleMap = HashMap<String, ResolvedStyle>;
 /// Synthetic style ID used for document-level default text properties.
 pub(super) const DOC_DEFAULT_STYLE_ID: &str = "__office2pdf_doc_defaults";
 
-/// Default font sizes for heading levels (Heading 1-6).
-/// Index 0 = Heading 1 (outline_lvl 0), index 5 = Heading 6 (outline_lvl 5).
-const HEADING_DEFAULT_SIZES: [f64; 6] = [24.0, 20.0, 16.0, 14.0, 12.0, 11.0];
+use crate::defaults::HEADING_FONT_SIZES;
 
 /// Build a map from style ID → resolved formatting by extracting formatting
 /// from each style's run_property and paragraph_property.
@@ -108,7 +106,7 @@ pub(super) fn merge_text_style(explicit: &TextStyle, style: Option<&ResolvedStyl
 
     if let Some(level) = heading_level {
         if merged.font_size.is_none() {
-            merged.font_size = Some(HEADING_DEFAULT_SIZES[level]);
+            merged.font_size = Some(HEADING_FONT_SIZES[level]);
         }
         if merged.bold.is_none() {
             merged.bold = Some(true);


### PR DESCRIPTION
## Summary

- Created `crates/office2pdf/src/defaults.rs` with named constants for all document defaults: paper sizes (A4, Letter, Legal), 1-inch margin, heading font sizes (H1-H6), streaming chunk size, and unit conversion factors (points/inch, pixels/inch).
- Replaced all hardcoded magic numbers in production code (`config.rs`, `ir/document.rs`, `lib_pipeline.rs`, `parser/docx_styles.rs`, `parser/docx_media.rs`) with references to the centralized constants.
- Added 15 tests verifying constant values, monotonic heading size ordering, and unit conversion correctness.

## Test plan

- [x] All 919 existing tests pass (`cargo test -p office2pdf`)
- [x] 15 new defaults tests pass
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] No hardcoded paper size, margin, heading size, or streaming chunk values remain in production code (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)