### PR TITLE
fix: preserve DOCX run page breaks

### DIFF
--- a/crates/office2pdf/src/parser/docx.rs
+++ b/crates/office2pdf/src/parser/docx.rs
@@ -43,8 +43,9 @@ use self::styles::{
 use self::tables::convert_table;
 use self::text::{
     extract_doc_default_text_style, extract_paragraph_style, extract_run_style,
-    extract_run_style_id, extract_run_text, extract_run_text_skip_column_breaks,
-    extract_tab_stop_overrides, is_column_break, parse_hex_color, resolve_hyperlink_url,
+    extract_run_style_id, extract_run_text, extract_run_text_skip_layout_breaks,
+    extract_tab_stop_overrides, is_column_break, is_page_break, parse_hex_color,
+    resolve_hyperlink_url,
 };
 #[cfg(test)]
 use self::text::{extract_tab_stops, resolve_highlight_color};
@@ -416,15 +417,16 @@ fn build_text_run(
 }
 
 /// Intermediate results from scanning a run's children for media, text boxes,
-/// and structural elements (column breaks).
+/// and structural page/column breaks.
 struct RunChildrenMedia {
     has_column_break: bool,
+    has_page_break: bool,
     text_box_blocks: Vec<Block>,
 }
 
-/// Scan a run's children for drawings, VML shapes, and column breaks.
-/// Extracted images are pushed to `inline_images`; text boxes and column break
-/// detection are returned in `RunChildrenMedia`.
+/// Scan a run's children for drawings, VML shapes, and layout breaks.
+/// Extracted images are pushed to `inline_images`; text boxes and break detection
+/// are returned in `RunChildrenMedia`.
 fn extract_run_children_media(
     run: &docx_rs::Run,
     images: &ImageMap,
@@ -434,6 +436,7 @@ fn extract_run_children_media(
     inline_images: &mut Vec<Block>,
 ) -> RunChildrenMedia {
     let mut has_column_break: bool = false;
+    let mut has_page_break: bool = false;
     let mut text_box_blocks: Vec<Block> = Vec::new();
 
     for run_child in &run.children {
@@ -474,10 +477,16 @@ fn extract_run_children_media(
         {
             has_column_break = true;
         }
+        if let docx_rs::RunChild::Break(br) = run_child
+            && is_page_break(br)
+        {
+            has_page_break = true;
+        }
     }
 
     RunChildrenMedia {
         has_column_break,
+        has_page_break,
         text_box_blocks,
     }
 }
@@ -585,17 +594,21 @@ fn convert_paragraph_blocks(
                     out.extend(media.text_box_blocks);
                 }
 
-                if media.has_column_break {
-                    // Flush current runs as a paragraph before the column break
+                if media.has_page_break || media.has_column_break {
+                    // Flush current runs as a paragraph before the layout break.
                     if !runs.is_empty() {
                         out.append(&mut inline_images);
                         push_paragraph_from_runs(out, para, resolved_style, is_rtl, &mut runs);
                         emitted_paragraph = true;
                     }
-                    out.push(Block::ColumnBreak);
+                    out.push(if media.has_page_break {
+                        Block::PageBreak
+                    } else {
+                        Block::ColumnBreak
+                    });
 
                     // Still extract any text from this run (after the break)
-                    let text: String = extract_run_text_skip_column_breaks(run);
+                    let text: String = extract_run_text_skip_layout_breaks(run);
                     if let Some(ir_run) = build_text_run(
                         text,
                         &run.run_property,

--- a/crates/office2pdf/src/parser/docx_layout_rtl_tests.rs
+++ b/crates/office2pdf/src/parser/docx_layout_rtl_tests.rs
@@ -250,6 +250,30 @@ fn test_parse_docx_column_break() {
 }
 
 #[test]
+fn test_parse_docx_run_page_break() {
+    let data = build_docx_bytes(vec![
+        docx_rs::Paragraph::new()
+            .add_run(docx_rs::Run::new().add_text("Before"))
+            .add_run(docx_rs::Run::new().add_break(docx_rs::BreakType::Page))
+            .add_run(docx_rs::Run::new().add_text("After")),
+    ]);
+    let parser = DocxParser;
+    let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
+
+    let flow = match &doc.pages[0] {
+        Page::Flow(flow) => flow,
+        _ => panic!("Expected FlowPage"),
+    };
+
+    assert!(
+        flow.content
+            .iter()
+            .any(|block| matches!(block, Block::PageBreak)),
+        "a run-level page break should remain a structural page break"
+    );
+}
+
+#[test]
 fn test_parse_docx_single_column_no_layout() {
     let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">

--- a/crates/office2pdf/src/parser/docx_text.rs
+++ b/crates/office2pdf/src/parser/docx_text.rs
@@ -240,22 +240,26 @@ pub(super) fn resolve_hyperlink_url(
 }
 
 pub(super) fn is_column_break(br: &docx_rs::Break) -> bool {
-    serde_json::to_value(br)
-        .ok()
-        .and_then(|v| {
-            v.get("breakType")
-                .and_then(|bt| bt.as_str().map(|s| s == "column"))
-        })
-        .unwrap_or(false)
+    break_type(br).as_deref() == Some("column")
 }
 
-pub(super) fn extract_run_text_skip_column_breaks(run: &docx_rs::Run) -> String {
+pub(super) fn is_page_break(br: &docx_rs::Break) -> bool {
+    break_type(br).as_deref() == Some("page")
+}
+
+fn break_type(br: &docx_rs::Break) -> Option<String> {
+    serde_json::to_value(br)
+        .ok()
+        .and_then(|value| value.get("breakType")?.as_str().map(String::from))
+}
+
+pub(super) fn extract_run_text_skip_layout_breaks(run: &docx_rs::Run) -> String {
     let mut text = String::new();
     for child in &run.children {
         match child {
             docx_rs::RunChild::Text(t) => text.push_str(&t.text),
             docx_rs::RunChild::Tab(_) => text.push('\t'),
-            docx_rs::RunChild::Break(br) if !is_column_break(br) => {
+            docx_rs::RunChild::Break(br) if !is_column_break(br) && !is_page_break(br) => {
                 text.push('\n');
             }
             _ => {}


### PR DESCRIPTION
## What changed

- preserve run-level DOCX page breaks as structural PDF page breaks
- keep ordinary line breaks as text newlines
- share layout-break filtering between page and column breaks
- add a parser regression for `w:br w:type="page"`

## Why

A Microsoft Word ground-truth visual audit found three public real-world DOCX fixtures collapsing from two pages to one. Their explicit run-level page breaks were previously converted to newlines, moving page-two body content onto page one.

## Visual verification

After the fix, `DiffFirstPageHeadFoot.docx`, `FancyFoot.docx`, and `HeaderFooterUnicode.docx` all render as two pages, matching Word. Paired PNG inspection confirmed that page-two body content is restored to the correct page.

## Tests

- `cargo test -p office2pdf --lib --quiet` (1,077 passed)
- `cargo test -p office2pdf --test docx_fixtures --quiet` (146 passed)

Related: #189
