### PR TITLE
fix: preserve pptx no-wrap auto-fit title spacing

### DIFF
--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -1125,7 +1125,7 @@ fn generate_floating_text_box_content(
 }
 
 fn single_line_fit_paragraph(text_box: &TextBoxData, inner_height_pt: f64) -> Option<&Paragraph> {
-    if text_box.no_wrap {
+    if text_box.no_wrap && !text_box.auto_fit {
         return None;
     }
     let [Block::Paragraph(paragraph)] = text_box.content.as_slice() else {

--- a/crates/office2pdf/src/render/typst_gen_fixed_page_textbox_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_fixed_page_textbox_tests.rs
@@ -1216,6 +1216,85 @@ fn test_fixed_page_text_box_auto_fit_short_text_uses_scale_to_fit() {
 }
 
 #[test]
+fn test_fixed_page_text_box_no_wrap_auto_fit_uses_scale_to_fit() {
+    let doc = make_doc(vec![make_fixed_page(
+        960.0,
+        540.0,
+        vec![FixedElement {
+            x: 295.0,
+            y: 78.0,
+            width: 143.16,
+            height: 58.15,
+            kind: FixedElementKind::TextBox(crate::ir::TextBoxData {
+                content: vec![Block::Paragraph(Paragraph {
+                    style: ParagraphStyle::default(),
+                    runs: vec![
+                        Run {
+                            text: "- ".to_string(),
+                            style: TextStyle {
+                                font_size: Some(41.99),
+                                ..TextStyle::default()
+                            },
+                            href: None,
+                            footnote: None,
+                        },
+                        Run {
+                            text: "목 차 ".to_string(),
+                            style: TextStyle {
+                                font_size: Some(41.99),
+                                ..TextStyle::default()
+                            },
+                            href: None,
+                            footnote: None,
+                        },
+                        Run {
+                            text: "-".to_string(),
+                            style: TextStyle {
+                                font_size: Some(41.99),
+                                ..TextStyle::default()
+                            },
+                            href: None,
+                            footnote: None,
+                        },
+                    ],
+                })],
+                padding: Insets::default(),
+                vertical_align: crate::ir::TextBoxVerticalAlign::Top,
+                fill: None,
+                opacity: None,
+                stroke: None,
+                shape_kind: None,
+                no_wrap: true,
+                auto_fit: true,
+            }),
+        }],
+    )]);
+    let output = generate_typst(&doc).unwrap();
+    assert!(
+        output.source.contains("#let text_box_raw_0 = ["),
+        "Expected no-wrap auto-fit title to use raw single-line measurement, got:\n{}",
+        output.source,
+    );
+    assert!(
+        output.source.contains("let text_box_scale_width_0 ="),
+        "Expected no-wrap auto-fit title to compute width scale, got:\n{}",
+        output.source,
+    );
+    assert!(
+        output.source.contains("let text_box_scale_height_0 ="),
+        "Expected no-wrap auto-fit title to compute height scale, got:\n{}",
+        output.source,
+    );
+    assert!(
+        output.source.contains(
+            "#scale(x: text_box_scale_0, y: text_box_scale_0, origin: top + left, reflow: true)["
+        ),
+        "Expected no-wrap auto-fit title to use scale-to-fit, got:\n{}",
+        output.source,
+    );
+}
+
+#[test]
 fn test_fixed_page_text_box_mixed_font_header_uses_scale_to_fit() {
     let doc = make_doc(vec![make_fixed_page(
         960.0,


### PR DESCRIPTION
What changed
- allow fixed PPTX text boxes with both no-wrap and auto-fit enabled to use the single-line scale-to-fit path
- add regression coverage for tight no-wrap auto-fit title boxes so the scaled Typst output matches the intended fixed-height PPT box

Why
- a classified PPTX fixture regressed on slide 2 where a no-wrap auto-fit title rendered too tall and overlapped the first list item

Validation
- cargo test --offline -p office2pdf fixed_page_textbox_tests
- rebuilt the CLI and regenerated the classified fixture PDF for visual verification of slide 2

Related: #111