### PR TITLE
fix(clippy): collapse nested if into match guard (clippy 1.96)

### DIFF
--- a/crates/office2pdf/src/parser/docx_sections.rs
+++ b/crates/office2pdf/src/parser/docx_sections.rs
@@ -395,15 +395,13 @@ fn extract_hf_run_elements(
                     }));
                 }
             }
-            docx_rs::RunChild::Tab(_) => {
-                if !in_field {
-                    elements.push(HFInline::Run(Run {
-                        text: "\t".to_string(),
-                        style: style.clone(),
-                        href: None,
-                        footnote: None,
-                    }));
-                }
+            docx_rs::RunChild::Tab(_) if !in_field => {
+                elements.push(HFInline::Run(Run {
+                    text: "\t".to_string(),
+                    style: style.clone(),
+                    href: None,
+                    footnote: None,
+                }));
             }
             _ => {}
         }

--- a/crates/office2pdf/src/parser/docx_tables.rs
+++ b/crates/office2pdf/src/parser/docx_tables.rs
@@ -366,17 +366,15 @@ fn extract_cell_content(
             docx_rs::TableCellContent::Paragraph(para) => {
                 convert_paragraph_blocks(para, &mut blocks, images, hyperlinks, style_map, ctx);
             }
-            docx_rs::TableCellContent::Table(nested_table) => {
-                if depth < MAX_TABLE_DEPTH {
-                    blocks.push(Block::Table(convert_table(
-                        nested_table,
-                        images,
-                        hyperlinks,
-                        style_map,
-                        ctx,
-                        depth + 1,
-                    )));
-                }
+            docx_rs::TableCellContent::Table(nested_table) if depth < MAX_TABLE_DEPTH => {
+                blocks.push(Block::Table(convert_table(
+                    nested_table,
+                    images,
+                    hyperlinks,
+                    style_map,
+                    ctx,
+                    depth + 1,
+                )));
             }
             _ => {}
         }

--- a/crates/office2pdf/src/parser/docx_text.rs
+++ b/crates/office2pdf/src/parser/docx_text.rs
@@ -255,10 +255,8 @@ pub(super) fn extract_run_text_skip_column_breaks(run: &docx_rs::Run) -> String 
         match child {
             docx_rs::RunChild::Text(t) => text.push_str(&t.text),
             docx_rs::RunChild::Tab(_) => text.push('\t'),
-            docx_rs::RunChild::Break(br) => {
-                if !is_column_break(br) {
-                    text.push('\n');
-                }
+            docx_rs::RunChild::Break(br) if !is_column_break(br) => {
+                text.push('\n');
             }
             _ => {}
         }

--- a/crates/office2pdf/src/parser/smartart.rs
+++ b/crates/office2pdf/src/parser/smartart.rs
@@ -35,11 +35,9 @@ pub(crate) fn parse_smartart_data_xml(xml: &str) -> Vec<SmartArtNode> {
             "doc" => {
                 doc_id = Some(pt.model_id.clone());
             }
-            "node" => {
-                if !pt.text.is_empty() {
-                    node_texts.insert(pt.model_id.clone(), pt.text.clone());
-                    node_order.push(pt.model_id.clone());
-                }
+            "node" if !pt.text.is_empty() => {
+                node_texts.insert(pt.model_id.clone(), pt.text.clone());
+                node_order.push(pt.model_id.clone());
             }
             _ => {}
         }


### PR DESCRIPTION
## What

clippy **1.96.0** (current `stable`) enforces `collapsible_match`, which flags a `match` arm whose entire body is a single `if`. Four pre-existing parser arms hit it; this folds each `if` condition into the arm as a guard:

- `parser/docx_sections.rs` — `RunChild::Tab(_) if !in_field => …`
- `parser/docx_tables.rs` — `TableCellContent::Table(t) if depth < MAX_TABLE_DEPTH => …`
- `parser/docx_text.rs` — `RunChild::Break(br) if !is_column_break(br) => …`
- `parser/smartart.rs` — `"node" if !pt.text.is_empty() => …`

## Why now

This is **not** new code — it surfaced because the merge of #179 was the first `main` CI run since clippy 1.96 became stable, and the `Clippy` job (`-D warnings`) now fails on these. Unrelated to the wasm fix itself.

## Safety

Each of these matches has a `_ => {}` catch-all, so when the new guard fails the arm falls through to the no-op arm — behavior is identical to the previous `if`.

## Verification

- `cargo +1.96.0 clippy --workspace --all-targets -- -D warnings` ✓ (reproduces the failing CI job; now clean)
- `cargo test -p office2pdf --lib` ✓ (1061 passed)
- `cargo fmt --all -- --check` ✓

Restores `main` to green.