### PR TITLE
feat: add PPTX table style support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ No LibreOffice, no Chromium, no Docker — just a single binary powered by [Typs
 ## Features
 
 - **DOCX** — paragraphs, inline formatting (bold/italic/underline/color), tables, images, lists, headers/footers, page setup
-- **PPTX** — slides, text boxes, shapes, images, slide masters, speaker notes, gradient backgrounds, shadow/reflection effects
+- **PPTX** — slides, text boxes, shapes, tables (with theme-based table styles), images, slide masters, speaker notes, gradient backgrounds, shadow/reflection effects
 - **XLSX** — sheets, cell formatting, merged cells, column widths, row heights, conditional formatting (DataBar, IconSet)
 - **PDF/A-2b** — archival-compliant output via `--pdf-a`
 - **Embedded font extraction** — fonts embedded in PPTX/DOCX are automatically extracted, deobfuscated, and used during conversion
@@ -129,7 +129,7 @@ Available functions: `convertToPdf(data, format)`, `convertDocxToPdf(data)`, `co
 | Format | Status | Key Features |
 |--------|--------|-------------|
 | DOCX | Supported | Text, tables, images, lists, headers/footers, page setup |
-| PPTX | Supported | Slides, text boxes, shapes, images, masters, gradients, effects |
+| PPTX | Supported | Slides, text boxes, shapes, tables, images, masters, gradients, effects |
 | XLSX | Supported | Sheets, formatting, merged cells, column/row sizing, conditional formatting |
 
 ## License

--- a/crates/office2pdf/src/parser/pptx.rs
+++ b/crates/office2pdf/src/parser/pptx.rs
@@ -44,6 +44,8 @@ mod package;
 mod shapes;
 #[path = "pptx_slides.rs"]
 mod slides;
+#[path = "pptx_table_styles.rs"]
+mod table_styles;
 #[path = "pptx_tables.rs"]
 mod tables;
 #[path = "pptx_text.rs"]

--- a/crates/office2pdf/src/parser/pptx.rs
+++ b/crates/office2pdf/src/parser/pptx.rs
@@ -21,7 +21,9 @@ use crate::parser::Parser;
 use crate::parser::smartart;
 use crate::parser::units::emu_to_pt;
 
-use self::package::{load_theme, parse_presentation_xml, parse_rels_xml, read_zip_entry};
+use self::package::{
+    load_table_styles, load_theme, parse_presentation_xml, parse_rels_xml, read_zip_entry,
+};
 #[cfg(test)]
 use self::package::{resolve_relative_path, scan_chart_refs};
 use self::shapes::{
@@ -393,6 +395,11 @@ impl Parser for PptxParser {
         // Load theme data (if available)
         let theme = load_theme(&rel_map, &mut archive);
 
+        // Load table styles (uses theme colors for scheme color resolution)
+        let master_color_map: ColorMapData = default_color_map();
+        let table_styles: table_styles::TableStyleMap =
+            load_table_styles(&mut archive, &theme, &master_color_map);
+
         let mut warnings = Vec::new();
 
         // Parse each slide in order, skipping broken slides with warnings
@@ -419,6 +426,7 @@ impl Parser for PptxParser {
                     &slide_label,
                     slide_size,
                     &theme,
+                    &table_styles,
                     &mut archive,
                 ) {
                     Ok((page, slide_warnings)) => {

--- a/crates/office2pdf/src/parser/pptx_package.rs
+++ b/crates/office2pdf/src/parser/pptx_package.rs
@@ -380,6 +380,19 @@ pub(super) fn load_theme<R: Read + std::io::Seek>(
     parse_theme_xml(&theme_xml)
 }
 
+/// Load and parse `ppt/tableStyles.xml` from the archive.
+/// Returns an empty map if the file is missing.
+pub(super) fn load_table_styles<R: Read + std::io::Seek>(
+    archive: &mut ZipArchive<R>,
+    theme: &ThemeData,
+    color_map: &ColorMapData,
+) -> table_styles::TableStyleMap {
+    let Ok(xml) = read_zip_entry(archive, "ppt/tableStyles.xml") else {
+        return table_styles::TableStyleMap::new();
+    };
+    table_styles::parse_table_styles_xml(&xml, theme, color_map)
+}
+
 pub(super) fn resolve_relative_path(base_dir: &str, relative: &str) -> String {
     crate::parser::xml_util::resolve_relative_path(base_dir, relative)
 }

--- a/crates/office2pdf/src/parser/pptx_shapes.rs
+++ b/crates/office2pdf/src/parser/pptx_shapes.rs
@@ -86,6 +86,7 @@ pub(super) fn parse_group_shape(
     color_map: &ColorMapData,
     warning_context: &str,
     inherited_text_body_defaults: &PptxTextBodyStyleDefaults,
+    table_styles: &table_styles::TableStyleMap,
 ) -> Result<(Vec<FixedElement>, Vec<ConvertWarning>), ConvertError> {
     let mut transform = GroupTransform::default();
     let mut in_xfrm = false;
@@ -173,6 +174,7 @@ pub(super) fn parse_group_shape(
                         color_map,
                         warning_context,
                         inherited_text_body_defaults,
+                        table_styles,
                     )?;
                     for element in &mut child_elements {
                         transform.apply(element);

--- a/crates/office2pdf/src/parser/pptx_slides.rs
+++ b/crates/office2pdf/src/parser/pptx_slides.rs
@@ -75,6 +75,7 @@ fn parse_layer_elements<R: Read + std::io::Seek>(
     archive: &mut ZipArchive<R>,
 ) -> (Vec<FixedElement>, Vec<ConvertWarning>) {
     let images: SlideImageMap = load_slide_images(layer_path, archive);
+    let empty_table_styles: table_styles::TableStyleMap = table_styles::TableStyleMap::new();
     parse_slide_xml(
         layer_xml,
         &images,
@@ -82,6 +83,7 @@ fn parse_layer_elements<R: Read + std::io::Seek>(
         color_map,
         label,
         text_style_defaults,
+        &empty_table_styles,
     )
     .unwrap_or_default()
 }
@@ -192,6 +194,7 @@ pub(super) fn parse_single_slide<R: Read + std::io::Seek>(
     slide_label: &str,
     slide_size: PageSize,
     theme: &ThemeData,
+    table_styles: &table_styles::TableStyleMap,
     archive: &mut ZipArchive<R>,
 ) -> Result<(Page, Vec<ConvertWarning>), ConvertError> {
     let chain: SlideInheritanceChain = resolve_inheritance_chain(slide_path, theme, archive)?;
@@ -206,6 +209,7 @@ pub(super) fn parse_single_slide<R: Read + std::io::Seek>(
         &chain.slide_color_map,
         slide_label,
         &chain.master_text_style_defaults,
+        table_styles,
     )?;
     warnings.extend(slide_warnings);
 
@@ -613,6 +617,7 @@ struct SlideXmlParser<'a> {
     color_map: &'a ColorMapData,
     warning_context: &'a str,
     inherited_text_body_defaults: &'a PptxTextBodyStyleDefaults,
+    table_styles: &'a table_styles::TableStyleMap,
 
     // ── Output accumulators ─────────────────────────────────────────
     elements: Vec<FixedElement>,
@@ -669,6 +674,7 @@ impl<'a> SlideXmlParser<'a> {
         color_map: &'a ColorMapData,
         warning_context: &'a str,
         inherited_text_body_defaults: &'a PptxTextBodyStyleDefaults,
+        table_styles: &'a table_styles::TableStyleMap,
     ) -> Self {
         Self {
             xml,
@@ -677,6 +683,7 @@ impl<'a> SlideXmlParser<'a> {
             color_map,
             warning_context,
             inherited_text_body_defaults,
+            table_styles,
 
             elements: Vec::new(),
             warnings: Vec::new(),
@@ -729,7 +736,9 @@ impl<'a> SlideXmlParser<'a> {
                 self.gf.in_xfrm = true;
             }
             b"tbl" if self.in_graphic_frame => {
-                if let Ok(mut table) = parse_pptx_table(reader, self.theme, self.color_map) {
+                if let Ok(mut table) =
+                    parse_pptx_table(reader, self.theme, self.color_map, self.table_styles)
+                {
                     scale_pptx_table_geometry_to_frame(
                         &mut table,
                         emu_to_pt(self.gf.cx),
@@ -753,6 +762,7 @@ impl<'a> SlideXmlParser<'a> {
                     self.color_map,
                     self.warning_context,
                     self.inherited_text_body_defaults,
+                    self.table_styles,
                 ) {
                     self.elements.extend(group_elems);
                     self.warnings.extend(group_warnings);
@@ -1320,6 +1330,7 @@ pub(super) fn parse_slide_xml(
     color_map: &ColorMapData,
     warning_context: &str,
     inherited_text_body_defaults: &PptxTextBodyStyleDefaults,
+    table_styles: &table_styles::TableStyleMap,
 ) -> Result<(Vec<FixedElement>, Vec<ConvertWarning>), ConvertError> {
     let mut reader = Reader::from_str(xml);
     let mut parser = SlideXmlParser::new(
@@ -1329,6 +1340,7 @@ pub(super) fn parse_slide_xml(
         color_map,
         warning_context,
         inherited_text_body_defaults,
+        table_styles,
     );
 
     loop {

--- a/crates/office2pdf/src/parser/pptx_table_style_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_table_style_tests.rs
@@ -1,5 +1,43 @@
 use super::*;
+use std::io::Write;
 use table_styles::{PptxTableProps, PptxTableStyleDef, TableCellRegionStyle, TableStyleMap};
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+fn make_table_graphic_frame(
+    x: i64,
+    y: i64,
+    cx: i64,
+    cy: i64,
+    col_widths_emu: &[i64],
+    rows_xml: &str,
+) -> String {
+    let mut grid = String::new();
+    for width in col_widths_emu {
+        grid.push_str(&format!(r#"<a:gridCol w="{width}"/>"#));
+    }
+    format!(
+        r#"<p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="4" name="Table"/><p:cNvGraphicFramePr><a:graphicFrameLocks noGrp="1"/></p:cNvGraphicFramePr><p:nvPr/></p:nvGraphicFramePr><p:xfrm><a:off x="{x}" y="{y}"/><a:ext cx="{cx}" cy="{cy}"/></p:xfrm><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl><a:tblPr/><a:tblGrid>{grid}</a:tblGrid>{rows_xml}</a:tbl></a:graphicData></a:graphic></p:graphicFrame>"#
+    )
+}
+
+fn make_table_row(cells: &[&str]) -> String {
+    let mut xml = String::from(r#"<a:tr h="370840">"#);
+    for text in cells {
+        xml.push_str(&format!(
+            r#"<a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:rPr lang="en-US"/><a:t>{text}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>"#
+        ));
+    }
+    xml.push_str("</a:tr>");
+    xml
+}
+
+fn table_element(elem: &FixedElement) -> &Table {
+    match &elem.kind {
+        FixedElementKind::Table(table) => table,
+        _ => panic!("Expected Table, got {:?}", elem.kind),
+    }
+}
 
 // ── Unit tests: parse_table_styles_xml ─────────────────────────────────
 
@@ -366,5 +404,204 @@ fn test_apply_table_style_missing_style_id_is_noop() {
 
     table_styles::apply_table_style(&mut table, &props, &styles);
 
+    assert_eq!(table.rows[0].cells[0].background, None);
+}
+
+// ── Integration tests: end-to-end PPTX with table styles ──────────────
+
+/// Build a PPTX with theme and tableStyles.xml included.
+fn build_test_pptx_with_table_styles(
+    slide_cx_emu: i64,
+    slide_cy_emu: i64,
+    slide_xmls: &[String],
+    theme_xml: &str,
+    table_styles_xml: &str,
+) -> Vec<u8> {
+    let mut zip = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let opts = FileOptions::default();
+
+    let mut ct = String::from(r#"<?xml version="1.0" encoding="UTF-8"?>"#);
+    ct.push_str(r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">"#);
+    ct.push_str(r#"<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>"#);
+    ct.push_str(r#"<Default Extension="xml" ContentType="application/xml"/>"#);
+    for i in 0..slide_xmls.len() {
+        ct.push_str(&format!(
+            r#"<Override PartName="/ppt/slides/slide{}.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>"#,
+            i + 1
+        ));
+    }
+    ct.push_str("</Types>");
+    zip.start_file("[Content_Types].xml", opts).unwrap();
+    zip.write_all(ct.as_bytes()).unwrap();
+
+    zip.start_file("_rels/.rels", opts).unwrap();
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/></Relationships>"#,
+    )
+    .unwrap();
+
+    let mut pres = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?><p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:sldSz cx="{}" cy="{}"/><p:sldIdLst>"#,
+        slide_cx_emu, slide_cy_emu
+    );
+    for i in 0..slide_xmls.len() {
+        pres.push_str(&format!(
+            r#"<p:sldId id="{}" r:id="rId{}"/>"#,
+            256 + i,
+            2 + i
+        ));
+    }
+    pres.push_str("</p:sldIdLst></p:presentation>");
+    zip.start_file("ppt/presentation.xml", opts).unwrap();
+    zip.write_all(pres.as_bytes()).unwrap();
+
+    let mut pres_rels = String::from(
+        r#"<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+    );
+    pres_rels.push_str(
+        r#"<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/>"#,
+    );
+    for i in 0..slide_xmls.len() {
+        pres_rels.push_str(&format!(
+            r#"<Relationship Id="rId{}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide{}.xml"/>"#,
+            2 + i,
+            1 + i
+        ));
+    }
+    pres_rels.push_str("</Relationships>");
+    zip.start_file("ppt/_rels/presentation.xml.rels", opts)
+        .unwrap();
+    zip.write_all(pres_rels.as_bytes()).unwrap();
+
+    zip.start_file("ppt/theme/theme1.xml", opts).unwrap();
+    zip.write_all(theme_xml.as_bytes()).unwrap();
+
+    zip.start_file("ppt/tableStyles.xml", opts).unwrap();
+    zip.write_all(table_styles_xml.as_bytes()).unwrap();
+
+    for (i, slide_xml) in slide_xmls.iter().enumerate() {
+        zip.start_file(format!("ppt/slides/slide{}.xml", i + 1), opts)
+            .unwrap();
+        zip.write_all(slide_xml.as_bytes()).unwrap();
+    }
+
+    zip.finish().unwrap().into_inner()
+}
+
+#[test]
+fn test_pptx_table_with_style_applies_header_fill_and_text_color() {
+    // Table style: firstRow has accent1 fill and white bold text, band1H has light tint
+    let table_styles_xml = concat!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>"#,
+        r#"<a:tblStyleLst xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" def="{5940675A-B579-460E-94D1-54222C63F5DA}">"#,
+        r#"<a:tblStyle styleId="{5940675A-B579-460E-94D1-54222C63F5DA}" styleName="Test">"#,
+        r#"<a:firstRow>"#,
+        r#"<a:tcTxStyle b="on"><a:fontRef idx="minor"><a:schemeClr val="lt1"/></a:fontRef></a:tcTxStyle>"#,
+        r#"<a:tcStyle><a:fill><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:fill></a:tcStyle>"#,
+        r#"</a:firstRow>"#,
+        r#"<a:band1H>"#,
+        r#"<a:tcStyle><a:fill><a:solidFill><a:schemeClr val="accent1"><a:tint val="40000"/></a:schemeClr></a:solidFill></a:fill></a:tcStyle>"#,
+        r#"</a:band1H>"#,
+        r#"</a:tblStyle>"#,
+        r#"</a:tblStyleLst>"#,
+    );
+
+    // Table with tblPr firstRow=1 bandRow=1 and a tableStyleId
+    let table_xml = concat!(
+        r#"<p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="4" name="Table"/>"#,
+        r#"<p:cNvGraphicFramePr><a:graphicFrameLocks noGrp="1"/></p:cNvGraphicFramePr>"#,
+        r#"<p:nvPr/></p:nvGraphicFramePr>"#,
+        r#"<p:xfrm><a:off x="0" y="0"/><a:ext cx="3657600" cy="1828800"/></p:xfrm>"#,
+        r#"<a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table">"#,
+        r#"<a:tbl>"#,
+        r#"<a:tblPr firstRow="1" bandRow="1"><a:tableStyleId>{5940675A-B579-460E-94D1-54222C63F5DA}</a:tableStyleId></a:tblPr>"#,
+        r#"<a:tblGrid><a:gridCol w="1828800"/><a:gridCol w="1828800"/></a:tblGrid>"#,
+        // Header row with white text (schemeClr bg1 = lt1 = white)
+        r#"<a:tr h="370840">"#,
+        r#"<a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:rPr lang="en-US"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:rPr><a:t>Model</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>"#,
+        r#"<a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:rPr lang="en-US"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:rPr><a:t>GPU</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>"#,
+        r#"</a:tr>"#,
+        // Data row 1
+        r#"<a:tr h="370840">"#,
+        r#"<a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:rPr lang="en-US"/><a:t>YOLOv8n</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>"#,
+        r#"<a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:rPr lang="en-US"/><a:t>RTX 4090</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>"#,
+        r#"</a:tr>"#,
+        // Data row 2
+        r#"<a:tr h="370840">"#,
+        r#"<a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:rPr lang="en-US"/><a:t>YOLOv8s</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>"#,
+        r#"<a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:rPr lang="en-US"/><a:t>A100</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>"#,
+        r#"</a:tr>"#,
+        r#"</a:tbl></a:graphicData></a:graphic></p:graphicFrame>"#,
+    );
+
+    let slide = make_slide_xml(&[table_xml.to_string()]);
+    let theme_xml = make_theme_xml(&standard_theme_colors(), "Calibri Light", "Calibri");
+    let data = build_test_pptx_with_table_styles(
+        SLIDE_CX,
+        SLIDE_CY,
+        &[slide],
+        &theme_xml,
+        table_styles_xml,
+    );
+
+    let parser = PptxParser;
+    let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
+
+    let page = first_fixed_page(&doc);
+    let table = table_element(&page.elements[0]);
+
+    // Header row should get accent1 (#4472C4) background from firstRow style
+    assert_eq!(
+        table.rows[0].cells[0].background,
+        Some(Color::new(0x44, 0x72, 0xC4))
+    );
+    assert_eq!(
+        table.rows[0].cells[1].background,
+        Some(Color::new(0x44, 0x72, 0xC4))
+    );
+
+    // Header row text: explicit white (bg1→lt1→#FFFFFF) preserved, bold from style
+    let header_run = match &table.rows[0].cells[0].content[0] {
+        Block::Paragraph(p) => &p.runs[0],
+        _ => panic!("Expected paragraph"),
+    };
+    assert_eq!(header_run.text, "Model");
+    assert_eq!(header_run.style.color, Some(Color::new(0xFF, 0xFF, 0xFF)));
+    assert_eq!(header_run.style.bold, Some(true));
+
+    // Data row 1 (band index 0 → band1H) should get tinted accent1
+    // accent1=(68,114,196) with tint 40%: (180,199,231)
+    assert_eq!(
+        table.rows[1].cells[0].background,
+        Some(Color::new(180, 199, 231))
+    );
+
+    // Data row 2 (band index 1 → band2H, not defined) → no fill
+    assert_eq!(table.rows[2].cells[0].background, None);
+
+    // header_row_count should be 1
+    assert_eq!(table.header_row_count, 1);
+}
+
+#[test]
+fn test_pptx_table_without_table_styles_xml_still_works() {
+    // Regular PPTX without tableStyles.xml should work fine
+    let rows = format!(
+        "{}{}",
+        make_table_row(&["A1", "B1"]),
+        make_table_row(&["A2", "B2"]),
+    );
+    let table_frame =
+        make_table_graphic_frame(0, 0, 3657600, 1828800, &[1828800, 1828800], &rows);
+    let slide = make_slide_xml(&[table_frame]);
+    let theme_xml = make_theme_xml(&standard_theme_colors(), "Calibri Light", "Calibri");
+    let data = build_test_pptx_with_theme(SLIDE_CX, SLIDE_CY, &[slide], &theme_xml);
+
+    let parser = PptxParser;
+    let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
+
+    let page = first_fixed_page(&doc);
+    let table = table_element(&page.elements[0]);
+    assert_eq!(table.rows.len(), 2);
     assert_eq!(table.rows[0].cells[0].background, None);
 }

--- a/crates/office2pdf/src/parser/pptx_table_style_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_table_style_tests.rs
@@ -70,8 +70,7 @@ fn test_parse_table_style_with_whole_table_fill() {
     let theme: ThemeData = test_theme();
     let color_map: ColorMapData = test_color_map();
 
-    let styles: TableStyleMap =
-        table_styles::parse_table_styles_xml(&xml, &theme, &color_map);
+    let styles: TableStyleMap = table_styles::parse_table_styles_xml(&xml, &theme, &color_map);
 
     let style: &PptxTableStyleDef = styles
         .get("{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}")
@@ -93,8 +92,7 @@ fn test_parse_table_style_with_first_row_scheme_color() {
     let theme: ThemeData = test_theme();
     let color_map: ColorMapData = test_color_map();
 
-    let styles: TableStyleMap =
-        table_styles::parse_table_styles_xml(&xml, &theme, &color_map);
+    let styles: TableStyleMap = table_styles::parse_table_styles_xml(&xml, &theme, &color_map);
 
     let style: &PptxTableStyleDef = styles.get("style1").expect("style not found");
     let first_row = style.first_row.as_ref().expect("firstRow missing");
@@ -113,8 +111,7 @@ fn test_parse_table_style_banded_rows() {
     let theme: ThemeData = test_theme();
     let color_map: ColorMapData = test_color_map();
 
-    let styles: TableStyleMap =
-        table_styles::parse_table_styles_xml(&xml, &theme, &color_map);
+    let styles: TableStyleMap = table_styles::parse_table_styles_xml(&xml, &theme, &color_map);
 
     let style: &PptxTableStyleDef = styles.get("bandtest").expect("style not found");
     assert_eq!(
@@ -135,8 +132,7 @@ fn test_parse_table_style_with_color_transforms() {
     let theme: ThemeData = test_theme();
     let color_map: ColorMapData = test_color_map();
 
-    let styles: TableStyleMap =
-        table_styles::parse_table_styles_xml(&xml, &theme, &color_map);
+    let styles: TableStyleMap = table_styles::parse_table_styles_xml(&xml, &theme, &color_map);
 
     let style: &PptxTableStyleDef = styles.get("tinttest").expect("style not found");
     let band = style.band1_h.as_ref().expect("band1H missing");
@@ -288,7 +284,12 @@ fn test_apply_table_style_banded_rows_skip_first_row() {
     };
 
     let mut table = Table {
-        rows: vec![make_row("Header"), make_row("Row1"), make_row("Row2"), make_row("Row3")],
+        rows: vec![
+            make_row("Header"),
+            make_row("Row1"),
+            make_row("Row2"),
+            make_row("Row3"),
+        ],
         column_widths: vec![200.0],
         header_row_count: 1,
         alignment: None,
@@ -591,8 +592,7 @@ fn test_pptx_table_without_table_styles_xml_still_works() {
         make_table_row(&["A1", "B1"]),
         make_table_row(&["A2", "B2"]),
     );
-    let table_frame =
-        make_table_graphic_frame(0, 0, 3657600, 1828800, &[1828800, 1828800], &rows);
+    let table_frame = make_table_graphic_frame(0, 0, 3657600, 1828800, &[1828800, 1828800], &rows);
     let slide = make_slide_xml(&[table_frame]);
     let theme_xml = make_theme_xml(&standard_theme_colors(), "Calibri Light", "Calibri");
     let data = build_test_pptx_with_theme(SLIDE_CX, SLIDE_CY, &[slide], &theme_xml);

--- a/crates/office2pdf/src/parser/pptx_table_style_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_table_style_tests.rs
@@ -1,0 +1,370 @@
+use super::*;
+use table_styles::{PptxTableProps, PptxTableStyleDef, TableCellRegionStyle, TableStyleMap};
+
+// ── Unit tests: parse_table_styles_xml ─────────────────────────────────
+
+fn make_table_style_xml(styles: &[(&str, &str)]) -> String {
+    let mut xml = String::from(
+        r#"<?xml version="1.0" encoding="UTF-8"?><a:tblStyleLst xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" def="{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}">"#,
+    );
+    for (style_id, body) in styles {
+        xml.push_str(&format!(
+            r#"<a:tblStyle styleId="{style_id}" styleName="Test">{body}</a:tblStyle>"#
+        ));
+    }
+    xml.push_str("</a:tblStyleLst>");
+    xml
+}
+
+fn test_theme() -> ThemeData {
+    let theme_xml = make_theme_xml(&standard_theme_colors(), "Calibri Light", "Calibri");
+    parse_theme_xml(&theme_xml)
+}
+
+fn test_color_map() -> ColorMapData {
+    default_color_map()
+}
+
+#[test]
+fn test_parse_table_style_with_whole_table_fill() {
+    let body = r#"<a:wholeTbl><a:tcStyle><a:fill><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:fill></a:tcStyle></a:wholeTbl>"#;
+    let xml = make_table_style_xml(&[("{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}", body)]);
+    let theme: ThemeData = test_theme();
+    let color_map: ColorMapData = test_color_map();
+
+    let styles: TableStyleMap =
+        table_styles::parse_table_styles_xml(&xml, &theme, &color_map);
+
+    let style: &PptxTableStyleDef = styles
+        .get("{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}")
+        .expect("style not found");
+    let whole = style.whole_table.as_ref().expect("wholeTbl missing");
+    assert_eq!(whole.fill, Some(Color::new(255, 0, 0)));
+}
+
+#[test]
+fn test_parse_table_style_with_first_row_scheme_color() {
+    // firstRow with accent1 fill and white bold text
+    let body = concat!(
+        r#"<a:firstRow>"#,
+        r#"<a:tcTxStyle b="on"><a:fontRef idx="minor"><a:schemeClr val="lt1"/></a:fontRef></a:tcTxStyle>"#,
+        r#"<a:tcStyle><a:fill><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:fill></a:tcStyle>"#,
+        r#"</a:firstRow>"#,
+    );
+    let xml = make_table_style_xml(&[("style1", body)]);
+    let theme: ThemeData = test_theme();
+    let color_map: ColorMapData = test_color_map();
+
+    let styles: TableStyleMap =
+        table_styles::parse_table_styles_xml(&xml, &theme, &color_map);
+
+    let style: &PptxTableStyleDef = styles.get("style1").expect("style not found");
+    let first_row = style.first_row.as_ref().expect("firstRow missing");
+    assert_eq!(first_row.fill, Some(Color::new(0x44, 0x72, 0xC4)));
+    assert_eq!(first_row.text_color, Some(Color::new(0xFF, 0xFF, 0xFF)));
+    assert_eq!(first_row.text_bold, Some(true));
+}
+
+#[test]
+fn test_parse_table_style_banded_rows() {
+    let body = concat!(
+        r#"<a:band1H><a:tcStyle><a:fill><a:solidFill><a:srgbClr val="DDDDDD"/></a:solidFill></a:fill></a:tcStyle></a:band1H>"#,
+        r#"<a:band2H><a:tcStyle><a:fill><a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill></a:fill></a:tcStyle></a:band2H>"#,
+    );
+    let xml = make_table_style_xml(&[("bandtest", body)]);
+    let theme: ThemeData = test_theme();
+    let color_map: ColorMapData = test_color_map();
+
+    let styles: TableStyleMap =
+        table_styles::parse_table_styles_xml(&xml, &theme, &color_map);
+
+    let style: &PptxTableStyleDef = styles.get("bandtest").expect("style not found");
+    assert_eq!(
+        style.band1_h.as_ref().unwrap().fill,
+        Some(Color::new(0xDD, 0xDD, 0xDD))
+    );
+    assert_eq!(
+        style.band2_h.as_ref().unwrap().fill,
+        Some(Color::new(0xFF, 0xFF, 0xFF))
+    );
+}
+
+#[test]
+fn test_parse_table_style_with_color_transforms() {
+    // accent1=#4472C4 with tint 40% → blend toward white
+    let body = r#"<a:band1H><a:tcStyle><a:fill><a:solidFill><a:schemeClr val="accent1"><a:tint val="40000"/></a:schemeClr></a:solidFill></a:fill></a:tcStyle></a:band1H>"#;
+    let xml = make_table_style_xml(&[("tinttest", body)]);
+    let theme: ThemeData = test_theme();
+    let color_map: ColorMapData = test_color_map();
+
+    let styles: TableStyleMap =
+        table_styles::parse_table_styles_xml(&xml, &theme, &color_map);
+
+    let style: &PptxTableStyleDef = styles.get("tinttest").expect("style not found");
+    let band = style.band1_h.as_ref().expect("band1H missing");
+    // accent1 = (68, 114, 196). tint 40%: channel = 255 - (255-ch)*0.4
+    // r = 255 - 187*0.4 = 255 - 74.8 = 180.2 → 180
+    // g = 255 - 141*0.4 = 255 - 56.4 = 198.6 → 199
+    // b = 255 - 59*0.4 = 255 - 23.6 = 231.4 → 231
+    assert_eq!(band.fill, Some(Color::new(180, 199, 231)));
+}
+
+// ── Unit tests: apply_table_style ──────────────────────────────────────
+
+#[test]
+fn test_apply_table_style_first_row_gets_header_fill_and_text_color() {
+    let mut styles: TableStyleMap = HashMap::new();
+    styles.insert(
+        "style1".to_string(),
+        PptxTableStyleDef {
+            first_row: Some(TableCellRegionStyle {
+                fill: Some(Color::new(0x44, 0x72, 0xC4)),
+                text_color: Some(Color::new(255, 255, 255)),
+                text_bold: Some(true),
+            }),
+            ..Default::default()
+        },
+    );
+    let props = PptxTableProps {
+        style_id: Some("style1".to_string()),
+        first_row: true,
+        ..Default::default()
+    };
+
+    // Build a simple 2-row table with no explicit fills
+    let mut table = Table {
+        rows: vec![
+            TableRow {
+                cells: vec![TableCell {
+                    content: vec![Block::Paragraph(Paragraph {
+                        style: ParagraphStyle::default(),
+                        runs: vec![Run {
+                            text: "Header".to_string(),
+                            style: TextStyle::default(),
+                            href: None,
+                            footnote: None,
+                        }],
+                    })],
+                    col_span: 1,
+                    row_span: 1,
+                    border: None,
+                    background: None,
+                    data_bar: None,
+                    icon_text: None,
+                    vertical_align: None,
+                    padding: None,
+                }],
+                height: Some(30.0),
+            },
+            TableRow {
+                cells: vec![TableCell {
+                    content: vec![Block::Paragraph(Paragraph {
+                        style: ParagraphStyle::default(),
+                        runs: vec![Run {
+                            text: "Data".to_string(),
+                            style: TextStyle::default(),
+                            href: None,
+                            footnote: None,
+                        }],
+                    })],
+                    col_span: 1,
+                    row_span: 1,
+                    border: None,
+                    background: None,
+                    data_bar: None,
+                    icon_text: None,
+                    vertical_align: None,
+                    padding: None,
+                }],
+                height: Some(30.0),
+            },
+        ],
+        column_widths: vec![200.0],
+        header_row_count: 1,
+        alignment: None,
+        default_cell_padding: None,
+        use_content_driven_row_heights: true,
+    };
+
+    table_styles::apply_table_style(&mut table, &props, &styles);
+
+    // Header row cell should have blue background and white bold text
+    let header_cell = &table.rows[0].cells[0];
+    assert_eq!(header_cell.background, Some(Color::new(0x44, 0x72, 0xC4)));
+    let header_run = match &header_cell.content[0] {
+        Block::Paragraph(p) => &p.runs[0],
+        _ => panic!("Expected paragraph"),
+    };
+    assert_eq!(header_run.style.color, Some(Color::new(255, 255, 255)));
+    assert_eq!(header_run.style.bold, Some(true));
+
+    // Data row should be unaffected
+    let data_cell = &table.rows[1].cells[0];
+    assert_eq!(data_cell.background, None);
+}
+
+#[test]
+fn test_apply_table_style_banded_rows_skip_first_row() {
+    let mut styles: TableStyleMap = HashMap::new();
+    styles.insert(
+        "bandstyle".to_string(),
+        PptxTableStyleDef {
+            band1_h: Some(TableCellRegionStyle {
+                fill: Some(Color::new(0xDD, 0xEE, 0xFF)),
+                text_color: None,
+                text_bold: None,
+            }),
+            ..Default::default()
+        },
+    );
+    let props = PptxTableProps {
+        style_id: Some("bandstyle".to_string()),
+        first_row: true,
+        band_row: true,
+        ..Default::default()
+    };
+
+    let make_row = |text: &str| -> TableRow {
+        TableRow {
+            cells: vec![TableCell {
+                content: vec![Block::Paragraph(Paragraph {
+                    style: ParagraphStyle::default(),
+                    runs: vec![Run {
+                        text: text.to_string(),
+                        style: TextStyle::default(),
+                        href: None,
+                        footnote: None,
+                    }],
+                })],
+                col_span: 1,
+                row_span: 1,
+                border: None,
+                background: None,
+                data_bar: None,
+                icon_text: None,
+                vertical_align: None,
+                padding: None,
+            }],
+            height: Some(30.0),
+        }
+    };
+
+    let mut table = Table {
+        rows: vec![make_row("Header"), make_row("Row1"), make_row("Row2"), make_row("Row3")],
+        column_widths: vec![200.0],
+        header_row_count: 1,
+        alignment: None,
+        default_cell_padding: None,
+        use_content_driven_row_heights: true,
+    };
+
+    table_styles::apply_table_style(&mut table, &props, &styles);
+
+    // Header row (row 0) excluded from banding
+    assert_eq!(table.rows[0].cells[0].background, None);
+    // Row 1 (data row index 0) = band1 → fill applied
+    assert_eq!(
+        table.rows[1].cells[0].background,
+        Some(Color::new(0xDD, 0xEE, 0xFF))
+    );
+    // Row 2 (data row index 1) = band2 → no fill (band2 not defined)
+    assert_eq!(table.rows[2].cells[0].background, None);
+    // Row 3 (data row index 2) = band1 → fill applied
+    assert_eq!(
+        table.rows[3].cells[0].background,
+        Some(Color::new(0xDD, 0xEE, 0xFF))
+    );
+}
+
+#[test]
+fn test_apply_table_style_explicit_cell_fill_not_overridden() {
+    let mut styles: TableStyleMap = HashMap::new();
+    styles.insert(
+        "override".to_string(),
+        PptxTableStyleDef {
+            whole_table: Some(TableCellRegionStyle {
+                fill: Some(Color::new(0xAA, 0xBB, 0xCC)),
+                text_color: None,
+                text_bold: None,
+            }),
+            ..Default::default()
+        },
+    );
+    let props = PptxTableProps {
+        style_id: Some("override".to_string()),
+        ..Default::default()
+    };
+
+    let mut table = Table {
+        rows: vec![TableRow {
+            cells: vec![TableCell {
+                content: vec![Block::Paragraph(Paragraph {
+                    style: ParagraphStyle::default(),
+                    runs: vec![Run {
+                        text: "Explicit".to_string(),
+                        style: TextStyle::default(),
+                        href: None,
+                        footnote: None,
+                    }],
+                })],
+                col_span: 1,
+                row_span: 1,
+                border: None,
+                background: Some(Color::new(0xFF, 0x00, 0x00)),
+                data_bar: None,
+                icon_text: None,
+                vertical_align: None,
+                padding: None,
+            }],
+            height: Some(30.0),
+        }],
+        column_widths: vec![200.0],
+        header_row_count: 0,
+        alignment: None,
+        default_cell_padding: None,
+        use_content_driven_row_heights: true,
+    };
+
+    table_styles::apply_table_style(&mut table, &props, &styles);
+
+    // Explicit cell fill should be preserved, not overridden by wholeTbl
+    assert_eq!(
+        table.rows[0].cells[0].background,
+        Some(Color::new(0xFF, 0x00, 0x00))
+    );
+}
+
+#[test]
+fn test_apply_table_style_missing_style_id_is_noop() {
+    let styles: TableStyleMap = HashMap::new();
+    let props = PptxTableProps {
+        style_id: None,
+        ..Default::default()
+    };
+
+    let mut table = Table {
+        rows: vec![TableRow {
+            cells: vec![TableCell {
+                content: vec![],
+                col_span: 1,
+                row_span: 1,
+                border: None,
+                background: None,
+                data_bar: None,
+                icon_text: None,
+                vertical_align: None,
+                padding: None,
+            }],
+            height: Some(30.0),
+        }],
+        column_widths: vec![200.0],
+        header_row_count: 0,
+        alignment: None,
+        default_cell_padding: None,
+        use_content_driven_row_heights: true,
+    };
+
+    table_styles::apply_table_style(&mut table, &props, &styles);
+
+    assert_eq!(table.rows[0].cells[0].background, None);
+}

--- a/crates/office2pdf/src/parser/pptx_table_styles.rs
+++ b/crates/office2pdf/src/parser/pptx_table_styles.rs
@@ -59,8 +59,12 @@ pub(super) fn parse_table_styles_xml(
                     current_def = PptxTableStyleDef::default();
                 }
                 b"wholeTbl" if current_style_id.is_some() => {
-                    current_def.whole_table =
-                        Some(parse_region_style(&mut reader, b"wholeTbl", theme, color_map));
+                    current_def.whole_table = Some(parse_region_style(
+                        &mut reader,
+                        b"wholeTbl",
+                        theme,
+                        color_map,
+                    ));
                 }
                 b"band1H" if current_style_id.is_some() => {
                     current_def.band1_h =
@@ -71,20 +75,36 @@ pub(super) fn parse_table_styles_xml(
                         Some(parse_region_style(&mut reader, b"band2H", theme, color_map));
                 }
                 b"firstRow" if current_style_id.is_some() => {
-                    current_def.first_row =
-                        Some(parse_region_style(&mut reader, b"firstRow", theme, color_map));
+                    current_def.first_row = Some(parse_region_style(
+                        &mut reader,
+                        b"firstRow",
+                        theme,
+                        color_map,
+                    ));
                 }
                 b"lastRow" if current_style_id.is_some() => {
-                    current_def.last_row =
-                        Some(parse_region_style(&mut reader, b"lastRow", theme, color_map));
+                    current_def.last_row = Some(parse_region_style(
+                        &mut reader,
+                        b"lastRow",
+                        theme,
+                        color_map,
+                    ));
                 }
                 b"firstCol" if current_style_id.is_some() => {
-                    current_def.first_col =
-                        Some(parse_region_style(&mut reader, b"firstCol", theme, color_map));
+                    current_def.first_col = Some(parse_region_style(
+                        &mut reader,
+                        b"firstCol",
+                        theme,
+                        color_map,
+                    ));
                 }
                 b"lastCol" if current_style_id.is_some() => {
-                    current_def.last_col =
-                        Some(parse_region_style(&mut reader, b"lastCol", theme, color_map));
+                    current_def.last_col = Some(parse_region_style(
+                        &mut reader,
+                        b"lastCol",
+                        theme,
+                        color_map,
+                    ));
                 }
                 _ => {}
             },
@@ -130,13 +150,11 @@ fn parse_region_style(
                 b"solidFill" if in_fill || in_tc_style => in_solid_fill = true,
                 b"fontRef" if in_tc_tx_style => in_font_ref = true,
                 b"srgbClr" | b"schemeClr" | b"sysClr" if in_solid_fill => {
-                    let parsed: ParsedColor =
-                        parse_color_from_start(reader, e, theme, color_map);
+                    let parsed: ParsedColor = parse_color_from_start(reader, e, theme, color_map);
                     style.fill = parsed.color;
                 }
                 b"srgbClr" | b"schemeClr" | b"sysClr" if in_font_ref => {
-                    let parsed: ParsedColor =
-                        parse_color_from_start(reader, e, theme, color_map);
+                    let parsed: ParsedColor = parse_color_from_start(reader, e, theme, color_map);
                     style.text_color = parsed.color;
                 }
                 _ => {}
@@ -185,11 +203,7 @@ fn parse_region_style(
 /// Apply table style colors/formatting to cells that don't have explicit overrides.
 ///
 /// Priority (highest wins): cell-level explicit → firstRow/lastRow/firstCol/lastCol → band → wholeTbl
-pub(super) fn apply_table_style(
-    table: &mut Table,
-    props: &PptxTableProps,
-    styles: &TableStyleMap,
-) {
+pub(super) fn apply_table_style(table: &mut Table, props: &PptxTableProps, styles: &TableStyleMap) {
     let style_id: &str = match props.style_id.as_deref() {
         Some(id) => id,
         None => return,
@@ -206,7 +220,8 @@ pub(super) fn apply_table_style(
 
     for (row_idx, row) in table.rows.iter_mut().enumerate() {
         let is_first_row: bool = props.first_row && row_idx < header_rows;
-        let is_last_row: bool = props.last_row && total_rows > header_rows && row_idx == total_rows - 1;
+        let is_last_row: bool =
+            props.last_row && total_rows > header_rows && row_idx == total_rows - 1;
 
         // Data row index for banding (excludes first/last special rows)
         let data_row_idx: Option<usize> = if !is_first_row && !is_last_row {
@@ -271,10 +286,10 @@ fn apply_region_to_cell(cell: &mut TableCell, region: &TableCellRegionStyle) {
                     if region.text_color.is_some() && run.style.color.is_none() {
                         run.style.color = region.text_color;
                     }
-                    if let Some(bold) = region.text_bold {
-                        if run.style.bold.is_none() {
-                            run.style.bold = Some(bold);
-                        }
+                    if let Some(bold) = region.text_bold
+                        && run.style.bold.is_none()
+                    {
+                        run.style.bold = Some(bold);
                     }
                 }
             }

--- a/crates/office2pdf/src/parser/pptx_table_styles.rs
+++ b/crates/office2pdf/src/parser/pptx_table_styles.rs
@@ -1,0 +1,283 @@
+use super::*;
+
+// ── Table style data structures ─────────────────────────────────────────
+
+/// Styling for a table cell region (e.g., firstRow, band1H, wholeTbl).
+#[derive(Debug, Clone, Default)]
+pub(super) struct TableCellRegionStyle {
+    pub(super) fill: Option<Color>,
+    pub(super) text_color: Option<Color>,
+    pub(super) text_bold: Option<bool>,
+}
+
+/// Parsed definition of a single `<a:tblStyle>` element.
+#[derive(Debug, Clone, Default)]
+pub(super) struct PptxTableStyleDef {
+    pub(super) whole_table: Option<TableCellRegionStyle>,
+    pub(super) band1_h: Option<TableCellRegionStyle>,
+    pub(super) band2_h: Option<TableCellRegionStyle>,
+    pub(super) first_row: Option<TableCellRegionStyle>,
+    pub(super) last_row: Option<TableCellRegionStyle>,
+    pub(super) first_col: Option<TableCellRegionStyle>,
+    pub(super) last_col: Option<TableCellRegionStyle>,
+}
+
+/// Map from style ID (GUID string) to parsed table style definition.
+pub(super) type TableStyleMap = HashMap<String, PptxTableStyleDef>;
+
+/// Attributes from `<a:tblPr>` that control which style regions are active.
+#[derive(Debug, Clone, Default)]
+pub(super) struct PptxTableProps {
+    pub(super) style_id: Option<String>,
+    pub(super) first_row: bool,
+    pub(super) last_row: bool,
+    pub(super) first_col: bool,
+    pub(super) last_col: bool,
+    pub(super) band_row: bool,
+    pub(super) band_col: bool,
+}
+
+// ── Parsing ─────────────────────────────────────────────────────────────
+
+/// Parse `ppt/tableStyles.xml` into a map of table style definitions.
+pub(super) fn parse_table_styles_xml(
+    xml: &str,
+    theme: &ThemeData,
+    color_map: &ColorMapData,
+) -> TableStyleMap {
+    let mut styles: TableStyleMap = HashMap::new();
+    let mut reader = Reader::from_str(xml);
+
+    let mut current_style_id: Option<String> = None;
+    let mut current_def = PptxTableStyleDef::default();
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) => match e.local_name().as_ref() {
+                b"tblStyle" => {
+                    current_style_id = get_attr_str(e, b"styleId");
+                    current_def = PptxTableStyleDef::default();
+                }
+                b"wholeTbl" if current_style_id.is_some() => {
+                    current_def.whole_table =
+                        Some(parse_region_style(&mut reader, b"wholeTbl", theme, color_map));
+                }
+                b"band1H" if current_style_id.is_some() => {
+                    current_def.band1_h =
+                        Some(parse_region_style(&mut reader, b"band1H", theme, color_map));
+                }
+                b"band2H" if current_style_id.is_some() => {
+                    current_def.band2_h =
+                        Some(parse_region_style(&mut reader, b"band2H", theme, color_map));
+                }
+                b"firstRow" if current_style_id.is_some() => {
+                    current_def.first_row =
+                        Some(parse_region_style(&mut reader, b"firstRow", theme, color_map));
+                }
+                b"lastRow" if current_style_id.is_some() => {
+                    current_def.last_row =
+                        Some(parse_region_style(&mut reader, b"lastRow", theme, color_map));
+                }
+                b"firstCol" if current_style_id.is_some() => {
+                    current_def.first_col =
+                        Some(parse_region_style(&mut reader, b"firstCol", theme, color_map));
+                }
+                b"lastCol" if current_style_id.is_some() => {
+                    current_def.last_col =
+                        Some(parse_region_style(&mut reader, b"lastCol", theme, color_map));
+                }
+                _ => {}
+            },
+            Ok(Event::End(ref e)) if e.local_name().as_ref() == b"tblStyle" => {
+                if let Some(id) = current_style_id.take() {
+                    styles.insert(id, std::mem::take(&mut current_def));
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    styles
+}
+
+/// Parse a region element (e.g., `<a:firstRow>`) and extract fill, text color, and bold.
+fn parse_region_style(
+    reader: &mut Reader<&[u8]>,
+    end_tag: &[u8],
+    theme: &ThemeData,
+    color_map: &ColorMapData,
+) -> TableCellRegionStyle {
+    let mut style = TableCellRegionStyle::default();
+    let mut in_tc_style = false;
+    let mut in_tc_tx_style = false;
+    let mut in_fill = false;
+    let mut in_solid_fill = false;
+    let mut in_font_ref = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) => match e.local_name().as_ref() {
+                b"tcStyle" => in_tc_style = true,
+                b"tcTxStyle" => {
+                    in_tc_tx_style = true;
+                    if let Some(bold) = get_attr_str(e, b"b") {
+                        style.text_bold = Some(bold == "on");
+                    }
+                }
+                b"fill" if in_tc_style => in_fill = true,
+                b"solidFill" if in_fill || in_tc_style => in_solid_fill = true,
+                b"fontRef" if in_tc_tx_style => in_font_ref = true,
+                b"srgbClr" | b"schemeClr" | b"sysClr" if in_solid_fill => {
+                    let parsed: ParsedColor =
+                        parse_color_from_start(reader, e, theme, color_map);
+                    style.fill = parsed.color;
+                }
+                b"srgbClr" | b"schemeClr" | b"sysClr" if in_font_ref => {
+                    let parsed: ParsedColor =
+                        parse_color_from_start(reader, e, theme, color_map);
+                    style.text_color = parsed.color;
+                }
+                _ => {}
+            },
+            Ok(Event::Empty(ref e)) => match e.local_name().as_ref() {
+                b"srgbClr" | b"schemeClr" | b"sysClr" if in_solid_fill => {
+                    let parsed: ParsedColor = parse_color_from_empty(e, theme, color_map);
+                    style.fill = parsed.color;
+                }
+                b"srgbClr" | b"schemeClr" | b"sysClr" if in_font_ref => {
+                    let parsed: ParsedColor = parse_color_from_empty(e, theme, color_map);
+                    style.text_color = parsed.color;
+                }
+                b"tcTxStyle" => {
+                    if let Some(bold) = get_attr_str(e, b"b") {
+                        style.text_bold = Some(bold == "on");
+                    }
+                }
+                _ => {}
+            },
+            Ok(Event::End(ref e)) => {
+                let local = e.local_name();
+                if local.as_ref() == end_tag {
+                    break;
+                }
+                match local.as_ref() {
+                    b"tcStyle" => in_tc_style = false,
+                    b"tcTxStyle" => in_tc_tx_style = false,
+                    b"fill" => in_fill = false,
+                    b"solidFill" => in_solid_fill = false,
+                    b"fontRef" => in_font_ref = false,
+                    _ => {}
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    style
+}
+
+// ── Style application ───────────────────────────────────────────────────
+
+/// Apply table style colors/formatting to cells that don't have explicit overrides.
+///
+/// Priority (highest wins): cell-level explicit → firstRow/lastRow/firstCol/lastCol → band → wholeTbl
+pub(super) fn apply_table_style(
+    table: &mut Table,
+    props: &PptxTableProps,
+    styles: &TableStyleMap,
+) {
+    let style_id: &str = match props.style_id.as_deref() {
+        Some(id) => id,
+        None => return,
+    };
+    let style_def: &PptxTableStyleDef = match styles.get(style_id) {
+        Some(def) => def,
+        None => return,
+    };
+
+    let total_rows: usize = table.rows.len();
+    let total_cols: usize = table.column_widths.len();
+    let header_rows: usize = if props.first_row { 1 } else { 0 };
+    let footer_rows: usize = if props.last_row { 1 } else { 0 };
+
+    for (row_idx, row) in table.rows.iter_mut().enumerate() {
+        let is_first_row: bool = props.first_row && row_idx < header_rows;
+        let is_last_row: bool = props.last_row && total_rows > header_rows && row_idx == total_rows - 1;
+
+        // Data row index for banding (excludes first/last special rows)
+        let data_row_idx: Option<usize> = if !is_first_row && !is_last_row {
+            Some(row_idx.saturating_sub(header_rows))
+        } else {
+            None
+        };
+
+        for (col_idx, cell) in row.cells.iter_mut().enumerate() {
+            let is_first_col: bool = props.first_col && col_idx == 0;
+            let is_last_col: bool = props.last_col && total_cols > 0 && col_idx == total_cols - 1;
+
+            // Determine which region style applies (highest priority first)
+            let region_style: Option<&TableCellRegionStyle> = if is_first_row {
+                style_def.first_row.as_ref()
+            } else if is_last_row {
+                style_def.last_row.as_ref()
+            } else if is_first_col {
+                style_def.first_col.as_ref()
+            } else if is_last_col {
+                style_def.last_col.as_ref()
+            } else if props.band_row
+                && let Some(data_idx) = data_row_idx
+            {
+                if data_idx % 2 == 0 {
+                    style_def.band1_h.as_ref()
+                } else {
+                    style_def.band2_h.as_ref()
+                }
+            } else {
+                style_def.whole_table.as_ref()
+            };
+
+            let Some(region) = region_style else {
+                // Fall back to wholeTbl if the region is defined but has no style
+                if let Some(whole) = style_def.whole_table.as_ref() {
+                    apply_region_to_cell(cell, whole);
+                }
+                continue;
+            };
+
+            apply_region_to_cell(cell, region);
+        }
+    }
+
+    // Suppress footer_rows warning
+    let _ = footer_rows;
+}
+
+/// Apply a region style to a cell, respecting explicit cell-level overrides.
+fn apply_region_to_cell(cell: &mut TableCell, region: &TableCellRegionStyle) {
+    // Only apply fill if cell doesn't have an explicit background
+    if cell.background.is_none() {
+        cell.background = region.fill;
+    }
+
+    // Apply text color and bold to all runs that don't have explicit overrides
+    if region.text_color.is_some() || region.text_bold.is_some() {
+        for block in &mut cell.content {
+            if let Block::Paragraph(paragraph) = block {
+                for run in &mut paragraph.runs {
+                    if region.text_color.is_some() && run.style.color.is_none() {
+                        run.style.color = region.text_color;
+                    }
+                    if let Some(bold) = region.text_bold {
+                        if run.style.bold.is_none() {
+                            run.style.bold = Some(bold);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/office2pdf/src/parser/pptx_tables.rs
+++ b/crates/office2pdf/src/parser/pptx_tables.rs
@@ -20,10 +20,14 @@ struct PptxTableParser<'a> {
     // External context (immutable references)
     theme: &'a ThemeData,
     color_map: &'a ColorMapData,
+    table_styles: &'a table_styles::TableStyleMap,
 
     // ── Table-level state ───────────────────────────────────────────
     column_widths: Vec<f64>,
     rows: Vec<TableRow>,
+    table_props: table_styles::PptxTableProps,
+    is_in_tbl_pr: bool,
+    is_in_table_style_id: bool,
 
     // ── Row-level state ─────────────────────────────────────────────
     is_in_row: bool,
@@ -80,13 +84,21 @@ struct PptxTableParser<'a> {
 }
 
 impl<'a> PptxTableParser<'a> {
-    fn new(theme: &'a ThemeData, color_map: &'a ColorMapData) -> Self {
+    fn new(
+        theme: &'a ThemeData,
+        color_map: &'a ColorMapData,
+        table_styles: &'a table_styles::TableStyleMap,
+    ) -> Self {
         Self {
             theme,
             color_map,
+            table_styles,
 
             column_widths: Vec::new(),
             rows: Vec::new(),
+            table_props: table_styles::PptxTableProps::default(),
+            is_in_tbl_pr: false,
+            is_in_table_style_id: false,
 
             is_in_row: false,
             row_height_emu: 0,
@@ -145,6 +157,13 @@ impl<'a> PptxTableParser<'a> {
     ) -> Result<(), ConvertError> {
         let local = e.local_name();
         match local.as_ref() {
+            b"tblPr" => {
+                self.is_in_tbl_pr = true;
+                self.parse_tbl_pr_attrs(e);
+            }
+            b"tableStyleId" if self.is_in_tbl_pr => {
+                self.is_in_table_style_id = true;
+            }
             b"gridCol" => {
                 if let Some(width) = get_attr_i64(e, b"w") {
                     self.column_widths.push(emu_to_pt(width));
@@ -236,6 +255,9 @@ impl<'a> PptxTableParser<'a> {
     fn handle_empty(&mut self, e: &BytesStart) {
         let local = e.local_name();
         match local.as_ref() {
+            b"tblPr" => {
+                self.parse_tbl_pr_attrs(e);
+            }
             b"gridCol" => {
                 if let Some(width) = get_attr_i64(e, b"w") {
                     self.column_widths.push(emu_to_pt(width));
@@ -296,7 +318,11 @@ impl<'a> PptxTableParser<'a> {
     // ── Text / GeneralRef events ────────────────────────────────────
 
     fn handle_text(&mut self, text: &quick_xml::events::BytesText<'_>) {
-        if self.is_in_text
+        if self.is_in_table_style_id {
+            if let Some(decoded) = decode_pptx_text_event(text) {
+                self.table_props.style_id = Some(decoded);
+            }
+        } else if self.is_in_text
             && let Some(decoded) = decode_pptx_text_event(text)
         {
             self.run_text.push_str(&decoded);
@@ -318,6 +344,12 @@ impl<'a> PptxTableParser<'a> {
         let local = e.local_name();
         match local.as_ref() {
             b"tbl" => return true,
+            b"tblPr" if self.is_in_tbl_pr => {
+                self.is_in_tbl_pr = false;
+            }
+            b"tableStyleId" if self.is_in_table_style_id => {
+                self.is_in_table_style_id = false;
+            }
             b"tr" if self.is_in_row => {
                 self.finish_row();
             }
@@ -362,14 +394,27 @@ impl<'a> PptxTableParser<'a> {
     // ── Consume accumulated state into the final Table ──────────────
 
     fn finish(self) -> Table {
-        Table {
+        let header_row_count: usize = if self.table_props.first_row { 1 } else { 0 };
+        let mut table = Table {
             rows: self.rows,
             column_widths: self.column_widths,
-            header_row_count: 0,
+            header_row_count,
             alignment: None,
             default_cell_padding: Some(default_pptx_table_cell_padding()),
             use_content_driven_row_heights: true,
-        }
+        };
+        table_styles::apply_table_style(&mut table, &self.table_props, self.table_styles);
+        table
+    }
+
+    /// Extract tblPr attributes (firstRow, bandRow, etc.)
+    fn parse_tbl_pr_attrs(&mut self, e: &BytesStart) {
+        self.table_props.first_row = get_attr_str(e, b"firstRow").as_deref() == Some("1");
+        self.table_props.last_row = get_attr_str(e, b"lastRow").as_deref() == Some("1");
+        self.table_props.first_col = get_attr_str(e, b"firstCol").as_deref() == Some("1");
+        self.table_props.last_col = get_attr_str(e, b"lastCol").as_deref() == Some("1");
+        self.table_props.band_row = get_attr_str(e, b"bandRow").as_deref() == Some("1");
+        self.table_props.band_col = get_attr_str(e, b"bandCol").as_deref() == Some("1");
     }
 
     // ── Private helpers: cell lifecycle ──────────────────────────────
@@ -735,8 +780,9 @@ pub(super) fn parse_pptx_table(
     reader: &mut Reader<&[u8]>,
     theme: &ThemeData,
     color_map: &ColorMapData,
+    table_styles: &table_styles::TableStyleMap,
 ) -> Result<Table, ConvertError> {
-    let mut state = PptxTableParser::new(theme, color_map);
+    let mut state = PptxTableParser::new(theme, color_map, table_styles);
 
     loop {
         match reader.read_event() {

--- a/crates/office2pdf/src/parser/pptx_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_tests.rs
@@ -489,6 +489,9 @@ use self::theme_tests::{
 #[path = "pptx_table_tests.rs"]
 mod table_tests;
 
+#[path = "pptx_table_style_tests.rs"]
+mod table_style_tests;
+
 #[path = "pptx_slide_feature_tests.rs"]
 mod slide_feature_tests;
 

--- a/crates/office2pdf/src/parser/pptx_theme.rs
+++ b/crates/office2pdf/src/parser/pptx_theme.rs
@@ -27,6 +27,8 @@ pub(super) struct ParsedColor {
 
 #[derive(Debug, Clone, Copy)]
 enum ColorTransform {
+    Tint(f64),
+    Shade(f64),
     LumMod(f64),
     LumOff(f64),
 }
@@ -176,6 +178,8 @@ fn parse_base_color(
 fn parse_color_transform(element: &BytesStart<'_>) -> Option<ColorTransform> {
     let val = get_attr_i64(element, b"val")? as f64 / 100_000.0;
     match element.local_name().as_ref() {
+        b"tint" => Some(ColorTransform::Tint(val)),
+        b"shade" => Some(ColorTransform::Shade(val)),
         b"lumMod" => Some(ColorTransform::LumMod(val)),
         b"lumOff" => Some(ColorTransform::LumOff(val)),
         _ => None,
@@ -183,7 +187,43 @@ fn parse_color_transform(element: &BytesStart<'_>) -> Option<ColorTransform> {
 }
 
 fn apply_color_transforms(color: Color, transforms: &[ColorTransform]) -> Color {
-    let (mut hue, mut saturation, mut lightness) = rgb_to_hsl(color);
+    // Apply tint/shade in RGB space first (OOXML spec: blend toward white/black).
+    let mut r: f64 = color.r as f64;
+    let mut g: f64 = color.g as f64;
+    let mut b: f64 = color.b as f64;
+
+    for transform in transforms {
+        match transform {
+            ColorTransform::Tint(t) => {
+                r = 255.0 - (255.0 - r) * t;
+                g = 255.0 - (255.0 - g) * t;
+                b = 255.0 - (255.0 - b) * t;
+            }
+            ColorTransform::Shade(s) => {
+                r *= s;
+                g *= s;
+                b *= s;
+            }
+            _ => {}
+        }
+    }
+
+    let tinted = Color::new(
+        r.round().clamp(0.0, 255.0) as u8,
+        g.round().clamp(0.0, 255.0) as u8,
+        b.round().clamp(0.0, 255.0) as u8,
+    );
+
+    // Then apply luminance transforms in HSL space.
+    let has_lum_transforms: bool = transforms
+        .iter()
+        .any(|t| matches!(t, ColorTransform::LumMod(_) | ColorTransform::LumOff(_)));
+
+    if !has_lum_transforms {
+        return tinted;
+    }
+
+    let (mut hue, mut saturation, mut lightness) = rgb_to_hsl(tinted);
 
     for transform in transforms {
         match transform {
@@ -193,6 +233,7 @@ fn apply_color_transforms(color: Color, transforms: &[ColorTransform]) -> Color 
             ColorTransform::LumOff(value) => {
                 lightness = (lightness + value).clamp(0.0, 1.0);
             }
+            _ => {}
         }
     }
 

--- a/crates/office2pdf/src/parser/pptx_theme_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_theme_tests.rs
@@ -533,7 +533,8 @@ fn test_no_theme_scheme_color_ignored() {
 }
 
 #[test]
-fn test_scheme_color_as_start_element() {
+fn test_scheme_color_tint_blends_toward_white() {
+    // accent3=#A5A5A5 with tint 50% → each channel: 255 - (255-165)*0.5 = 210 = 0xD2
     let shape_xml = r#"<p:sp><p:nvSpPr><p:cNvPr id="2" name="Shape"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1000000" cy="1000000"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:solidFill><a:schemeClr val="accent3"><a:tint val="50000"/></a:schemeClr></a:solidFill></p:spPr></p:sp>"#;
     let slide = make_slide_xml(&[shape_xml.to_string()]);
     let theme_xml = make_theme_xml(&standard_theme_colors(), "Calibri Light", "Calibri");
@@ -544,7 +545,25 @@ fn test_scheme_color_as_start_element() {
 
     let page = first_fixed_page(&doc);
     let shape = get_shape(&page.elements[0]);
-    assert_eq!(shape.fill, Some(Color::new(0xA5, 0xA5, 0xA5)));
+    assert_eq!(shape.fill, Some(Color::new(0xD2, 0xD2, 0xD2)));
+}
+
+#[test]
+fn test_scheme_color_shade_blends_toward_black() {
+    // accent1=#4472C4 with shade 50% → each channel * 0.5 → (34, 57, 98)
+    let shape_xml = r#"<p:sp><p:nvSpPr><p:cNvPr id="2" name="Shape"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1000000" cy="1000000"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:solidFill><a:schemeClr val="accent1"><a:shade val="50000"/></a:schemeClr></a:solidFill></p:spPr></p:sp>"#;
+    let slide = make_slide_xml(&[shape_xml.to_string()]);
+    let theme_xml = make_theme_xml(&standard_theme_colors(), "Calibri Light", "Calibri");
+    let data = build_test_pptx_with_theme(SLIDE_CX, SLIDE_CY, &[slide], &theme_xml);
+
+    let parser = PptxParser;
+    let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
+
+    let page = first_fixed_page(&doc);
+    let shape = get_shape(&page.elements[0]);
+    // accent1 = (0x44, 0x72, 0xC4) = (68, 114, 196)
+    // shade 50%: (34, 57, 98) = (0x22, 0x39, 0x62)
+    assert_eq!(shape.fill, Some(Color::new(0x22, 0x39, 0x62)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Parse `tableStyles.xml` and resolve theme-based colors (schemeClr, srgbClr, sysClr) with tint/shade transforms
- Apply table style regions (firstRow, lastRow, firstCol, lastCol, band1H, band2H, wholeTbl) during table parsing
- Respect explicit cell-level overrides over style-derived values

## Test plan
- [x] Unit tests for `parse_table_styles_xml` (solid fill, scheme colors, banded rows, color transforms)
- [x] Unit tests for `apply_table_style` (header fill, banding with skip, explicit override, missing style noop)
- [x] Integration tests: end-to-end PPTX with `tableStyles.xml` → correct IR table output
- [x] Full test suite passes (1,418 tests, 0 failures)
- [x] Visual comparison against PowerPoint ground truth on real PPTX (slides 5, 21, 24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)