### PR TITLE
docs: require upstream dependency fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@
 
 - Always read and follow the rules defined in `CLAUDE.md` before starting any task.
 - For visual bug fixes, store reproducible before/after images under `assets/bugfixes/issue-<number>/`.
+- If a dependency limitation or bug breaks PDF conversion, clone that library, fix and test it upstream, and open a PR. Follow its repository conventions and match the tone and scope of its recently merged PRs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@
 - If no relevant project exists in `references/`, search the web for well-maintained open-source projects that solve similar problems. Search across all languages — architectural patterns transfer regardless of language.
 - When a new useful project is discovered and `references/` exists, add it to `references/INDEX.md` and create a corresponding detail file. Keep detail files under 50 lines.
 - Cite which reference project informed your approach when applying patterns from it.
+- If a dependency limitation or bug breaks PDF conversion, clone that library, fix and test it upstream, and open a PR. Follow its repository conventions and match the tone and scope of its recently merged PRs.
 
 ## Confidentiality
 


### PR DESCRIPTION
## What changed

- Require cloning, fixing, and testing an upstream library when its limitation or bug breaks PDF conversion.
- Require upstream PRs to follow each repository's conventions and match the tone and scope of recently merged PRs.
- Record the rule in both `CLAUDE.md` and `AGENTS.md`.

## Verification

Documentation-only change; runtime tests were not required.