### PR TITLE
refactor: extract shared ZIP opening and parse error helpers

### DIFF
--- a/crates/office2pdf/src/parser/docx.rs
+++ b/crates/office2pdf/src/parser/docx.rs
@@ -111,8 +111,7 @@ struct ZipPreParseAssets {
 /// Falls back to empty contexts if the ZIP cannot be opened, letting
 /// docx-rs produce a proper parse error downstream.
 fn build_zip_preparse_assets(data: &[u8]) -> ZipPreParseAssets {
-    let cursor = std::io::Cursor::new(data);
-    match zip::ZipArchive::new(cursor) {
+    match crate::parser::open_zip(data) {
         Ok(mut archive) => {
             let metadata = crate::parser::metadata::extract_metadata_from_zip(&mut archive);
             let doc_xml = read_zip_text(&mut archive, "word/document.xml");
@@ -182,8 +181,9 @@ impl Parser for DocxParser {
             header_footer_assets,
         } = build_zip_preparse_assets(data);
 
-        let docx = docx_rs::read_docx(data)
-            .map_err(|e| ConvertError::Parse(format!("Failed to parse DOCX (docx-rs): {e}")))?;
+        let docx = docx_rs::read_docx(data).map_err(|e| {
+            crate::parser::parse_err(format!("Failed to parse DOCX (docx-rs): {e}"))
+        })?;
 
         // Populate locale-specific footnote/endnote style IDs from docx styles
         ctx.notes.populate_style_ids(&docx.styles);

--- a/crates/office2pdf/src/parser/mod.rs
+++ b/crates/office2pdf/src/parser/mod.rs
@@ -8,6 +8,10 @@ pub(crate) mod smartart;
 pub mod xlsx;
 pub(crate) mod xml_util;
 
+use std::io::Cursor;
+
+use zip::ZipArchive;
+
 use crate::config::ConvertOptions;
 use crate::error::{ConvertError, ConvertWarning};
 use crate::ir::Document;
@@ -20,4 +24,94 @@ pub trait Parser {
         data: &[u8],
         options: &ConvertOptions,
     ) -> Result<(Document, Vec<ConvertWarning>), ConvertError>;
+}
+
+/// Open a byte slice as a ZIP archive, returning a `ConvertError::Parse` on failure.
+pub(crate) fn open_zip(data: &[u8]) -> Result<ZipArchive<Cursor<&[u8]>>, ConvertError> {
+    let cursor: Cursor<&[u8]> = Cursor::new(data);
+    ZipArchive::new(cursor)
+        .map_err(|error| parse_err(format!("Failed to open ZIP archive: {error}")))
+}
+
+/// Convenience constructor for `ConvertError::Parse`.
+pub(crate) fn parse_err(msg: impl std::fmt::Display) -> ConvertError {
+    ConvertError::Parse(msg.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_zip_returns_archive_for_valid_zip() {
+        // Build a minimal valid ZIP in memory
+        let buf: Vec<u8> = Vec::new();
+        let cursor = Cursor::new(buf);
+        let mut writer = zip::ZipWriter::new(cursor);
+        let options = zip::write::FileOptions::default();
+        writer.start_file("hello.txt", options).unwrap();
+        std::io::Write::write_all(&mut writer, b"world").unwrap();
+        let cursor = writer.finish().unwrap();
+        let zip_bytes: Vec<u8> = cursor.into_inner();
+
+        let mut archive = open_zip(&zip_bytes).expect("should open valid ZIP");
+        assert_eq!(archive.len(), 1);
+        let file = archive.by_name("hello.txt");
+        assert!(file.is_ok());
+    }
+
+    #[test]
+    fn open_zip_returns_parse_error_for_invalid_data() {
+        let result = open_zip(b"this is not a zip file");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, ConvertError::Parse(ref msg) if msg.contains("Failed to open ZIP archive")),
+            "Expected Parse error with ZIP context, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn open_zip_returns_parse_error_for_empty_data() {
+        let result = open_zip(b"");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, ConvertError::Parse(_)),
+            "Expected Parse error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_err_creates_parse_variant_with_string_message() {
+        let err = parse_err("something went wrong");
+        match err {
+            ConvertError::Parse(msg) => assert_eq!(msg, "something went wrong"),
+            other => panic!("Expected Parse variant, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_err_works_with_format_display_types() {
+        let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "file missing");
+        let err = parse_err(format!("I/O failure: {io_error}"));
+        match err {
+            ConvertError::Parse(msg) => assert!(
+                msg.contains("I/O failure") && msg.contains("file missing"),
+                "Unexpected message: {msg}"
+            ),
+            other => panic!("Expected Parse variant, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_err_accepts_display_impl_directly() {
+        // Verify it works with any Display implementor, not just String/&str
+        let number: i32 = 42;
+        let err = parse_err(number);
+        match err {
+            ConvertError::Parse(msg) => assert_eq!(msg, "42"),
+            other => panic!("Expected Parse variant, got: {other:?}"),
+        }
+    }
 }

--- a/crates/office2pdf/src/parser/pptx.rs
+++ b/crates/office2pdf/src/parser/pptx.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
-use std::io::{Cursor, Read};
+#[cfg(test)]
+use std::io::Cursor;
+use std::io::Read;
 
 use quick_xml::Reader;
 use quick_xml::escape::unescape as unescape_xml_text;
@@ -377,9 +379,7 @@ impl Parser for PptxParser {
         data: &[u8],
         options: &ConvertOptions,
     ) -> Result<(Document, Vec<ConvertWarning>), ConvertError> {
-        let cursor = Cursor::new(data);
-        let mut archive = ZipArchive::new(cursor)
-            .map_err(|e| ConvertError::Parse(format!("Failed to read PPTX: {e}")))?;
+        let mut archive = crate::parser::open_zip(data)?;
 
         // Extract metadata from docProps/core.xml
         let metadata = crate::parser::metadata::extract_metadata_from_zip(&mut archive);

--- a/crates/office2pdf/src/parser/pptx_package.rs
+++ b/crates/office2pdf/src/parser/pptx_package.rs
@@ -61,10 +61,10 @@ pub(super) fn read_zip_entry<R: Read + std::io::Seek>(
 ) -> Result<String, ConvertError> {
     let mut file = archive
         .by_name(path)
-        .map_err(|error| ConvertError::Parse(format!("Missing {path} in PPTX: {error}")))?;
+        .map_err(|error| crate::parser::parse_err(format!("Missing {path} in PPTX: {error}")))?;
     let mut content = String::new();
     file.read_to_string(&mut content)
-        .map_err(|error| ConvertError::Parse(format!("Failed to read {path}: {error}")))?;
+        .map_err(|error| crate::parser::parse_err(format!("Failed to read {path}: {error}")))?;
     Ok(content)
 }
 
@@ -286,7 +286,7 @@ pub(super) fn parse_presentation_xml(xml: &str) -> Result<(PageSize, Vec<String>
             }
             Ok(Event::Eof) => break,
             Err(error) => {
-                return Err(ConvertError::Parse(format!(
+                return Err(crate::parser::parse_err(format!(
                     "XML error in presentation.xml: {error}"
                 )));
             }

--- a/crates/office2pdf/src/parser/pptx_shapes.rs
+++ b/crates/office2pdf/src/parser/pptx_shapes.rs
@@ -124,7 +124,7 @@ pub(super) fn parse_group_shape(
             },
             Ok(Event::Eof) => return Ok((Vec::new(), Vec::new())),
             Err(error) => {
-                return Err(ConvertError::Parse(format!(
+                return Err(crate::parser::parse_err(format!(
                     "XML error in group shape: {error}"
                 )));
             }
@@ -168,7 +168,7 @@ pub(super) fn parse_group_shape(
             }
             Ok(Event::Eof) => return Ok((Vec::new(), Vec::new())),
             Err(error) => {
-                return Err(ConvertError::Parse(format!(
+                return Err(crate::parser::parse_err(format!(
                     "XML error in group shape: {error}"
                 )));
             }

--- a/crates/office2pdf/src/parser/pptx_slides.rs
+++ b/crates/office2pdf/src/parser/pptx_slides.rs
@@ -987,7 +987,11 @@ pub(super) fn parse_slide_xml(
                 }
             }
             Ok(Event::Eof) => break,
-            Err(error) => return Err(ConvertError::Parse(format!("XML error in slide: {error}"))),
+            Err(error) => {
+                return Err(crate::parser::parse_err(format!(
+                    "XML error in slide: {error}"
+                )));
+            }
             _ => {}
         }
     }

--- a/crates/office2pdf/src/parser/pptx_tables.rs
+++ b/crates/office2pdf/src/parser/pptx_tables.rs
@@ -525,7 +525,11 @@ pub(super) fn parse_pptx_table(
                 }
             }
             Ok(Event::Eof) => break,
-            Err(error) => return Err(ConvertError::Parse(format!("XML error in table: {error}"))),
+            Err(error) => {
+                return Err(crate::parser::parse_err(format!(
+                    "XML error in table: {error}"
+                )));
+            }
             _ => {}
         }
     }

--- a/crates/office2pdf/src/parser/xlsx.rs
+++ b/crates/office2pdf/src/parser/xlsx.rs
@@ -40,7 +40,7 @@ impl XlsxParser {
     ) -> Result<(Vec<Document>, Vec<ConvertWarning>), ConvertError> {
         let cursor = Cursor::new(data);
         let book = umya_spreadsheet::reader::xlsx::read_reader(cursor, true).map_err(|e| {
-            ConvertError::Parse(format!("Failed to parse XLSX (umya-spreadsheet): {e}"))
+            crate::parser::parse_err(format!("Failed to parse XLSX (umya-spreadsheet): {e}"))
         })?;
 
         let metadata = extract_xlsx_metadata(&book);
@@ -131,7 +131,7 @@ impl Parser for XlsxParser {
     ) -> Result<(Document, Vec<ConvertWarning>), ConvertError> {
         let cursor = Cursor::new(data);
         let book = umya_spreadsheet::reader::xlsx::read_reader(cursor, true).map_err(|e| {
-            ConvertError::Parse(format!("Failed to parse XLSX (umya-spreadsheet): {e}"))
+            crate::parser::parse_err(format!("Failed to parse XLSX (umya-spreadsheet): {e}"))
         })?;
 
         // Extract metadata from umya-spreadsheet properties

--- a/crates/office2pdf/src/parser/xlsx_drawing.rs
+++ b/crates/office2pdf/src/parser/xlsx_drawing.rs
@@ -12,7 +12,7 @@ use crate::parser::xml_util;
 /// Charts without anchors (no drawing reference found) use `u32::MAX`
 /// as a sentinel to place them at the end of the sheet.
 pub(super) fn extract_charts_with_anchors(data: &[u8]) -> HashMap<String, Vec<(u32, Chart)>> {
-    let Ok(mut archive) = zip::ZipArchive::new(Cursor::new(data)) else {
+    let Ok(mut archive) = crate::parser::open_zip(data) else {
         return HashMap::new();
     };
 
@@ -138,7 +138,7 @@ pub(super) fn collect_positioned_chart_paths(
 ) -> HashSet<String> {
     // Re-trace the drawing → chart resolution to find which chart paths are covered.
     // This is intentionally conservative — if we can't determine the path, we skip.
-    let Ok(mut archive) = zip::ZipArchive::new(Cursor::new(data)) else {
+    let Ok(mut archive) = crate::parser::open_zip(data) else {
         return HashSet::new();
     };
     let mut positioned = HashSet::new();


### PR DESCRIPTION
## Summary
- Add `open_zip(data)` and `parse_err(msg)` helpers to `parser/mod.rs` to centralize duplicated ZIP archive opening and `ConvertError::Parse(format!(...))` construction across all parser modules
- Replace 4 duplicated `ZipArchive::new(Cursor::new(data))` call sites (PPTX, DOCX, XLSX drawing) with `open_zip` for consistent error messaging
- Replace 11 verbose `.map_err(|e| ConvertError::Parse(format!(...)))` patterns (DOCX, PPTX, PPTX package/shapes/slides/tables, XLSX) with `parse_err` while preserving all context-specific error messages
- Add 6 unit tests for the new helpers covering valid ZIP, invalid data, empty data, and various `Display` types

## Test plan
- [x] All 6 new unit tests pass (`open_zip` and `parse_err` coverage)
- [x] Full `cargo test -p office2pdf` passes (910 unit + 141 integration + 3 doc tests)
- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] `cargo fmt -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)