### PR TITLE
refactor: centralize unit conversions into parser/units module

### DIFF
--- a/crates/office2pdf/src/parser/docx.rs
+++ b/crates/office2pdf/src/parser/docx.rs
@@ -91,12 +91,6 @@ fn build_image_map(docx: &docx_rs::Docx) -> ImageMap {
         .collect()
 }
 
-/// Convert EMU (English Metric Units) to points.
-/// Kept in the parent module because multiple DOCX helper submodules use it.
-fn emu_to_pt(emu: u32) -> f64 {
-    emu as f64 / 12700.0
-}
-
 /// Pre-parsed assets extracted from the DOCX ZIP archive before docx-rs parsing.
 struct ZipPreParseAssets {
     metadata: crate::ir::Metadata,

--- a/crates/office2pdf/src/parser/docx_context_columns.rs
+++ b/crates/office2pdf/src/parser/docx_context_columns.rs
@@ -1,4 +1,5 @@
 use crate::ir::ColumnLayout;
+use crate::parser::units::twips_to_pt;
 
 pub(in super::super) fn scan_column_layouts(xml: &str) -> Vec<Option<ColumnLayout>> {
     let mut reader = quick_xml::Reader::from_str(xml);
@@ -19,7 +20,7 @@ pub(in super::super) fn scan_column_layouts(xml: &str) -> Vec<Option<ColumnLayou
 
             Some(ColumnLayout {
                 num_columns,
-                spacing: spacing_twips / 20.0,
+                spacing: twips_to_pt(spacing_twips),
                 column_widths: if !equal_width && !column_widths.is_empty() {
                     Some(column_widths.to_vec())
                 } else {
@@ -67,7 +68,7 @@ pub(in super::super) fn scan_column_layouts(xml: &str) -> Vec<Option<ColumnLayou
                             && let Ok(value) = attribute.unescape_value()
                             && let Ok(parsed) = value.parse::<f64>()
                         {
-                            column_widths.push(parsed / 20.0);
+                            column_widths.push(twips_to_pt(parsed));
                         }
                     }
                 }
@@ -104,7 +105,7 @@ pub(in super::super) fn scan_column_layouts(xml: &str) -> Vec<Option<ColumnLayou
                             && let Ok(value) = attribute.unescape_value()
                             && let Ok(parsed) = value.parse::<f64>()
                         {
-                            column_widths.push(parsed / 20.0);
+                            column_widths.push(twips_to_pt(parsed));
                         }
                     }
                 }
@@ -141,7 +142,7 @@ pub(in super::super) fn extract_column_layout_from_section_property(
 
     Some(ColumnLayout {
         num_columns: section_prop.columns as u32,
-        spacing: section_prop.space as f64 / 20.0,
+        spacing: twips_to_pt(section_prop.space as f64),
         column_widths: None,
     })
 }

--- a/crates/office2pdf/src/parser/docx_context_drawing.rs
+++ b/crates/office2pdf/src/parser/docx_context_drawing.rs
@@ -1,6 +1,6 @@
 use std::cell::Cell;
 
-use super::super::emu_to_pt;
+use crate::parser::units::emu_to_pt;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub(in super::super) struct DrawingTextBoxInfo {

--- a/crates/office2pdf/src/parser/docx_foundation_tests.rs
+++ b/crates/office2pdf/src/parser/docx_foundation_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::parser::units::twips_to_pt;
 
 // ----- Basic parsing tests -----
 
@@ -151,8 +152,8 @@ fn test_custom_page_size_extracted() {
         Page::Flow(p) => p,
         _ => panic!("Expected FlowPage"),
     };
-    let expected_width = width_twips as f64 / 20.0;
-    let expected_height = height_twips as f64 / 20.0;
+    let expected_width = twips_to_pt(width_twips as f64);
+    let expected_height = twips_to_pt(height_twips as f64);
     assert!(
         (page.size.width - expected_width).abs() < 1.0,
         "Expected width ~{expected_width}, got {}",
@@ -183,7 +184,7 @@ fn test_custom_margins_extracted() {
         Page::Flow(p) => p,
         _ => panic!("Expected FlowPage"),
     };
-    let expected_margin = 720.0 / 20.0;
+    let expected_margin = twips_to_pt(720.0);
     assert!(
         (page.margins.top - expected_margin).abs() < 1.0,
         "Expected top margin ~{expected_margin}, got {}",

--- a/crates/office2pdf/src/parser/docx_media.rs
+++ b/crates/office2pdf/src/parser/docx_media.rs
@@ -4,14 +4,7 @@ use super::{
     ImageFormat, ImageMap, StyleMap, VmlTextBoxInfo, WrapContext, convert_paragraph_blocks,
     convert_table,
 };
-
-fn emu_to_pt(emu: u32) -> f64 {
-    emu as f64 / 12700.0
-}
-
-fn emu_to_pt_signed(emu: i32) -> f64 {
-    emu as f64 / 12700.0
-}
+use crate::parser::units::emu_to_pt;
 
 pub(super) fn extract_drawing_image(
     drawing: &docx_rs::Drawing,
@@ -47,11 +40,11 @@ pub(super) fn extract_drawing_image(
     if pic.position_type == docx_rs::DrawingPositionType::Anchor {
         let wrap_mode = wraps.consume_next();
         let offset_x = match pic.position_h {
-            docx_rs::DrawingPosition::Offset(emu) => emu_to_pt_signed(emu),
+            docx_rs::DrawingPosition::Offset(emu) => emu_to_pt(emu),
             docx_rs::DrawingPosition::Align(_) => 0.0,
         };
         let offset_y = match pic.position_v {
-            docx_rs::DrawingPosition::Offset(emu) => emu_to_pt_signed(emu),
+            docx_rs::DrawingPosition::Offset(emu) => emu_to_pt(emu),
             docx_rs::DrawingPosition::Align(_) => 0.0,
         };
 
@@ -227,11 +220,11 @@ pub(super) fn extract_drawing_text_box_blocks(
     if text_box.position_type == docx_rs::DrawingPositionType::Anchor {
         let wrap_mode = ctx.wraps.consume_next();
         let offset_x = match text_box.position_h {
-            docx_rs::DrawingPosition::Offset(emu) => emu_to_pt_signed(emu),
+            docx_rs::DrawingPosition::Offset(emu) => emu_to_pt(emu),
             docx_rs::DrawingPosition::Align(_) => 0.0,
         };
         let offset_y = match text_box.position_v {
-            docx_rs::DrawingPosition::Offset(emu) => emu_to_pt_signed(emu),
+            docx_rs::DrawingPosition::Offset(emu) => emu_to_pt(emu),
             docx_rs::DrawingPosition::Align(_) => 0.0,
         };
         let (width, height) = resolve_drawing_text_box_size(text_box, layout);

--- a/crates/office2pdf/src/parser/docx_sections.rs
+++ b/crates/office2pdf/src/parser/docx_sections.rs
@@ -12,6 +12,7 @@ use super::{
     extract_paragraph_style, extract_run_style, extract_tab_stop_overrides, group_into_lists,
     merge_paragraph_style, read_zip_text,
 };
+use crate::parser::units::twips_to_pt;
 
 /// Parsed header/footer assets addressed by relationship ID.
 #[derive(Default)]
@@ -433,8 +434,8 @@ pub(super) fn extract_page_size(page_size: &docx_rs::PageSize) -> PageSize {
             .unwrap_or(0.0);
         let orientation = json.get("orient").and_then(|value| value.as_str());
         if width_twips > 0.0 && height_twips > 0.0 {
-            let mut width = width_twips / 20.0;
-            let mut height = height_twips / 20.0;
+            let mut width = twips_to_pt(width_twips);
+            let mut height = twips_to_pt(height_twips);
             if orientation == Some("landscape") && width < height {
                 std::mem::swap(&mut width, &mut height);
             }
@@ -448,9 +449,9 @@ pub(super) fn extract_page_size(page_size: &docx_rs::PageSize) -> PageSize {
 /// PageMargin fields are public i32 values in twips.
 fn extract_margins(page_margin: &docx_rs::PageMargin) -> Margins {
     Margins {
-        top: page_margin.top as f64 / 20.0,
-        bottom: page_margin.bottom as f64 / 20.0,
-        left: page_margin.left as f64 / 20.0,
-        right: page_margin.right as f64 / 20.0,
+        top: twips_to_pt(page_margin.top),
+        bottom: twips_to_pt(page_margin.bottom),
+        left: twips_to_pt(page_margin.left),
+        right: twips_to_pt(page_margin.right),
     }
 }

--- a/crates/office2pdf/src/parser/docx_tables.rs
+++ b/crates/office2pdf/src/parser/docx_tables.rs
@@ -4,6 +4,7 @@ use super::{
     HyperlinkMap, ImageMap, Insets, MAX_TABLE_DEPTH, StyleMap, Table, TableCell, TableRow,
     convert_paragraph_blocks, parse_hex_color,
 };
+use crate::parser::units::twips_to_pt;
 
 #[derive(Clone)]
 struct RawCell {
@@ -31,7 +32,7 @@ fn extract_margin_side_points(side_json: &serde_json::Value) -> Option<f64> {
     let value = side_json.get("val").and_then(|v| v.as_f64())?;
 
     match width_type {
-        "dxa" => Some(value / 20.0),
+        "dxa" => Some(twips_to_pt(value)),
         _ => None,
     }
 }
@@ -119,7 +120,7 @@ fn extract_table_cell_width(prop_json: Option<&serde_json::Value>) -> Option<f64
     let width = width_json.get("width").and_then(|v| v.as_f64())?;
 
     match width_type {
-        "dxa" => Some(width / 20.0),
+        "dxa" => Some(twips_to_pt(width)),
         _ => None,
     }
 }
@@ -150,7 +151,7 @@ pub(super) fn convert_table(
     let column_widths: Vec<f64> = if table.grid.is_empty() {
         derive_column_widths_from_cells(&raw_rows).unwrap_or_default()
     } else {
-        table.grid.iter().map(|&w| w as f64 / 20.0).collect()
+        table.grid.iter().map(|&w| twips_to_pt(w as f64)).collect()
     };
 
     let rows = resolve_vmerge_and_build_rows(&raw_rows);

--- a/crates/office2pdf/src/parser/docx_text.rs
+++ b/crates/office2pdf/src/parser/docx_text.rs
@@ -2,6 +2,7 @@ use super::{
     Alignment, Color, HyperlinkMap, LineSpacing, ParagraphStyle, TabAlignment, TabLeader, TabStop,
     TabStopOverride, TextStyle, VerticalTextAlign, apply_tab_stop_overrides,
 };
+use crate::parser::units::{half_points_to_pt, twips_to_pt};
 use crate::parser::xml_util;
 
 pub(super) fn extract_paragraph_style(prop: &docx_rs::ParagraphProperty) -> ParagraphStyle {
@@ -36,11 +37,11 @@ fn extract_indent(indent: &Option<docx_rs::Indent>) -> (Option<f64>, Option<f64>
         return (None, None, None);
     };
 
-    let left = indent.start.map(|v| v as f64 / 20.0);
-    let right = indent.end.map(|v| v as f64 / 20.0);
+    let left = indent.start.map(twips_to_pt);
+    let right = indent.end.map(twips_to_pt);
     let first_line = indent.special_indent.map(|si| match si {
-        docx_rs::SpecialIndentType::FirstLine(v) => v as f64 / 20.0,
-        docx_rs::SpecialIndentType::Hanging(v) => -(v as f64 / 20.0),
+        docx_rs::SpecialIndentType::FirstLine(v) => twips_to_pt(v),
+        docx_rs::SpecialIndentType::Hanging(v) => -twips_to_pt(v),
     });
 
     (left, right, first_line)
@@ -58,17 +59,14 @@ fn extract_line_spacing(
         Err(_) => return (None, None, None),
     };
 
-    let space_before = json
-        .get("before")
-        .and_then(|v| v.as_f64())
-        .map(|v| v / 20.0);
-    let space_after = json.get("after").and_then(|v| v.as_f64()).map(|v| v / 20.0);
+    let space_before = json.get("before").and_then(|v| v.as_f64()).map(twips_to_pt);
+    let space_after = json.get("after").and_then(|v| v.as_f64()).map(twips_to_pt);
 
     let line_spacing = json.get("line").and_then(|line_val| {
         let line = line_val.as_f64()?;
         let rule = json.get("lineRule").and_then(|v| v.as_str());
         match rule {
-            Some("exact") | Some("atLeast") => Some(LineSpacing::Exact(line / 20.0)),
+            Some("exact") | Some("atLeast") => Some(LineSpacing::Exact(twips_to_pt(line))),
             _ => Some(LineSpacing::Proportional(line / 240.0)),
         }
     });
@@ -91,7 +89,7 @@ pub(super) fn extract_tab_stop_overrides(tabs: &[docx_rs::Tab]) -> Option<Vec<Ta
     Some(
         tabs.iter()
             .filter_map(|tab| {
-                let position = tab.pos.map(|pos_twips| pos_twips as f64 / 20.0)?;
+                let position = tab.pos.map(|pos_twips| twips_to_pt(pos_twips as f64))?;
 
                 if matches!(tab.val, Some(docx_rs::TabValueType::Clear)) {
                     return Some(TabStopOverride::Clear(position));
@@ -152,7 +150,7 @@ pub(super) fn extract_run_style_from_json(rp: &serde_json::Value) -> TextStyle {
         font_size: rp
             .get("sz")
             .and_then(serde_json::Value::as_f64)
-            .map(|half_points| half_points / 2.0),
+            .map(half_points_to_pt),
         color: rp
             .get("color")
             .and_then(serde_json::Value::as_str)
@@ -176,7 +174,7 @@ pub(super) fn extract_run_style_from_json(rp: &serde_json::Value) -> TextStyle {
         letter_spacing: rp
             .get("characterSpacing")
             .and_then(serde_json::Value::as_i64)
-            .map(|twips| twips as f64 / 20.0),
+            .map(|twips| twips_to_pt(twips as f64)),
     }
 }
 

--- a/crates/office2pdf/src/parser/mod.rs
+++ b/crates/office2pdf/src/parser/mod.rs
@@ -5,12 +5,17 @@ pub(crate) mod metadata;
 pub(crate) mod omml;
 pub mod pptx;
 pub(crate) mod smartart;
+pub(crate) mod units;
 pub mod xlsx;
 pub(crate) mod xml_util;
 
 use std::io::Cursor;
 
 use zip::ZipArchive;
+
+#[cfg(test)]
+#[path = "units_tests.rs"]
+mod units_tests;
 
 use crate::config::ConvertOptions;
 use crate::error::{ConvertError, ConvertWarning};

--- a/crates/office2pdf/src/parser/pptx.rs
+++ b/crates/office2pdf/src/parser/pptx.rs
@@ -19,6 +19,7 @@ use crate::ir::{
 };
 use crate::parser::Parser;
 use crate::parser::smartart;
+use crate::parser::units::emu_to_pt;
 
 use self::package::{load_theme, parse_presentation_xml, parse_rels_xml, read_zip_entry};
 #[cfg(test)]
@@ -366,12 +367,6 @@ impl PptxTextBodyStyleDefaults {
 
 /// Parser for PPTX (Office Open XML PowerPoint) presentations.
 pub struct PptxParser;
-
-/// Convert EMU (English Metric Units) to points.
-/// 1 inch = 914400 EMU, 1 inch = 72 points, so 1 pt = 12700 EMU.
-fn emu_to_pt(emu: i64) -> f64 {
-    emu as f64 / 12700.0
-}
 
 impl Parser for PptxParser {
     fn parse(

--- a/crates/office2pdf/src/parser/pptx_slides.rs
+++ b/crates/office2pdf/src/parser/pptx_slides.rs
@@ -345,7 +345,7 @@ fn finalize_shape(
     } else if let Some(ref geom) = shape.prst_geom {
         let kind = prst_to_shape_kind(geom, emu_to_pt(shape.cx), emu_to_pt(shape.cy));
         let stroke = shape.ln_color.map(|color| BorderSide {
-            width: shape.ln_width_emu as f64 / 12700.0,
+            width: emu_to_pt(shape.ln_width_emu),
             color,
             style: shape.ln_dash_style,
         });

--- a/crates/office2pdf/src/parser/pptx_tables.rs
+++ b/crates/office2pdf/src/parser/pptx_tables.rs
@@ -506,7 +506,7 @@ pub(super) fn parse_pptx_table(
                     b"lnL" | b"lnR" | b"lnT" | b"lnB" if in_border_line => {
                         if let Some(color) = border_line_color.take() {
                             let side = BorderSide {
-                                width: border_line_width_emu as f64 / 12700.0,
+                                width: emu_to_pt(border_line_width_emu),
                                 color,
                                 style: border_line_dash_style,
                             };

--- a/crates/office2pdf/src/parser/pptx_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_tests.rs
@@ -195,8 +195,8 @@ fn test_slide_dimensions() {
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
     let page = first_fixed_page(&doc);
-    let expected_w = cx as f64 / 12700.0;
-    let expected_h = cy as f64 / 12700.0;
+    let expected_w = emu_to_pt(cx);
+    let expected_h = emu_to_pt(cy);
     assert!(
         (page.size.width - expected_w).abs() < 0.1,
         "Expected width ~{expected_w}pt, got {}",

--- a/crates/office2pdf/src/parser/pptx_text_box_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_text_box_tests.rs
@@ -37,10 +37,10 @@ fn test_text_box_position_and_size() {
     let page = first_fixed_page(&doc);
     let elem = &page.elements[0];
 
-    let expected_x = x as f64 / 12700.0;
-    let expected_y = y as f64 / 12700.0;
-    let expected_w = cx as f64 / 12700.0;
-    let expected_h = cy as f64 / 12700.0;
+    let expected_x = emu_to_pt(x);
+    let expected_y = emu_to_pt(y);
+    let expected_w = emu_to_pt(cx);
+    let expected_h = emu_to_pt(cy);
 
     assert!(
         (elem.x - expected_x).abs() < 0.1,

--- a/crates/office2pdf/src/parser/units.rs
+++ b/crates/office2pdf/src/parser/units.rs
@@ -1,0 +1,27 @@
+//! Centralized unit conversion functions for OOXML document formats.
+//!
+//! EMU (English Metric Units), twips, and half-points are the three primary
+//! measurement units used across DOCX, PPTX, and XLSX formats. This module
+//! provides a single source of truth for converting each to PDF points.
+
+/// Convert English Metric Units (EMU) to points.
+/// 1 inch = 914 400 EMU, 1 inch = 72 pt, therefore 1 pt = 12 700 EMU.
+///
+/// Accepts any integer type that implements `Into<i64>` (i32, u32, i64, etc.).
+pub fn emu_to_pt(emu: impl Into<i64>) -> f64 {
+    emu.into() as f64 / 12700.0
+}
+
+/// Convert twips to points. 1 pt = 20 twips.
+///
+/// Accepts any numeric type that implements `Into<f64>` (f64, i32, i64, etc.).
+pub fn twips_to_pt(twips: impl Into<f64>) -> f64 {
+    twips.into() / 20.0
+}
+
+/// Convert half-points to points. 1 pt = 2 half-points.
+///
+/// Used for font sizes in DOCX run properties (`w:sz` attribute).
+pub fn half_points_to_pt(hp: impl Into<f64>) -> f64 {
+    hp.into() / 2.0
+}

--- a/crates/office2pdf/src/parser/units_tests.rs
+++ b/crates/office2pdf/src/parser/units_tests.rs
@@ -1,0 +1,118 @@
+use super::units::{emu_to_pt, half_points_to_pt, twips_to_pt};
+
+// ── emu_to_pt ───────────────────────────────────────────────────────
+
+#[test]
+fn emu_to_pt_zero() {
+    assert_eq!(emu_to_pt(0i64), 0.0);
+}
+
+#[test]
+fn emu_to_pt_one_inch() {
+    // 1 inch = 914400 EMU = 72 points
+    let result: f64 = emu_to_pt(914_400i64);
+    assert!((result - 72.0).abs() < 1e-10);
+}
+
+#[test]
+fn emu_to_pt_one_point() {
+    // 1 pt = 12700 EMU
+    let result: f64 = emu_to_pt(12_700i64);
+    assert!((result - 1.0).abs() < 1e-10);
+}
+
+#[test]
+fn emu_to_pt_negative_value() {
+    let result: f64 = emu_to_pt(-12_700i64);
+    assert!((result - (-1.0)).abs() < 1e-10);
+}
+
+#[test]
+fn emu_to_pt_accepts_u32() {
+    // u32 should work via Into<i64>
+    let result: f64 = emu_to_pt(12_700u32);
+    assert!((result - 1.0).abs() < 1e-10);
+}
+
+#[test]
+fn emu_to_pt_accepts_i32() {
+    let result: f64 = emu_to_pt(-12_700i32);
+    assert!((result - (-1.0)).abs() < 1e-10);
+}
+
+#[test]
+fn emu_to_pt_fractional_result() {
+    // 6350 EMU = 0.5 pt
+    let result: f64 = emu_to_pt(6_350i64);
+    assert!((result - 0.5).abs() < 1e-10);
+}
+
+#[test]
+fn emu_to_pt_large_value() {
+    // Typical PPTX slide width: 12_192_000 EMU = 960 pt
+    let result: f64 = emu_to_pt(12_192_000i64);
+    assert!((result - 960.0).abs() < 1e-10);
+}
+
+// ── twips_to_pt ─────────────────────────────────────────────────────
+
+#[test]
+fn twips_to_pt_zero() {
+    assert_eq!(twips_to_pt(0.0), 0.0);
+}
+
+#[test]
+fn twips_to_pt_twenty_twips_is_one_point() {
+    assert!((twips_to_pt(20.0) - 1.0).abs() < 1e-10);
+}
+
+#[test]
+fn twips_to_pt_negative() {
+    assert!((twips_to_pt(-20.0) - (-1.0)).abs() < 1e-10);
+}
+
+#[test]
+fn twips_to_pt_typical_page_width() {
+    // 12240 twips = 612 pt = 8.5 inches
+    let result: f64 = twips_to_pt(12240.0);
+    assert!((result - 612.0).abs() < 1e-10);
+}
+
+#[test]
+fn twips_to_pt_accepts_integer_via_into() {
+    // i32 -> f64 via Into
+    let result: f64 = twips_to_pt(720i32);
+    assert!((result - 36.0).abs() < 1e-10);
+}
+
+#[test]
+fn twips_to_pt_accepts_u16_via_into() {
+    let result: f64 = twips_to_pt(240u16);
+    assert!((result - 12.0).abs() < 1e-10);
+}
+
+// ── half_points_to_pt ───────────────────────────────────────────────
+
+#[test]
+fn half_points_to_pt_zero() {
+    assert_eq!(half_points_to_pt(0.0), 0.0);
+}
+
+#[test]
+fn half_points_to_pt_two_half_points_is_one_point() {
+    assert!((half_points_to_pt(2.0) - 1.0).abs() < 1e-10);
+}
+
+#[test]
+fn half_points_to_pt_typical_font_size() {
+    // 24 half-points = 12 pt font
+    let result: f64 = half_points_to_pt(24.0);
+    assert!((result - 12.0).abs() < 1e-10);
+}
+
+#[test]
+fn half_points_to_pt_odd_value() {
+    // 25 half-points = 12.5 pt
+    let result: f64 = half_points_to_pt(25.0);
+    assert!((result - 12.5).abs() < 1e-10);
+}


### PR DESCRIPTION
## Summary
- Create `parser/units.rs` with `emu_to_pt`, `twips_to_pt`, and `half_points_to_pt` — single source of truth for OOXML unit conversions
- Remove 3 duplicate `emu_to_pt` implementations (docx.rs, pptx.rs, docx_media.rs) and `emu_to_pt_signed`
- Replace all inline `/ 12700.0` (EMU), `/ 20.0` (twips), and `/ 2.0` (half-points) conversions across 14 files with calls to the centralized module
- Use `impl Into<i64>` / `impl Into<f64>` generics so callers with u32, i32, i64, or f64 values work without manual casts
- Add 18 unit tests covering all three conversion functions with realistic OOXML values

## Test plan
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 922 unit tests pass (`cargo test -p office2pdf`)
- [x] All integration tests pass (docx, pptx, xlsx fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)