### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/crates/office2pdf-cli/Cargo.toml
+++ b/crates/office2pdf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf-cli"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ path = "src/main.rs"
 server = ["tiny_http"]
 
 [dependencies]
-office2pdf = { version = "0.4.0", path = "../office2pdf", features = ["pdf-ops"] }
+office2pdf = { version = "0.5.0", path = "../office2pdf", features = ["pdf-ops"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 rayon = "1"

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- Bump `office2pdf` and `office2pdf-cli` versions from 0.4.0 to 0.5.0
- Update CLI's `office2pdf` dependency version to 0.5.0

## Test plan
- [ ] CI passes
- [ ] `cargo check` succeeds with updated versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)