### PR TITLE
chore: publish 0.6.1

### DIFF
--- a/crates/office2pdf-cli/Cargo.toml
+++ b/crates/office2pdf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf-cli"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ path = "src/main.rs"
 server = ["tiny_http"]
 
 [dependencies]
-office2pdf = { version = "0.6.0", path = "../office2pdf", features = ["pdf-ops"] }
+office2pdf = { version = "0.6.1", path = "../office2pdf", features = ["pdf-ops"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 rayon = "1"

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## What changed

- bump `office2pdf` from 0.6.0 to 0.6.1
- bump `office2pdf-cli` from 0.6.0 to 0.6.1
- update the CLI's `office2pdf` dependency to 0.6.1

## Why

Publish the DOCX footer image and RTL text fix from #190 as a patch release.

## Validation

- `cargo test --offline -p office2pdf --lib` (1,076 passed)
- `cargo test --offline -p office2pdf-cli` (15 passed)

Related: #189
