### PR TITLE
refactor: extract generate_blocks helper for block iteration

### DIFF
--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -297,12 +297,7 @@ fn generate_flow_page(
     if let Some(ref cols) = page.columns {
         generate_flow_page_columns(out, &page.content, cols, ctx)?;
     } else {
-        for (i, block) in page.content.iter().enumerate() {
-            if i > 0 {
-                out.push('\n');
-            }
-            generate_block(out, block, ctx)?;
-        }
+        generate_blocks(out, &page.content, ctx)?;
     }
     Ok(())
 }
@@ -352,12 +347,7 @@ fn generate_flow_page_columns(
             cols.num_columns,
             format_f64(cols.spacing)
         );
-        for (i, block) in content.iter().enumerate() {
-            if i > 0 {
-                out.push('\n');
-            }
-            generate_block(out, block, ctx)?;
-        }
+        generate_blocks(out, content, ctx)?;
         out.push_str("\n]\n");
     }
     Ok(())
@@ -1017,6 +1007,21 @@ fn generate_hf_content(out: &mut String, hf: &HeaderFooter) {
             out.push(']');
         }
     }
+}
+
+/// Generate Typst markup for a sequence of blocks, separating each with a newline.
+fn generate_blocks(
+    out: &mut String,
+    blocks: &[Block],
+    ctx: &mut GenCtx,
+) -> Result<(), ConvertError> {
+    for (i, block) in blocks.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        generate_block(out, block, ctx)?;
+    }
+    Ok(())
 }
 
 fn generate_block(out: &mut String, block: &Block, ctx: &mut GenCtx) -> Result<(), ConvertError> {

--- a/crates/office2pdf/src/render/typst_gen_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_tests.rs
@@ -435,3 +435,74 @@ fn test_table_cell_vertical_align_bottom() {
         "Bottom vertical alignment should emit 'align: bottom'. Got: {result}"
     );
 }
+
+// ── generate_blocks helper tests ─────────────────────────────────────
+
+#[test]
+fn test_generate_blocks_empty_slice_produces_no_output() {
+    let blocks: Vec<Block> = vec![];
+    let mut out = String::new();
+    let mut ctx = GenCtx::new();
+    generate_blocks(&mut out, &blocks, &mut ctx).unwrap();
+    assert!(
+        out.is_empty(),
+        "Empty block slice should produce no output. Got: {out:?}"
+    );
+}
+
+#[test]
+fn test_generate_blocks_single_block_no_leading_newline() {
+    let blocks: Vec<Block> = vec![make_paragraph("Hello")];
+    let mut out = String::new();
+    let mut ctx = GenCtx::new();
+    generate_blocks(&mut out, &blocks, &mut ctx).unwrap();
+    assert!(
+        !out.starts_with('\n'),
+        "Single block should not start with newline. Got: {out:?}"
+    );
+    assert!(
+        out.contains("Hello"),
+        "Output should contain block text. Got: {out:?}"
+    );
+}
+
+#[test]
+fn test_generate_blocks_multiple_blocks_separated_by_newline() {
+    let blocks: Vec<Block> = vec![make_paragraph("First"), make_paragraph("Second")];
+    let mut out = String::new();
+    let mut ctx = GenCtx::new();
+    generate_blocks(&mut out, &blocks, &mut ctx).unwrap();
+    // The output should contain both paragraphs separated by a newline
+    let first_pos: usize = out.find("First").expect("Should contain 'First'");
+    let second_pos: usize = out.find("Second").expect("Should contain 'Second'");
+    assert!(
+        first_pos < second_pos,
+        "First should appear before Second. Got: {out:?}"
+    );
+    // There should be a newline between the two blocks
+    let between: &str = &out[first_pos..second_pos];
+    assert!(
+        between.contains('\n'),
+        "Blocks should be separated by newline. Got between: {between:?}"
+    );
+}
+
+#[test]
+fn test_generate_blocks_three_blocks_have_two_separators() {
+    let blocks: Vec<Block> = vec![
+        make_paragraph("A"),
+        make_paragraph("B"),
+        make_paragraph("C"),
+    ];
+    let mut out = String::new();
+    let mut ctx = GenCtx::new();
+    generate_blocks(&mut out, &blocks, &mut ctx).unwrap();
+    assert!(out.contains("A"), "Should contain A. Got: {out:?}");
+    assert!(out.contains("B"), "Should contain B. Got: {out:?}");
+    assert!(out.contains("C"), "Should contain C. Got: {out:?}");
+    // Verify ordering
+    let pos_a: usize = out.find("A").expect("A");
+    let pos_b: usize = out.find("B").expect("B");
+    let pos_c: usize = out.find("C").expect("C");
+    assert!(pos_a < pos_b && pos_b < pos_c, "Order should be A < B < C");
+}


### PR DESCRIPTION
## Summary
- Extracted a `generate_blocks()` helper function in `typst_gen.rs` that encapsulates the repeated pattern of iterating over `&[Block]` with newline separators and calling `generate_block()` for each.
- Replaced 2 duplicated instances in `generate_flow_page()` and `generate_flow_page_columns()` (equal-columns branch) with calls to the new helper.
- Left the unequal-columns branch (`Vec<&Block>` segments) and `generate_cell_content()` in `typst_gen_tables.rs` unchanged, as they have structurally different types or different per-block dispatch logic.
- Added 4 unit tests covering empty input, single block, two blocks with separator, and three blocks with ordering.

## Test plan
- [x] All 908 existing tests pass (`cargo test -p office2pdf --lib`)
- [x] 4 new `generate_blocks` unit tests pass
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] No behavioral changes — pure refactoring, output is identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)