### PR TITLE
refactor: rename TablePage to SheetPage and Page::Table to Page::Sheet

### DIFF
--- a/crates/office2pdf/src/ir/document.rs
+++ b/crates/office2pdf/src/ir/document.rs
@@ -27,8 +27,8 @@ pub enum Page {
     Flow(FlowPage),
     /// PPTX: fixed coordinate pages.
     Fixed(FixedPage),
-    /// XLSX: table-based pages.
-    Table(TablePage),
+    /// XLSX: spreadsheet sheet pages.
+    Sheet(SheetPage),
 }
 
 /// Page dimensions.
@@ -129,9 +129,9 @@ pub enum FixedElementKind {
     Chart(super::elements::Chart),
 }
 
-/// A table-based page (XLSX sheets).
+/// A spreadsheet sheet page (XLSX sheets).
 #[derive(Debug, Clone)]
-pub struct TablePage {
+pub struct SheetPage {
     pub name: String,
     pub size: PageSize,
     pub margins: Margins,

--- a/crates/office2pdf/src/parser/xlsx.rs
+++ b/crates/office2pdf/src/parser/xlsx.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 use crate::config::ConvertOptions;
 use crate::error::{ConvertError, ConvertWarning};
 use crate::ir::{
-    Document, Margins, Metadata, Page, PageSize, StyleSheet, Table, TablePage, TableRow,
+    Document, Margins, Metadata, Page, PageSize, SheetPage, StyleSheet, Table, TableRow,
 };
 use crate::parser::Parser;
 
@@ -29,7 +29,7 @@ pub struct XlsxParser;
 impl XlsxParser {
     /// Parse XLSX in streaming mode, returning one `Document` per chunk of rows.
     ///
-    /// Each chunk contains a single `TablePage` with at most `chunk_size` rows.
+    /// Each chunk contains a single `SheetPage` with at most `chunk_size` rows.
     /// This allows the caller to compile each chunk independently, bounding peak
     /// memory during Typst compilation.
     pub fn parse_streaming(
@@ -90,7 +90,7 @@ impl XlsxParser {
 
                 let doc = Document {
                     metadata: metadata.clone(),
-                    pages: vec![Page::Table(TablePage {
+                    pages: vec![Page::Sheet(SheetPage {
                         name: sheet_name.clone(),
                         size: PageSize::default(),
                         margins: Margins::default(),
@@ -182,7 +182,7 @@ impl Parser for XlsxParser {
 
             if row_breaks.is_empty() {
                 // No page breaks — single page
-                pages.push(Page::Table(TablePage {
+                pages.push(Page::Sheet(SheetPage {
                     name: sheet_name,
                     size: PageSize::default(),
                     margins: Margins::default(),
@@ -223,7 +223,7 @@ impl Parser for XlsxParser {
                 // For page-break segments, attach all charts to the first segment
                 let mut first_segment = true;
                 for segment in segments {
-                    pages.push(Page::Table(TablePage {
+                    pages.push(Page::Sheet(SheetPage {
                         name: sheet_name.clone(),
                         size: PageSize::default(),
                         margins: Margins::default(),

--- a/crates/office2pdf/src/parser/xlsx_cell_format_tests.rs
+++ b/crates/office2pdf/src/parser/xlsx_cell_format_tests.rs
@@ -26,7 +26,7 @@ fn test_merge_colspan_basic() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(
         tp.table.rows[0].cells.len(),
         1,
@@ -43,7 +43,7 @@ fn test_merge_rowspan_basic() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.rows[0].cells.len(), 1);
     assert_eq!(tp.table.rows[0].cells[0].row_span, 2);
     assert_eq!(tp.table.rows[0].cells[0].col_span, 1);
@@ -61,7 +61,7 @@ fn test_merge_colspan_and_rowspan() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.rows[0].cells.len(), 2);
     assert_eq!(tp.table.rows[0].cells[0].col_span, 2);
     assert_eq!(tp.table.rows[0].cells[0].row_span, 2);
@@ -81,7 +81,7 @@ fn test_merge_content_in_top_left_only() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.rows[0].cells.len(), 1);
     assert_eq!(cell_text(&tp.table.rows[0].cells[0]), "TopLeft");
 }
@@ -96,7 +96,7 @@ fn test_merge_multiple_ranges() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.rows[0].cells.len(), 1);
     assert_eq!(tp.table.rows[0].cells[0].col_span, 2);
     assert_eq!(cell_text(&tp.table.rows[0].cells[0]), "Wide");
@@ -114,7 +114,7 @@ fn test_merge_no_merges_unchanged() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.rows[0].cells.len(), 2);
     for cell in &tp.table.rows[0].cells {
         assert_eq!(cell.col_span, 1);
@@ -128,7 +128,7 @@ fn test_merge_wide_colspan() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.rows[0].cells.len(), 1);
     assert_eq!(tp.table.rows[0].cells[0].col_span, 4);
     assert_eq!(cell_text(&tp.table.rows[0].cells[0]), "Title");
@@ -159,7 +159,7 @@ fn test_cell_bold_text() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let style = first_run_style(&tp.table.rows[0].cells[0]);
     assert_eq!(style.bold, Some(true));
 }
@@ -174,7 +174,7 @@ fn test_cell_italic_text() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let style = first_run_style(&tp.table.rows[0].cells[0]);
     assert_eq!(style.italic, Some(true));
 }
@@ -192,7 +192,7 @@ fn test_cell_font_color() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let style = first_run_style(&tp.table.rows[0].cells[0]);
     assert_eq!(style.color, Some(Color::new(255, 0, 0)));
 }
@@ -209,7 +209,7 @@ fn test_cell_font_name_and_size() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let style = first_run_style(&tp.table.rows[0].cells[0]);
     assert_eq!(style.font_family.as_deref(), Some("Arial"));
     assert_eq!(style.font_size, Some(14.0));
@@ -225,7 +225,7 @@ fn test_cell_background_fill() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let cell = &tp.table.rows[0].cells[0];
     assert_eq!(cell.background, Some(Color::new(255, 255, 0)));
 }
@@ -251,7 +251,7 @@ fn test_cell_borders() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let cell = &tp.table.rows[0].cells[0];
     let border = cell.border.as_ref().expect("Expected border");
     let bottom = border.bottom.as_ref().expect("Expected bottom border");
@@ -291,7 +291,7 @@ fn test_cell_border_styles() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let cell = &tp.table.rows[0].cells[0];
     let border = cell.border.as_ref().expect("Expected border");
 
@@ -334,7 +334,7 @@ fn test_cell_border_medium_dashed() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let cell = &tp.table.rows[0].cells[0];
     let border = cell.border.as_ref().expect("Expected border");
     let top = border.top.as_ref().expect("Expected top border");
@@ -351,7 +351,7 @@ fn test_row_height() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let row = &tp.table.rows[0];
     assert_eq!(row.height, Some(30.0));
 }
@@ -362,7 +362,7 @@ fn test_cell_no_formatting_defaults() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let cell = &tp.table.rows[0].cells[0];
     let style = first_run_style(cell);
     assert!(style.bold.is_none() || style.bold == Some(false));
@@ -385,7 +385,7 @@ fn test_number_format_currency() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let text = cell_text(&tp.table.rows[0].cells[0]);
     assert!(
         text.contains('$') && text.contains("1,234.56"),
@@ -405,7 +405,7 @@ fn test_number_format_percentage() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let text = cell_text(&tp.table.rows[0].cells[0]);
     assert!(
         text.contains('%'),
@@ -425,7 +425,7 @@ fn test_number_format_percentage_with_decimals() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let text = cell_text(&tp.table.rows[0].cells[0]);
     assert!(
         text.contains('%') && text.contains("50.00"),
@@ -445,7 +445,7 @@ fn test_number_format_date() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let text = cell_text(&tp.table.rows[0].cells[0]);
     assert!(
         text.contains('-') && !text.contains("45306"),
@@ -465,7 +465,7 @@ fn test_number_format_thousands_separator() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let text = cell_text(&tp.table.rows[0].cells[0]);
     assert_eq!(text, "1,234,567", "Expected thousands separator formatting");
 }
@@ -479,7 +479,7 @@ fn test_number_format_general_unchanged() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(cell_text(&tp.table.rows[0].cells[0]), "42");
     assert_eq!(cell_text(&tp.table.rows[0].cells[1]), "3.14");
 }
@@ -496,7 +496,7 @@ fn test_number_format_builtin_id() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let text = cell_text(&tp.table.rows[0].cells[0]);
     assert!(
         text.contains("1,234") && text.contains("50"),
@@ -516,7 +516,7 @@ fn test_number_format_custom_format_string() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let text = cell_text(&tp.table.rows[0].cells[0]);
     assert_eq!(text, "3.142", "Expected 3 decimal places formatting");
 }
@@ -542,7 +542,7 @@ fn test_cell_combined_formatting() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let cell = &tp.table.rows[0].cells[0];
     let style = first_run_style(cell);
     assert_eq!(style.bold, Some(true));

--- a/crates/office2pdf/src/parser/xlsx_chart_tests.rs
+++ b/crates/office2pdf/src/parser/xlsx_chart_tests.rs
@@ -74,9 +74,9 @@ fn test_xlsx_with_chart_embeds_in_table_page() {
         1,
         "Expected 1 page (chart embedded in table)"
     );
-    assert!(matches!(&doc.pages[0], Page::Table(_)));
+    assert!(matches!(&doc.pages[0], Page::Sheet(_)));
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert!(!tp.charts.is_empty(), "Expected charts in table page");
 
     let chart = &tp.charts[0].1;
@@ -93,7 +93,7 @@ fn test_xlsx_without_chart_no_extra_pages() {
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
     assert_eq!(doc.pages.len(), 1);
-    assert!(matches!(&doc.pages[0], Page::Table(_)));
+    assert!(matches!(&doc.pages[0], Page::Sheet(_)));
 }
 
 #[test]
@@ -127,7 +127,7 @@ fn test_xlsx_chart_data_is_correct() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert!(!tp.charts.is_empty(), "Expected a chart in the table page");
     let chart = &tp.charts[0].1;
     assert_eq!(chart.chart_type, ChartType::Pie);
@@ -273,7 +273,7 @@ fn test_xlsx_chart_anchored_at_row_5() {
         "Chart with anchor should be embedded in table page, not separate"
     );
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.charts.len(), 1, "Expected 1 anchored chart");
     assert_eq!(tp.charts[0].0, 5, "Chart should be anchored at row 5");
     assert_eq!(tp.charts[0].1.chart_type, ChartType::Bar);
@@ -286,7 +286,7 @@ fn test_xlsx_chart_without_anchor_falls_back_to_end() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert!(
         !tp.charts.is_empty(),
         "Unanchored chart should still be embedded in table page"

--- a/crates/office2pdf/src/parser/xlsx_condfmt_tests.rs
+++ b/crates/office2pdf/src/parser/xlsx_condfmt_tests.rs
@@ -40,7 +40,7 @@ fn test_cond_fmt_greater_than_background() {
 
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
 
     assert!(
         tp.table.rows[0].cells[0].background.is_none(),
@@ -84,7 +84,7 @@ fn test_cond_fmt_less_than_font_color() {
 
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
 
     let style_a1 = first_run_style(&tp.table.rows[0].cells[0]);
     assert_eq!(
@@ -123,7 +123,7 @@ fn test_cond_fmt_equal_bold() {
 
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
 
     let style_a1 = first_run_style(&tp.table.rows[0].cells[0]);
     assert_eq!(style_a1.bold, Some(true), "A1 (100) should be bold");
@@ -163,7 +163,7 @@ fn test_cond_fmt_between() {
 
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
 
     assert!(tp.table.rows[0].cells[0].background.is_none());
     assert_eq!(
@@ -221,7 +221,7 @@ fn test_cond_fmt_color_scale_two_color() {
 
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
 
     let bg_a1 = tp.table.rows[0].cells[0]
         .background
@@ -254,7 +254,7 @@ fn test_cond_fmt_no_rules_unchanged() {
     let data = build_xlsx_bytes("Sheet1", &[("A1", "42")]);
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
 
     assert!(tp.table.rows[0].cells[0].background.is_none());
 }
@@ -286,7 +286,7 @@ fn test_cond_fmt_non_numeric_cell_skipped() {
 
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
 
     assert!(tp.table.rows[0].cells[0].background.is_none());
     assert_eq!(
@@ -328,7 +328,7 @@ fn test_cond_fmt_data_bar() {
 
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
 
     let db1 = tp.table.rows[0].cells[0]
         .data_bar
@@ -399,7 +399,7 @@ fn test_cond_fmt_icon_set() {
 
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
 
     let icon1 = tp.table.rows[0].cells[0]
         .icon_text

--- a/crates/office2pdf/src/parser/xlsx_page_feature_tests.rs
+++ b/crates/office2pdf/src/parser/xlsx_page_feature_tests.rs
@@ -17,7 +17,7 @@ fn test_sheet_filter_single_sheet() {
     let (doc, _warnings) = parser.parse(&data, &opts).unwrap();
 
     assert_eq!(doc.pages.len(), 1, "Should only include 1 sheet");
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.name, "Expenses");
     assert_eq!(cell_text(&tp.table.rows[0].cells[0]), "Cost");
 }
@@ -37,8 +37,8 @@ fn test_sheet_filter_multiple_sheets() {
     let (doc, _warnings) = parser.parse(&data, &opts).unwrap();
 
     assert_eq!(doc.pages.len(), 2, "Should include 2 sheets");
-    let tp0 = get_table_page(&doc, 0);
-    let tp1 = get_table_page(&doc, 1);
+    let tp0 = get_sheet_page(&doc, 0);
+    let tp1 = get_sheet_page(&doc, 1);
     assert_eq!(tp0.name, "Sales");
     assert_eq!(tp1.name, "Summary");
 }
@@ -135,7 +135,7 @@ fn test_print_area_limits_output() {
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
     assert_eq!(doc.pages.len(), 1);
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.rows.len(), 2, "Should have 2 rows from print area");
     assert_eq!(
         tp.table.rows[0].cells.len(),
@@ -158,7 +158,7 @@ fn test_print_area_without_dollar_signs() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.rows.len(), 2);
     assert_eq!(tp.table.rows[0].cells.len(), 1, "Only column A");
     assert_eq!(cell_text(&tp.table.rows[0].cells[0]), "X");
@@ -171,7 +171,7 @@ fn test_no_print_area_includes_all() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.rows.len(), 3);
     assert_eq!(tp.table.rows[0].cells.len(), 3);
 }
@@ -192,8 +192,8 @@ fn test_row_page_breaks_split_into_pages() {
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
     assert_eq!(doc.pages.len(), 2, "Break should split into 2 pages");
-    let tp0 = get_table_page(&doc, 0);
-    let tp1 = get_table_page(&doc, 1);
+    let tp0 = get_sheet_page(&doc, 0);
+    let tp1 = get_sheet_page(&doc, 1);
 
     assert_eq!(tp0.table.rows.len(), 2, "First page: rows 1-2");
     assert_eq!(cell_text(&tp0.table.rows[0].cells[0]), "R1");
@@ -222,9 +222,9 @@ fn test_multiple_row_page_breaks() {
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
     assert_eq!(doc.pages.len(), 3, "Two breaks should produce 3 pages");
-    let tp0 = get_table_page(&doc, 0);
-    let tp1 = get_table_page(&doc, 1);
-    let tp2 = get_table_page(&doc, 2);
+    let tp0 = get_sheet_page(&doc, 0);
+    let tp1 = get_sheet_page(&doc, 1);
+    let tp2 = get_sheet_page(&doc, 2);
 
     assert_eq!(tp0.table.rows.len(), 2);
     assert_eq!(tp1.table.rows.len(), 2);
@@ -242,7 +242,7 @@ fn test_no_page_breaks_single_page() {
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
     assert_eq!(doc.pages.len(), 1);
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.rows.len(), 3);
 }
 
@@ -256,8 +256,8 @@ fn test_page_break_column_widths_preserved() {
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
     assert_eq!(doc.pages.len(), 2);
-    let tp0 = get_table_page(&doc, 0);
-    let tp1 = get_table_page(&doc, 1);
+    let tp0 = get_sheet_page(&doc, 0);
+    let tp1 = get_sheet_page(&doc, 1);
     assert_eq!(tp0.table.column_widths.len(), 2);
     assert_eq!(tp1.table.column_widths.len(), 2);
     assert_eq!(tp0.table.column_widths, tp1.table.column_widths);
@@ -383,7 +383,7 @@ fn test_xlsx_sheet_with_custom_header() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let header = tp.header.as_ref().expect("Expected header");
     assert_eq!(header.paragraphs.len(), 1);
     assert_eq!(
@@ -402,7 +402,7 @@ fn test_xlsx_sheet_with_page_number_footer() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let footer = tp.footer.as_ref().expect("Expected footer");
     assert_eq!(footer.paragraphs.len(), 1);
     let elems = &footer.paragraphs[0].elements;

--- a/crates/office2pdf/src/parser/xlsx_streaming_tests.rs
+++ b/crates/office2pdf/src/parser/xlsx_streaming_tests.rs
@@ -30,16 +30,16 @@ fn test_parse_streaming_creates_chunks() {
         "5 rows with chunk_size=2 should yield 3 chunks"
     );
 
-    let tp0 = get_table_page(&chunks[0], 0);
+    let tp0 = get_sheet_page(&chunks[0], 0);
     assert_eq!(tp0.table.rows.len(), 2);
     assert_eq!(cell_text(&tp0.table.rows[0].cells[0]), "R1C1");
     assert_eq!(cell_text(&tp0.table.rows[1].cells[0]), "R2C1");
 
-    let tp1 = get_table_page(&chunks[1], 0);
+    let tp1 = get_sheet_page(&chunks[1], 0);
     assert_eq!(tp1.table.rows.len(), 2);
     assert_eq!(cell_text(&tp1.table.rows[0].cells[0]), "R3C1");
 
-    let tp2 = get_table_page(&chunks[2], 0);
+    let tp2 = get_sheet_page(&chunks[2], 0);
     assert_eq!(tp2.table.rows.len(), 1);
     assert_eq!(cell_text(&tp2.table.rows[0].cells[0]), "R5C1");
 }
@@ -57,7 +57,7 @@ fn test_parse_streaming_single_chunk_for_small_sheet() {
         1,
         "3 rows with chunk_size=10 should yield 1 chunk"
     );
-    let tp = get_table_page(&chunks[0], 0);
+    let tp = get_sheet_page(&chunks[0], 0);
     assert_eq!(tp.table.rows.len(), 3);
 }
 
@@ -69,8 +69,8 @@ fn test_parse_streaming_preserves_column_widths() {
         .parse_streaming(&data, &ConvertOptions::default(), 2)
         .unwrap();
 
-    let tp0 = get_table_page(&chunks[0], 0);
-    let tp1 = get_table_page(&chunks[1], 0);
+    let tp0 = get_sheet_page(&chunks[0], 0);
+    let tp1 = get_sheet_page(&chunks[1], 0);
     assert_eq!(tp0.table.column_widths.len(), tp1.table.column_widths.len());
     assert_eq!(tp0.table.column_widths, tp1.table.column_widths);
 }
@@ -89,7 +89,7 @@ fn test_parse_streaming_respects_sheet_filter() {
     let (chunks, _warnings) = parser.parse_streaming(&data, &opts, 10).unwrap();
 
     assert_eq!(chunks.len(), 1, "Only Sheet2 should be included");
-    let tp = get_table_page(&chunks[0], 0);
+    let tp = get_sheet_page(&chunks[0], 0);
     assert_eq!(tp.name, "Sheet2");
 }
 

--- a/crates/office2pdf/src/parser/xlsx_tests.rs
+++ b/crates/office2pdf/src/parser/xlsx_tests.rs
@@ -41,11 +41,11 @@ fn build_xlsx_multi_sheet(sheets: &[(&str, &[(&str, &str)])]) -> Vec<u8> {
     cursor.into_inner()
 }
 
-/// Helper: extract TablePage from Document by index.
-fn get_table_page(doc: &Document, idx: usize) -> &TablePage {
+/// Helper: extract SheetPage from Document by index.
+fn get_sheet_page(doc: &Document, idx: usize) -> &SheetPage {
     match &doc.pages[idx] {
-        Page::Table(tp) => tp,
-        _ => panic!("Expected TablePage at index {idx}"),
+        Page::Sheet(sp) => sp,
+        _ => panic!("Expected SheetPage at index {idx}"),
     }
 }
 
@@ -78,7 +78,7 @@ fn test_parse_single_cell() {
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
     assert_eq!(doc.pages.len(), 1);
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.name, "Sheet1");
     assert_eq!(tp.table.rows.len(), 1);
     assert_eq!(tp.table.rows[0].cells.len(), 1);
@@ -94,7 +94,7 @@ fn test_parse_multiple_cells() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.rows.len(), 2);
     assert_eq!(tp.table.rows[0].cells.len(), 2);
     assert_eq!(cell_text(&tp.table.rows[0].cells[0]), "Name");
@@ -110,7 +110,7 @@ fn test_parse_empty_cells_in_grid() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.rows.len(), 2);
     assert_eq!(tp.table.rows[0].cells.len(), 2);
     // A1 has content
@@ -129,7 +129,7 @@ fn test_parse_numbers() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(cell_text(&tp.table.rows[0].cells[0]), "42");
     assert_eq!(cell_text(&tp.table.rows[0].cells[1]), "3.14");
 }
@@ -140,7 +140,7 @@ fn test_parse_dates_as_text() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(cell_text(&tp.table.rows[0].cells[0]), "2024-01-15");
     assert_eq!(cell_text(&tp.table.rows[1].cells[0]), "December 25");
 }
@@ -153,7 +153,7 @@ fn test_sheet_name_preserved() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.name, "Financial Report");
 }
 
@@ -169,8 +169,8 @@ fn test_parse_multiple_sheets() {
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
     assert_eq!(doc.pages.len(), 2);
-    let tp1 = get_table_page(&doc, 0);
-    let tp2 = get_table_page(&doc, 1);
+    let tp1 = get_sheet_page(&doc, 0);
+    let tp2 = get_sheet_page(&doc, 1);
     assert_eq!(tp1.name, "Sheet1");
     assert_eq!(tp2.name, "Sheet2");
     assert_eq!(cell_text(&tp1.table.rows[0].cells[0]), "Data1");
@@ -185,7 +185,7 @@ fn test_column_widths_default() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.column_widths.len(), 2);
     // Default column width is ~8.43 chars * 7.0 ≈ 59 pt
     // umya-spreadsheet may use a slightly different default; allow 1pt tolerance
@@ -205,7 +205,7 @@ fn test_page_size_defaults() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let default_size = PageSize::default();
     assert!((tp.size.width - default_size.width).abs() < 0.01);
     assert!((tp.size.height - default_size.height).abs() < 0.01);
@@ -223,7 +223,7 @@ fn test_table_row_column_consistency() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     assert_eq!(tp.table.rows.len(), 3, "Expected 3 rows");
     // All rows should have same number of columns
     for row in &tp.table.rows {
@@ -265,7 +265,7 @@ fn test_empty_cells_have_no_content() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     // B1 should be empty (no paragraphs)
     assert!(
         tp.table.rows[0].cells[1].content.is_empty(),
@@ -279,7 +279,7 @@ fn test_cell_default_span_values() {
     let parser = XlsxParser;
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
 
-    let tp = get_table_page(&doc, 0);
+    let tp = get_sheet_page(&doc, 0);
     let cell = &tp.table.rows[0].cells[0];
     assert_eq!(cell.col_span, 1);
     assert_eq!(cell.row_span, 1);

--- a/crates/office2pdf/src/render/font_subst.rs
+++ b/crates/office2pdf/src/render/font_subst.rs
@@ -307,7 +307,7 @@ fn collect_document_font_families(doc: &Document) -> BTreeSet<String> {
                     }
                 }
             }
-            Page::Table(page) => {
+            Page::Sheet(page) => {
                 if let Some(header) = &page.header {
                     collect_header_footer_fonts(header, &mut fonts);
                 }
@@ -344,7 +344,7 @@ pub(crate) fn document_requests_font_families(doc: &Document) -> bool {
             | FixedElementKind::SmartArt(_)
             | FixedElementKind::Chart(_) => false,
         }),
-        Page::Table(page) => {
+        Page::Sheet(page) => {
             page.header
                 .as_ref()
                 .is_some_and(header_footer_requests_font_family)

--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -10,9 +10,9 @@ use crate::ir::{
     Color, ColumnLayout, Document, FixedElement, FixedElementKind, FixedPage, FloatingImage,
     FloatingTextBox, FlowPage, GradientFill, HFInline, HeaderFooter, ImageCrop, ImageData,
     ImageFormat, Insets, LineSpacing, List, ListKind, Margins, MathEquation, Metadata, Page,
-    PageSize, Paragraph, ParagraphStyle, Run, Shadow, Shape, ShapeKind, SmartArt, TabAlignment,
-    TabLeader, TabStop, Table, TableCell, TablePage, TableRow, TextBoxData, TextBoxVerticalAlign,
-    TextDirection, TextStyle, VerticalTextAlign, WrapMode,
+    PageSize, Paragraph, ParagraphStyle, Run, Shadow, Shape, ShapeKind, SheetPage, SmartArt,
+    TabAlignment, TabLeader, TabStop, Table, TableCell, TableRow, TextBoxData,
+    TextBoxVerticalAlign, TextDirection, TextStyle, VerticalTextAlign, WrapMode,
 };
 
 use self::diagrams::{generate_chart, generate_smartart};
@@ -272,8 +272,8 @@ pub(crate) fn generate_typst_with_options_and_font_context(
             match page {
                 Page::Flow(flow) => generate_flow_page(&mut out, flow, &mut ctx, options)?,
                 Page::Fixed(fixed) => generate_fixed_page(&mut out, fixed, &mut ctx, options)?,
-                Page::Table(table_page) => {
-                    generate_table_page(&mut out, table_page, &mut ctx, options)?;
+                Page::Sheet(sheet_page) => {
+                    generate_table_page(&mut out, sheet_page, &mut ctx, options)?;
                 }
             }
         }
@@ -411,7 +411,7 @@ fn generate_fixed_page(
 
 fn generate_table_page(
     out: &mut String,
-    page: &TablePage,
+    page: &SheetPage,
     ctx: &mut GenCtx,
     options: &ConvertOptions,
 ) -> Result<(), ConvertError> {
@@ -924,8 +924,8 @@ fn write_flow_page_setup(out: &mut String, page: &FlowPage, size: &PageSize) {
     out.push_str(")\n");
 }
 
-/// Write the full page setup for a TablePage, including optional header/footer.
-fn write_table_page_setup(out: &mut String, page: &TablePage, size: &PageSize) {
+/// Write the full page setup for a SheetPage, including optional header/footer.
+fn write_table_page_setup(out: &mut String, page: &SheetPage, size: &PageSize) {
     if page.header.is_none() && page.footer.is_none() {
         write_page_setup(out, size, &page.margins);
         return;

--- a/crates/office2pdf/src/render/typst_gen_advanced_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_advanced_tests.rs
@@ -30,7 +30,7 @@ fn test_data_bar_codegen() {
         column_widths: vec![100.0],
         ..Table::default()
     };
-    let page = Page::Table(TablePage {
+    let page = Page::Sheet(SheetPage {
         name: "Sheet1".to_string(),
         size: PageSize::default(),
         margins: Margins::default(),
@@ -76,7 +76,7 @@ fn test_icon_text_codegen() {
         column_widths: vec![100.0],
         ..Table::default()
     };
-    let page = Page::Table(TablePage {
+    let page = Page::Sheet(SheetPage {
         name: "Sheet1".to_string(),
         size: PageSize::default(),
         margins: Margins::default(),

--- a/crates/office2pdf/src/render/typst_gen_page_misc_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_page_misc_tests.rs
@@ -362,7 +362,7 @@ fn test_footnote_with_special_chars() {
 
 #[test]
 fn test_table_page_with_header() {
-    let page = Page::Table(TablePage {
+    let page = Page::Sheet(SheetPage {
         name: "Sheet1".to_string(),
         size: PageSize::default(),
         margins: Margins::default(),
@@ -392,7 +392,7 @@ fn test_table_page_with_header() {
 
 #[test]
 fn test_table_page_with_page_number_footer() {
-    let page = Page::Table(TablePage {
+    let page = Page::Sheet(SheetPage {
         name: "Sheet1".to_string(),
         size: PageSize::default(),
         margins: Margins::default(),
@@ -433,7 +433,7 @@ fn test_table_page_with_page_number_footer() {
 
 #[test]
 fn test_table_page_no_header_footer() {
-    let page = Page::Table(TablePage {
+    let page = Page::Sheet(SheetPage {
         name: "Sheet1".to_string(),
         size: PageSize::default(),
         margins: Margins::default(),
@@ -462,7 +462,7 @@ fn test_table_page_with_chart_at_row() {
         }],
     };
 
-    let page = Page::Table(TablePage {
+    let page = Page::Sheet(SheetPage {
         name: "Sheet1".to_string(),
         size: PageSize::default(),
         margins: Margins::default(),
@@ -500,7 +500,7 @@ fn test_table_page_with_chart_at_end() {
         }],
     };
 
-    let page = Page::Table(TablePage {
+    let page = Page::Sheet(SheetPage {
         name: "Sheet1".to_string(),
         size: PageSize::default(),
         margins: Margins::default(),

--- a/crates/office2pdf/src/render/typst_gen_table_page_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_table_page_tests.rs
@@ -3,7 +3,7 @@ use super::*;
 #[test]
 fn test_table_page_basic() {
     let table = make_simple_table(vec![vec!["A1", "B1"], vec!["A2", "B2"]]);
-    let doc = make_doc(vec![make_table_page(
+    let doc = make_doc(vec![make_sheet_page(
         "Sheet1",
         595.28,
         841.89,
@@ -22,7 +22,7 @@ fn test_table_page_basic() {
 #[test]
 fn test_table_page_custom_page_size_and_margins() {
     let table = make_simple_table(vec![vec!["Data"]]);
-    let doc = make_doc(vec![make_table_page(
+    let doc = make_doc(vec![make_sheet_page(
         "Custom",
         800.0,
         600.0,
@@ -47,7 +47,7 @@ fn test_table_page_cell_data_types() {
         vec!["Name", "Age", "Date"],
         vec!["Alice", "30", "2024-01-15"],
     ]);
-    let doc = make_doc(vec![make_table_page(
+    let doc = make_doc(vec![make_sheet_page(
         "Data",
         595.28,
         841.89,
@@ -116,7 +116,7 @@ fn test_table_page_merged_cells() {
         column_widths: vec![],
         ..Table::default()
     };
-    let doc = make_doc(vec![make_table_page(
+    let doc = make_doc(vec![make_sheet_page(
         "MergeSheet",
         595.28,
         841.89,
@@ -165,7 +165,7 @@ fn test_table_page_with_column_widths() {
         column_widths: vec![100.0, 200.0],
         ..Table::default()
     };
-    let doc = make_doc(vec![make_table_page(
+    let doc = make_doc(vec![make_sheet_page(
         "Widths",
         595.28,
         841.89,
@@ -183,7 +183,7 @@ fn test_table_page_empty_table() {
         column_widths: vec![],
         ..Table::default()
     };
-    let doc = make_doc(vec![make_table_page(
+    let doc = make_doc(vec![make_sheet_page(
         "Empty",
         595.28,
         841.89,
@@ -199,8 +199,8 @@ fn test_table_page_multiple_sheets() {
     let table1 = make_simple_table(vec![vec!["Sheet1Data"]]);
     let table2 = make_simple_table(vec![vec!["Sheet2Data"]]);
     let doc = make_doc(vec![
-        make_table_page("Sheet1", 595.28, 841.89, Margins::default(), table1),
-        make_table_page("Sheet2", 595.28, 841.89, Margins::default(), table2),
+        make_sheet_page("Sheet1", 595.28, 841.89, Margins::default(), table1),
+        make_sheet_page("Sheet2", 595.28, 841.89, Margins::default(), table2),
     ]);
     let output = generate_typst(&doc).unwrap();
     assert!(output.source.contains("Sheet1Data"));
@@ -260,7 +260,7 @@ fn test_table_page_rowspan_merge() {
         column_widths: vec![],
         ..Table::default()
     };
-    let doc = make_doc(vec![make_table_page(
+    let doc = make_doc(vec![make_sheet_page(
         "RowMerge",
         595.28,
         841.89,

--- a/crates/office2pdf/src/render/typst_gen_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_tests.rs
@@ -156,11 +156,11 @@ mod fixed_page_tests;
 #[path = "typst_gen_fixed_page_textbox_tests.rs"]
 mod fixed_page_textbox_tests;
 
-// ── TablePage codegen tests ──────────────────────────────────────────
+// ── SheetPage codegen tests ──────────────────────────────────────────
 
-/// Helper to create a TablePage.
-fn make_table_page(name: &str, width: f64, height: f64, margins: Margins, table: Table) -> Page {
-    Page::Table(crate::ir::TablePage {
+/// Helper to create a SheetPage.
+fn make_sheet_page(name: &str, width: f64, height: f64, margins: Margins, table: Table) -> Page {
+    Page::Sheet(crate::ir::SheetPage {
         name: name.to_string(),
         size: PageSize { width, height },
         margins,

--- a/crates/office2pdf/src/render/typst_gen_text_pipeline_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_text_pipeline_tests.rs
@@ -271,7 +271,7 @@ fn test_generate_fixed_page_empty_elements() {
 
 #[test]
 fn test_generate_table_page_empty_rows() {
-    let doc = make_doc(vec![Page::Table(TablePage {
+    let doc = make_doc(vec![Page::Sheet(SheetPage {
         name: String::new(),
         size: PageSize::default(),
         margins: Margins::default(),

--- a/crates/office2pdf/tests/xlsx_fixtures.rs
+++ b/crates/office2pdf/tests/xlsx_fixtures.rs
@@ -9,7 +9,7 @@ mod common;
 use std::path::PathBuf;
 
 use office2pdf::config::ConvertOptions;
-use office2pdf::ir::{Block, Page, TablePage};
+use office2pdf::ir::{Block, Page, SheetPage};
 use office2pdf::parser::Parser;
 use office2pdf::parser::xlsx::XlsxParser;
 
@@ -45,28 +45,28 @@ fn assert_produces_valid_pdf(name: &str) {
     }
 }
 
-/// Parse an XLSX fixture and return the table pages (sheets).
-fn table_pages(name: &str) -> Vec<TablePage> {
+/// Parse an XLSX fixture and return the sheet pages.
+fn sheet_pages(name: &str) -> Vec<SheetPage> {
     let data = load_fixture(name);
     let (doc, _warnings) = XlsxParser.parse(&data, &ConvertOptions::default()).unwrap();
     doc.pages
         .into_iter()
         .filter_map(|p| match p {
-            Page::Table(tp) => Some(tp),
+            Page::Sheet(sp) => Some(sp),
             _ => None,
         })
         .collect()
 }
 
-fn sheet_names(pages: &[TablePage]) -> Vec<&str> {
+fn sheet_names(pages: &[SheetPage]) -> Vec<&str> {
     pages.iter().map(|p| p.name.as_str()).collect()
 }
 
-fn total_rows(pages: &[TablePage]) -> usize {
+fn total_rows(pages: &[SheetPage]) -> usize {
     pages.iter().map(|p| p.table.rows.len()).sum()
 }
 
-fn has_cell_border(pages: &[TablePage]) -> bool {
+fn has_cell_border(pages: &[SheetPage]) -> bool {
     pages.iter().any(|p| {
         p.table
             .rows
@@ -76,7 +76,7 @@ fn has_cell_border(pages: &[TablePage]) -> bool {
     })
 }
 
-fn has_merged_cells(pages: &[TablePage]) -> bool {
+fn has_merged_cells(pages: &[SheetPage]) -> bool {
     pages.iter().any(|p| {
         p.table
             .rows
@@ -86,7 +86,7 @@ fn has_merged_cells(pages: &[TablePage]) -> bool {
     })
 }
 
-fn has_formatted_text(pages: &[TablePage]) -> bool {
+fn has_formatted_text(pages: &[SheetPage]) -> bool {
     pages.iter().any(|p| {
         p.table.rows.iter().flat_map(|r| r.cells.iter()).any(|c| {
             c.content.iter().any(|b| match b {
@@ -114,7 +114,7 @@ fn smoke_any_sheets() {
 fn structure_any_sheets() {
     // any_sheets.xlsx has 4 sheets: Visible, Hidden, VeryHidden, Chart.
     // Parser only returns visible data worksheets (not hidden/chart sheets).
-    let pages = table_pages("any_sheets.xlsx");
+    let pages = sheet_pages("any_sheets.xlsx");
     assert!(!pages.is_empty(), "should have at least one visible sheet");
     let names = sheet_names(&pages);
     assert!(
@@ -134,7 +134,7 @@ fn smoke_date() {
 
 #[test]
 fn structure_date() {
-    let pages = table_pages("date.xlsx");
+    let pages = sheet_pages("date.xlsx");
     assert!(!pages.is_empty(), "should have at least one sheet");
     assert!(total_rows(&pages) > 0, "should have data rows");
 }
@@ -150,7 +150,7 @@ fn smoke_merge_cells() {
 
 #[test]
 fn structure_merge_cells() {
-    let pages = table_pages("merge_cells.xlsx");
+    let pages = sheet_pages("merge_cells.xlsx");
     assert!(
         has_merged_cells(&pages),
         "should have cells with col_span > 1 or row_span > 1"
@@ -168,7 +168,7 @@ fn smoke_sh001_table() {
 
 #[test]
 fn structure_sh001_table() {
-    let pages = table_pages("SH001-Table.xlsx");
+    let pages = sheet_pages("SH001-Table.xlsx");
     assert!(!pages.is_empty(), "should have at least one sheet");
     assert!(total_rows(&pages) > 0, "should have data rows");
 }
@@ -184,7 +184,7 @@ fn smoke_sh002_two_tables_two_sheets() {
 
 #[test]
 fn structure_sh002_two_tables_two_sheets() {
-    let pages = table_pages("SH002-TwoTablesTwoSheets.xlsx");
+    let pages = sheet_pages("SH002-TwoTablesTwoSheets.xlsx");
     assert!(pages.len() >= 2, "should have >= 2 sheets");
     let names = sheet_names(&pages);
     let unique: std::collections::HashSet<_> = names.iter().collect();
@@ -202,7 +202,7 @@ fn smoke_sh106_formatted() {
 
 #[test]
 fn structure_sh106_formatted() {
-    let pages = table_pages("SH106-Formatted.xlsx");
+    let pages = sheet_pages("SH106-Formatted.xlsx");
     assert!(
         has_formatted_text(&pages),
         "should have formatted text (bold/italic/color)"
@@ -220,7 +220,7 @@ fn smoke_sh109_cell_with_border() {
 
 #[test]
 fn structure_sh109_cell_with_border() {
-    let pages = table_pages("SH109-CellWithBorder.xlsx");
+    let pages = sheet_pages("SH109-CellWithBorder.xlsx");
     assert!(has_cell_border(&pages), "should have cells with borders");
 }
 
@@ -235,7 +235,7 @@ fn smoke_temperature() {
 
 #[test]
 fn structure_temperature() {
-    let pages = table_pages("temperature.xlsx");
+    let pages = sheet_pages("temperature.xlsx");
     assert!(!pages.is_empty(), "should have at least one sheet");
     assert!(total_rows(&pages) > 0, "should have data rows");
 }


### PR DESCRIPTION
## Summary

- Rename `Page::Table(TablePage)` variant to `Page::Sheet(SheetPage)` to better describe the layout model (a spreadsheet sheet) rather than implying a generic table or leaking the source format association.
- Pure rename across 16 files -- no logic changes.
- `Page::Flow(FlowPage)` and `Page::Fixed(FixedPage)` are kept as-is since they are already layout-oriented names.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -p office2pdf -- -D warnings` passes
- [x] `cargo test -p office2pdf` passes (947 unit tests + 141 integration tests + doc-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)