### PR TITLE
Fix #178: Use web_time::Instant for wasm32 target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
   wasm-check:
-    name: WASM Check
+    name: WASM Check & Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -66,6 +66,15 @@ jobs:
           key: wasm
       - run: cargo check --target wasm32-unknown-unknown -p office2pdf
       - run: cargo check --target wasm32-unknown-unknown -p office2pdf --features wasm
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+      # Runs the wasm integration tests in src/wasm.rs under Node, exercising
+      # the wasm32 time paths (Instant/SystemTime) end-to-end so the issue #178
+      # class of runtime panic cannot regress unnoticed.
+      - name: Run wasm tests in Node
+        working-directory: crates/office2pdf
+        run: wasm-pack test --node --features wasm
 
   fmt:
     name: Format

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -50,9 +50,14 @@ web-time = "1.1"
 wasm-bindgen-test = "0.3"
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
 paste = "1"
 pdf-extract = "0.10"
+
+# criterion pulls rayon, which fails to compile for wasm32. Keep the benchmark
+# harness off wasm targets so `wasm-pack test` (which builds all dev-deps) can
+# build and run the wasm integration tests in src/wasm.rs.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]
 name = "conversion"

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["pdf", "docx", "xlsx", "pptx", "converter"]
 categories = ["text-processing"]
 
 [features]
-wasm = ["wasm-bindgen", "web-time"]
+wasm = ["wasm-bindgen"]
 pdf-ops = ["lopdf"]
 typescript = ["ts-rs"]
 
@@ -36,11 +36,15 @@ image = "0.25"
 tracing = "0.1"
 wasm-bindgen = { version = "0.2", optional = true }
 ts-rs = { version = "12", optional = true }
-web-time = { version = "1.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
 getrandom = { version = "0.3", features = ["wasm_js"] }
+# `std::time::{Instant, SystemTime}` panic with "time not implemented on this
+# platform" on wasm32-unknown-unknown. web-time shims them via the browser
+# clock and re-exports std on every other target. Kept out of the `wasm`
+# feature so a no-feature wasm32 build (CI `wasm-check` step 1) still compiles.
+web-time = "1.1"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["pdf", "docx", "xlsx", "pptx", "converter"]
 categories = ["text-processing"]
 
 [features]
-wasm = ["wasm-bindgen"]
+wasm = ["wasm-bindgen", "web-time"]
 pdf-ops = ["lopdf"]
 typescript = ["ts-rs"]
 
@@ -20,7 +20,10 @@ thiserror = "2"
 lopdf = { version = "0.39", optional = true }
 typst = "0.14"
 typst-pdf = "0.14"
-typst-kit = { version = "0.14", default-features = false, features = ["fonts", "embed-fonts"] }
+typst-kit = { version = "0.14", default-features = false, features = [
+    "fonts",
+    "embed-fonts",
+] }
 comemo = "0.5"
 docx-rs = "0.4"
 serde = "1"
@@ -33,6 +36,7 @@ image = "0.25"
 tracing = "0.1"
 wasm-bindgen = { version = "0.2", optional = true }
 ts-rs = { version = "12", optional = true }
+web-time = { version = "1.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }

--- a/crates/office2pdf/examples/custom_options.rs
+++ b/crates/office2pdf/examples/custom_options.rs
@@ -3,13 +3,19 @@
 //! Usage:
 //!   cargo run --example custom_options -- input.pptx output.pdf
 
-use std::env;
-use std::fs;
-use std::process;
+// `office2pdf::convert_with_options` reads from the filesystem and is not
+// available on wasm32. Keep a stub so the example still compiles for that target.
+#[cfg(target_arch = "wasm32")]
+fn main() {}
 
-use office2pdf::config::{ConvertOptions, PaperSize, SlideRange};
-
+#[cfg(not(target_arch = "wasm32"))]
 fn main() {
+    use std::env;
+    use std::fs;
+    use std::process;
+
+    use office2pdf::config::{ConvertOptions, PaperSize, SlideRange};
+
     let args: Vec<String> = env::args().collect();
     if args.len() != 3 {
         eprintln!("Usage: {} <input> <output.pdf>", args[0]);

--- a/crates/office2pdf/examples/simple_convert.rs
+++ b/crates/office2pdf/examples/simple_convert.rs
@@ -3,11 +3,17 @@
 //! Usage:
 //!   cargo run --example simple_convert -- input.docx output.pdf
 
-use std::env;
-use std::fs;
-use std::process;
+// `office2pdf::convert` reads from the filesystem and is not available on
+// wasm32. Keep a stub so the example still compiles for that target.
+#[cfg(target_arch = "wasm32")]
+fn main() {}
 
+#[cfg(not(target_arch = "wasm32"))]
 fn main() {
+    use std::env;
+    use std::fs;
+    use std::process;
+
     let args: Vec<String> = env::args().collect();
     if args.len() != 3 {
         eprintln!("Usage: {} <input> <output.pdf>", args[0]);

--- a/crates/office2pdf/src/lib_conversion_tests.rs
+++ b/crates/office2pdf/src/lib_conversion_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))] // native-only unit tests (filesystem, system fonts)
 use super::test_support::{build_test_docx, build_test_pptx, build_test_xlsx};
 use super::*;
 

--- a/crates/office2pdf/src/lib_pipeline.rs
+++ b/crates/office2pdf/src/lib_pipeline.rs
@@ -1,5 +1,8 @@
 use std::collections::HashSet;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 use crate::config::{ConvertOptions, Format};
 use crate::error::{ConvertError, ConvertMetrics, ConvertResult, ConvertWarning};

--- a/crates/office2pdf/src/lib_pipeline_tests.rs
+++ b/crates/office2pdf/src/lib_pipeline_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))] // native-only unit tests (filesystem, system fonts)
 use super::test_support::{
     build_docx_with_title, build_test_docx, make_simple_document, make_test_docx_bytes,
 };

--- a/crates/office2pdf/src/render/font_context_tests.rs
+++ b/crates/office2pdf/src/render/font_context_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))] // native-only unit tests (filesystem, system fonts)
 use super::*;
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/crates/office2pdf/src/render/font_subst_tests.rs
+++ b/crates/office2pdf/src/render/font_subst_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))] // native-only unit tests (filesystem, system fonts)
 use super::*;
 
 // --- substitutes() tests ---

--- a/crates/office2pdf/src/render/pdf.rs
+++ b/crates/office2pdf/src/render/pdf.rs
@@ -2,7 +2,12 @@ use std::collections::HashMap;
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
+// `SystemTime::now()` panics on wasm32-unknown-unknown; web-time shims it there
+// and re-exports std elsewhere. Mirrors the `Instant` handling in lib_pipeline.
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(target_arch = "wasm32")]
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use typst::diag::FileResult;
 use typst::foundations::{Bytes, Datetime};

--- a/crates/office2pdf/src/render/pdf_tests.rs
+++ b/crates/office2pdf/src/render/pdf_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))] // native-only unit tests (filesystem, system fonts)
 use super::*;
 
 #[test]

--- a/crates/office2pdf/tests/artifact_generator.rs
+++ b/crates/office2pdf/tests/artifact_generator.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))] // native-only integration tests (fs, qpdf, criterion)
 //! Artifact generator for visual comparison of classified fixtures.
 //!
 //! Converts each input file, renders both output and ground truth PDFs to PNGs,

--- a/crates/office2pdf/tests/bulk_conversion.rs
+++ b/crates/office2pdf/tests/bulk_conversion.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))] // native-only integration tests (fs, qpdf, criterion)
 //! Bulk conversion smoke tests for all fixture files.
 //!
 //! These tests iterate over ALL fixture files in `tests/fixtures/` and attempt

--- a/crates/office2pdf/tests/docx_fixtures.rs
+++ b/crates/office2pdf/tests/docx_fixtures.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))] // native-only integration tests (fs, qpdf, criterion)
 //! Integration tests for DOCX fixtures.
 //!
 //! Each real-world `.docx` file in `tests/fixtures/docx/` gets two tests:

--- a/crates/office2pdf/tests/pdf_validation.rs
+++ b/crates/office2pdf/tests/pdf_validation.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))] // native-only integration tests (fs, qpdf, criterion)
 //! PDF validation tests using qpdf.
 //!
 //! These tests convert real fixture files to PDF and validate the output

--- a/crates/office2pdf/tests/perf_validation.rs
+++ b/crates/office2pdf/tests/perf_validation.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))] // native-only integration tests (fs, qpdf, criterion)
 //! Performance validation tests with tiered targets.
 //!
 //! Three tiers based on document complexity:

--- a/crates/office2pdf/tests/pptx_fixtures.rs
+++ b/crates/office2pdf/tests/pptx_fixtures.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))] // native-only integration tests (fs, qpdf, criterion)
 //! Integration tests for PPTX fixtures.
 //!
 //! Each real-world `.pptx` file in `tests/fixtures/pptx/` gets two tests:

--- a/crates/office2pdf/tests/xlsx_fixtures.rs
+++ b/crates/office2pdf/tests/xlsx_fixtures.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))] // native-only integration tests (fs, qpdf, criterion)
 //! Integration tests for XLSX fixtures.
 //!
 //! Each real-world `.xlsx` file in `tests/fixtures/xlsx/` gets two tests:


### PR DESCRIPTION
Addresses #178 — the `wasm` build compiled for `wasm32-unknown-unknown` but panicked at runtime with `time not implemented on this platform`, because `std::time::Instant::now()` (and `SystemTime::now()`) are not implemented on that target.

## What changed

- **`lib_pipeline.rs`** (original commit by @yourlogarithm): use `web_time::Instant` on `wasm32`, `std::time::Instant` elsewhere.
- **`Cargo.toml`**: `web-time` is declared under `[target.'cfg(target_arch = "wasm32")'.dependencies]` instead of being tied to the `wasm` feature. It is therefore always available on `wasm32` (regardless of the `wasm` feature) and a zero-cost `std` re-export on every other target — mirroring the existing `getrandom` setup. This also supports `wasm32-wasi` consumers.
- **`render/pdf.rs`**: `current_utc_datetime()` used an unconditional `SystemTime::now()` for PDF/A and PDF/UA timestamps, which panics the same way on `wasm32`. It now uses `web_time::SystemTime` on `wasm32`.

## Why the dependency is target-scoped, not feature-scoped

`mod pipeline` (which uses `Instant`) is compiled unconditionally, and the import is gated on `target_arch`, not on the `wasm` feature. If `web-time` were only pulled in by the `wasm` feature, the CI `wasm-check` step `cargo check --target wasm32-unknown-unknown -p office2pdf` (no `--features wasm`) would fail with `E0432: unresolved module or unlinked crate web_time`. Scoping the dependency to the `wasm32` target keeps that build green.

## CI now runs the wasm tests (regression guard)

Previously the `wasm-check` job only ran `cargo check`, so the wasm integration tests in `src/wasm.rs` were never executed and the original panic went uncaught. This PR makes CI actually run them via `wasm-pack test --node --features wasm`. Because `wasm-pack test` builds every test target + dev-dependency for wasm32, the native-only pieces are gated off wasm so the wasm tests can build:

- `criterion` (pulls rayon, no wasm support) moved to non-wasm32 dev-dependencies.
- Native unit-test modules and the fixture/qpdf integration tests gated behind `cfg(not(target_arch = "wasm32"))`.
- wasm32 stub `main` for the two filesystem examples.

## Verification

- `cargo check --target wasm32-unknown-unknown -p office2pdf` ✓ (no feature) and `--features wasm` ✓
- `cargo check --workspace` / `cargo clippy --workspace --all-targets -D warnings` / `cargo fmt --all -- --check` ✓
- `cargo test -p office2pdf --lib` ✓ (1061 passed)
- `wasm-pack test --node --features wasm` ✓ (6 wasm tests pass in Node: docx/pptx/xlsx + error cases)

`web-time` (1.1) is the de-facto standard `std::time` shim for WASM (used by winit/egui); MSRV 1.60, well within the workspace MSRV (1.89).