### PR TITLE
refactor: unify style merge logic into ir/style.rs methods

### DIFF
--- a/crates/office2pdf/src/ir/style.rs
+++ b/crates/office2pdf/src/ir/style.rs
@@ -119,6 +119,88 @@ pub struct TextStyle {
     pub letter_spacing: Option<f64>,
 }
 
+impl TextStyle {
+    /// Merge fields from `other` into `self`. For each field, if `other` has
+    /// `Some(value)`, it overwrites `self`'s value. Fields that are `None` in
+    /// `other` are left unchanged.
+    pub fn merge_from(&mut self, other: &TextStyle) {
+        if other.font_family.is_some() {
+            self.font_family = other.font_family.clone();
+        }
+        if other.font_size.is_some() {
+            self.font_size = other.font_size;
+        }
+        if other.bold.is_some() {
+            self.bold = other.bold;
+        }
+        if other.italic.is_some() {
+            self.italic = other.italic;
+        }
+        if other.underline.is_some() {
+            self.underline = other.underline;
+        }
+        if other.strikethrough.is_some() {
+            self.strikethrough = other.strikethrough;
+        }
+        if other.color.is_some() {
+            self.color = other.color;
+        }
+        if other.highlight.is_some() {
+            self.highlight = other.highlight;
+        }
+        if other.vertical_align.is_some() {
+            self.vertical_align = other.vertical_align;
+        }
+        if other.all_caps.is_some() {
+            self.all_caps = other.all_caps;
+        }
+        if other.small_caps.is_some() {
+            self.small_caps = other.small_caps;
+        }
+        if other.letter_spacing.is_some() {
+            self.letter_spacing = other.letter_spacing;
+        }
+    }
+}
+
+impl ParagraphStyle {
+    /// Merge fields from `other` into `self`. For each field, if `other` has
+    /// `Some(value)`, it overwrites `self`'s value. Fields that are `None` in
+    /// `other` are left unchanged.
+    pub fn merge_from(&mut self, other: &ParagraphStyle) {
+        if other.alignment.is_some() {
+            self.alignment = other.alignment;
+        }
+        if other.indent_left.is_some() {
+            self.indent_left = other.indent_left;
+        }
+        if other.indent_right.is_some() {
+            self.indent_right = other.indent_right;
+        }
+        if other.indent_first_line.is_some() {
+            self.indent_first_line = other.indent_first_line;
+        }
+        if other.line_spacing.is_some() {
+            self.line_spacing = other.line_spacing;
+        }
+        if other.space_before.is_some() {
+            self.space_before = other.space_before;
+        }
+        if other.space_after.is_some() {
+            self.space_after = other.space_after;
+        }
+        if other.heading_level.is_some() {
+            self.heading_level = other.heading_level;
+        }
+        if other.direction.is_some() {
+            self.direction = other.direction;
+        }
+        if other.tab_stops.is_some() {
+            self.tab_stops = other.tab_stops.clone();
+        }
+    }
+}
+
 /// RGB color.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Color {

--- a/crates/office2pdf/src/ir/style_tests.rs
+++ b/crates/office2pdf/src/ir/style_tests.rs
@@ -57,3 +57,214 @@ fn test_text_style_caps() {
     assert_eq!(ts.all_caps, Some(true));
     assert_eq!(ts.small_caps, Some(true));
 }
+
+// ── TextStyle::merge_from tests ──────────────────────────────────────
+
+#[test]
+fn text_style_merge_from_all_none_source_preserves_target() {
+    let mut target = TextStyle {
+        font_family: Some("Arial".to_string()),
+        font_size: Some(12.0),
+        bold: Some(true),
+        italic: Some(false),
+        underline: Some(true),
+        strikethrough: Some(false),
+        color: Some(Color::new(255, 0, 0)),
+        highlight: Some(Color::new(0, 255, 0)),
+        vertical_align: Some(VerticalTextAlign::Superscript),
+        all_caps: Some(true),
+        small_caps: Some(false),
+        letter_spacing: Some(1.5),
+    };
+    let original: TextStyle = target.clone();
+    let source = TextStyle::default();
+
+    target.merge_from(&source);
+
+    assert_eq!(target, original);
+}
+
+#[test]
+fn text_style_merge_from_all_some_source_overwrites_target() {
+    let mut target = TextStyle {
+        font_family: Some("Arial".to_string()),
+        font_size: Some(12.0),
+        bold: Some(true),
+        italic: Some(true),
+        underline: Some(true),
+        strikethrough: Some(true),
+        color: Some(Color::new(255, 0, 0)),
+        highlight: Some(Color::new(0, 255, 0)),
+        vertical_align: Some(VerticalTextAlign::Superscript),
+        all_caps: Some(true),
+        small_caps: Some(true),
+        letter_spacing: Some(1.5),
+    };
+    let source = TextStyle {
+        font_family: Some("Times".to_string()),
+        font_size: Some(24.0),
+        bold: Some(false),
+        italic: Some(false),
+        underline: Some(false),
+        strikethrough: Some(false),
+        color: Some(Color::new(0, 0, 255)),
+        highlight: Some(Color::new(128, 128, 128)),
+        vertical_align: Some(VerticalTextAlign::Subscript),
+        all_caps: Some(false),
+        small_caps: Some(false),
+        letter_spacing: Some(3.0),
+    };
+
+    target.merge_from(&source);
+
+    assert_eq!(target, source);
+}
+
+#[test]
+fn text_style_merge_from_partial_overlap() {
+    let mut target = TextStyle {
+        font_family: Some("Arial".to_string()),
+        font_size: Some(12.0),
+        bold: None,
+        italic: Some(true),
+        ..TextStyle::default()
+    };
+    let source = TextStyle {
+        font_family: Some("Helvetica".to_string()),
+        bold: Some(true),
+        italic: None,
+        color: Some(Color::new(100, 100, 100)),
+        ..TextStyle::default()
+    };
+
+    target.merge_from(&source);
+
+    assert_eq!(target.font_family, Some("Helvetica".to_string()));
+    assert_eq!(target.font_size, Some(12.0));
+    assert_eq!(target.bold, Some(true));
+    assert_eq!(target.italic, Some(true));
+    assert_eq!(target.color, Some(Color::new(100, 100, 100)));
+    assert!(target.underline.is_none());
+}
+
+#[test]
+fn text_style_merge_from_into_default_target() {
+    let mut target = TextStyle::default();
+    let source = TextStyle {
+        font_size: Some(18.0),
+        bold: Some(false),
+        letter_spacing: Some(2.0),
+        ..TextStyle::default()
+    };
+
+    target.merge_from(&source);
+
+    assert_eq!(target.font_size, Some(18.0));
+    assert_eq!(target.bold, Some(false));
+    assert_eq!(target.letter_spacing, Some(2.0));
+    assert!(target.font_family.is_none());
+}
+
+// ── ParagraphStyle::merge_from tests ─────────────────────────────────
+
+#[test]
+fn paragraph_style_merge_from_all_none_source_preserves_target() {
+    let mut target = ParagraphStyle {
+        alignment: Some(Alignment::Center),
+        indent_left: Some(10.0),
+        indent_right: Some(5.0),
+        indent_first_line: Some(20.0),
+        line_spacing: Some(LineSpacing::Proportional(1.5)),
+        space_before: Some(6.0),
+        space_after: Some(12.0),
+        heading_level: Some(2),
+        direction: Some(TextDirection::Rtl),
+        tab_stops: Some(vec![TabStop {
+            position: 72.0,
+            alignment: TabAlignment::Left,
+            leader: TabLeader::None,
+        }]),
+    };
+    let original: ParagraphStyle = target.clone();
+    let source = ParagraphStyle::default();
+
+    target.merge_from(&source);
+
+    assert_eq!(target.alignment, original.alignment);
+    assert_eq!(target.indent_left, original.indent_left);
+    assert_eq!(target.indent_right, original.indent_right);
+    assert_eq!(target.indent_first_line, original.indent_first_line);
+    assert_eq!(target.space_before, original.space_before);
+    assert_eq!(target.space_after, original.space_after);
+    assert_eq!(target.heading_level, original.heading_level);
+    assert_eq!(target.direction, original.direction);
+    assert_eq!(target.tab_stops, original.tab_stops);
+}
+
+#[test]
+fn paragraph_style_merge_from_all_some_source_overwrites_target() {
+    let mut target = ParagraphStyle {
+        alignment: Some(Alignment::Left),
+        indent_left: Some(10.0),
+        space_before: Some(6.0),
+        ..ParagraphStyle::default()
+    };
+    let source = ParagraphStyle {
+        alignment: Some(Alignment::Right),
+        indent_left: Some(20.0),
+        indent_right: Some(15.0),
+        indent_first_line: Some(30.0),
+        line_spacing: Some(LineSpacing::Exact(14.0)),
+        space_before: Some(8.0),
+        space_after: Some(16.0),
+        heading_level: Some(1),
+        direction: Some(TextDirection::Rtl),
+        tab_stops: Some(vec![TabStop {
+            position: 144.0,
+            alignment: TabAlignment::Right,
+            leader: TabLeader::Dot,
+        }]),
+    };
+
+    target.merge_from(&source);
+
+    assert_eq!(target.alignment, Some(Alignment::Right));
+    assert_eq!(target.indent_left, Some(20.0));
+    assert_eq!(target.indent_right, Some(15.0));
+    assert_eq!(target.indent_first_line, Some(30.0));
+    assert_eq!(target.space_before, Some(8.0));
+    assert_eq!(target.space_after, Some(16.0));
+    assert_eq!(target.heading_level, Some(1));
+    assert_eq!(target.direction, Some(TextDirection::Rtl));
+    assert_eq!(
+        target.tab_stops,
+        Some(vec![TabStop {
+            position: 144.0,
+            alignment: TabAlignment::Right,
+            leader: TabLeader::Dot,
+        }])
+    );
+}
+
+#[test]
+fn paragraph_style_merge_from_partial_overlap() {
+    let mut target = ParagraphStyle {
+        alignment: Some(Alignment::Left),
+        indent_left: Some(10.0),
+        space_before: Some(6.0),
+        ..ParagraphStyle::default()
+    };
+    let source = ParagraphStyle {
+        alignment: Some(Alignment::Center),
+        space_after: Some(12.0),
+        ..ParagraphStyle::default()
+    };
+
+    target.merge_from(&source);
+
+    assert_eq!(target.alignment, Some(Alignment::Center));
+    assert_eq!(target.indent_left, Some(10.0));
+    assert_eq!(target.space_before, Some(6.0));
+    assert_eq!(target.space_after, Some(12.0));
+    assert!(target.heading_level.is_none());
+}

--- a/crates/office2pdf/src/parser/docx_styles.rs
+++ b/crates/office2pdf/src/parser/docx_styles.rs
@@ -89,21 +89,11 @@ pub(super) fn merge_text_style(explicit: &TextStyle, style: Option<&ResolvedStyl
         None => return explicit.clone(),
     };
 
-    let mut merged = TextStyle {
-        bold: style_text.bold,
-        italic: style_text.italic,
-        underline: style_text.underline,
-        strikethrough: style_text.strikethrough,
-        font_size: style_text.font_size,
-        color: style_text.color,
-        font_family: style_text.font_family.clone(),
-        highlight: style_text.highlight,
-        vertical_align: style_text.vertical_align,
-        all_caps: style_text.all_caps,
-        small_caps: style_text.small_caps,
-        letter_spacing: style_text.letter_spacing,
-    };
+    let mut merged: TextStyle = style_text.clone();
 
+    // Heading defaults: apply fallback size/bold when the style itself
+    // doesn't specify them. This must happen before the explicit overwrite
+    // so that explicit values still win.
     if let Some(level) = heading_level {
         if merged.font_size.is_none() {
             merged.font_size = Some(HEADING_FONT_SIZES[level]);
@@ -113,42 +103,7 @@ pub(super) fn merge_text_style(explicit: &TextStyle, style: Option<&ResolvedStyl
         }
     }
 
-    if explicit.bold.is_some() {
-        merged.bold = explicit.bold;
-    }
-    if explicit.italic.is_some() {
-        merged.italic = explicit.italic;
-    }
-    if explicit.underline.is_some() {
-        merged.underline = explicit.underline;
-    }
-    if explicit.strikethrough.is_some() {
-        merged.strikethrough = explicit.strikethrough;
-    }
-    if explicit.font_size.is_some() {
-        merged.font_size = explicit.font_size;
-    }
-    if explicit.color.is_some() {
-        merged.color = explicit.color;
-    }
-    if explicit.font_family.is_some() {
-        merged.font_family = explicit.font_family.clone();
-    }
-    if explicit.highlight.is_some() {
-        merged.highlight = explicit.highlight;
-    }
-    if explicit.vertical_align.is_some() {
-        merged.vertical_align = explicit.vertical_align;
-    }
-    if explicit.all_caps.is_some() {
-        merged.all_caps = explicit.all_caps;
-    }
-    if explicit.small_caps.is_some() {
-        merged.small_caps = explicit.small_caps;
-    }
-    if explicit.letter_spacing.is_some() {
-        merged.letter_spacing = explicit.letter_spacing;
-    }
+    merged.merge_from(explicit);
 
     merged
 }

--- a/crates/office2pdf/src/parser/pptx.rs
+++ b/crates/office2pdf/src/parser/pptx.rs
@@ -328,23 +328,23 @@ struct PptxTextBodyStyleDefaults {
 
 impl PptxTextBodyStyleDefaults {
     fn paragraph_style_for_level(&self, level: u32) -> ParagraphStyle {
-        let mut style = self.default_paragraph.clone();
+        let mut style: ParagraphStyle = self.default_paragraph.clone();
         if let Some(level_style) = self.levels.get(&level) {
-            merge_paragraph_style(&mut style, &level_style.paragraph);
+            style.merge_from(&level_style.paragraph);
         }
         style
     }
 
     fn run_style_for_level(&self, level: u32) -> TextStyle {
-        let mut style = self.default_run.clone();
+        let mut style: TextStyle = self.default_run.clone();
         if let Some(level_style) = self.levels.get(&level) {
-            merge_text_style(&mut style, &level_style.run);
+            style.merge_from(&level_style.run);
         }
         style
     }
 
     fn bullet_for_level(&self, level: u32) -> PptxBulletDefinition {
-        let mut bullet = self.default_bullet.clone();
+        let mut bullet: PptxBulletDefinition = self.default_bullet.clone();
         if let Some(level_style) = self.levels.get(&level) {
             merge_pptx_bullet_definition(&mut bullet, &level_style.bullet);
         }
@@ -352,14 +352,15 @@ impl PptxTextBodyStyleDefaults {
     }
 
     fn merge_from(&mut self, overlay: &PptxTextBodyStyleDefaults) {
-        merge_paragraph_style(&mut self.default_paragraph, &overlay.default_paragraph);
-        merge_text_style(&mut self.default_run, &overlay.default_run);
+        self.default_paragraph
+            .merge_from(&overlay.default_paragraph);
+        self.default_run.merge_from(&overlay.default_run);
         merge_pptx_bullet_definition(&mut self.default_bullet, &overlay.default_bullet);
 
         for (level, overlay_style) in &overlay.levels {
-            let target = self.levels.entry(*level).or_default();
-            merge_paragraph_style(&mut target.paragraph, &overlay_style.paragraph);
-            merge_text_style(&mut target.run, &overlay_style.run);
+            let target: &mut PptxTextLevelStyle = self.levels.entry(*level).or_default();
+            target.paragraph.merge_from(&overlay_style.paragraph);
+            target.run.merge_from(&overlay_style.run);
             merge_pptx_bullet_definition(&mut target.bullet, &overlay_style.bullet);
         }
     }

--- a/crates/office2pdf/src/parser/pptx_text.rs
+++ b/crates/office2pdf/src/parser/pptx_text.rs
@@ -2,6 +2,7 @@ use super::*;
 
 /// Overwrite each `Option` field in `target` with `source` when the source is `Some`.
 /// Fields that require `.clone()` must be listed after a `;` separator.
+/// Kept only for PPTX-specific types that don't live in the IR layer.
 macro_rules! merge_option_fields {
     ($target:expr, $source:expr, $($copy_field:ident),* $(; $($clone_field:ident),*)?) => {
         $(
@@ -15,24 +16,6 @@ macro_rules! merge_option_fields {
             }
         )*)?
     };
-}
-
-pub(super) fn merge_paragraph_style(target: &mut ParagraphStyle, source: &ParagraphStyle) {
-    merge_option_fields!(
-        target, source,
-        alignment, indent_left, indent_right, indent_first_line,
-        line_spacing, space_before, space_after, heading_level, direction;
-        tab_stops
-    );
-}
-
-pub(super) fn merge_text_style(target: &mut TextStyle, source: &TextStyle) {
-    merge_option_fields!(
-        target, source,
-        font_size, bold, italic, underline, strikethrough,
-        color, highlight, vertical_align, all_caps, small_caps, letter_spacing;
-        font_family
-    );
 }
 
 pub(super) fn merge_pptx_bullet_definition(


### PR DESCRIPTION
## Summary

- Add `TextStyle::merge_from()` and `ParagraphStyle::merge_from()` methods to `ir/style.rs`, providing a single canonical implementation for field-by-field `Option` merging
- Replace two divergent merge implementations (DOCX standalone function in `docx_styles.rs` and PPTX macro-based functions in `pptx_text.rs`) with calls to the unified methods
- DOCX `merge_text_style()` wrapper is preserved in `docx_styles.rs` because it has extra heading-level default logic (font size + bold fallbacks), but now delegates the core field merge to `TextStyle::merge_from`
- PPTX callers in `pptx.rs` call the new methods directly; the old standalone `merge_text_style()` and `merge_paragraph_style()` are removed from `pptx_text.rs`
- The `merge_option_fields!` macro is retained only for `PptxBulletDefinition`, a PPTX-specific type that does not live in the IR layer

## Test plan

- [x] New unit tests for `TextStyle::merge_from`: all-None source preserves target, all-Some source overwrites target, partial overlap, merge into default target
- [x] New unit tests for `ParagraphStyle::merge_from`: all-None source preserves target, all-Some source overwrites target, partial overlap
- [x] All 141 existing tests pass (including DOCX heading style tests and PPTX paragraph/text merge tests)
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)