### PR TITLE
chore: publish 0.6.0

### DIFF
--- a/crates/office2pdf-cli/Cargo.toml
+++ b/crates/office2pdf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf-cli"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ path = "src/main.rs"
 server = ["tiny_http"]
 
 [dependencies]
-office2pdf = { version = "0.5.0", path = "../office2pdf", features = ["pdf-ops"] }
+office2pdf = { version = "0.6.0", path = "../office2pdf", features = ["pdf-ops"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 rayon = "1"

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## What changed

Bumps both published crates to `0.6.0` for the next release.

Updated:
- `crates/office2pdf/Cargo.toml` package version
- `crates/office2pdf-cli/Cargo.toml` package version
- CLI crate's `office2pdf` dependency version

## Why

This release includes the DOCX fidelity fixes from #181 and the issue #176 regression fixture from #182.

## Verification

- `cargo test --workspace`

Related: #176