### PR TITLE
chore: publish 0.6.2

### DIFF
--- a/crates/office2pdf-cli/Cargo.toml
+++ b/crates/office2pdf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf-cli"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ path = "src/main.rs"
 server = ["tiny_http"]
 
 [dependencies]
-office2pdf = { version = "0.6.1", path = "../office2pdf", features = ["pdf-ops"] }
+office2pdf = { version = "0.6.2", path = "../office2pdf", features = ["pdf-ops"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 rayon = "1"

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## What changed

- Bump `office2pdf` from 0.6.1 to 0.6.2.
- Bump `office2pdf-cli` from 0.6.1 to 0.6.2.
- Align the CLI dependency on `office2pdf` with 0.6.2.

## Why

Publish the DOCX rendering fixes merged since v0.6.1 as a synchronized library and CLI patch release.

## Verification

- `cargo metadata --no-deps --format-version 1` reports 0.6.2 for both packages.
- `cargo test --workspace` passes.

Related: #177