### PR TITLE
PPTX: skip hidden slides in PDF output

### DIFF
--- a/crates/office2pdf/src/parser/pptx.rs
+++ b/crates/office2pdf/src/parser/pptx.rs
@@ -439,7 +439,9 @@ impl Parser for PptxParser {
                     &table_styles,
                     &mut archive,
                 ) {
-                    Ok((page, slide_warnings)) => {
+                    // Hidden slide (show="0"): PowerPoint omits it from PDF export.
+                    Ok(None) => {}
+                    Ok(Some((page, slide_warnings))) => {
                         warnings.extend(slide_warnings);
                         // Emit structured warnings for fallback-rendered elements
                         if let Page::Fixed(ref fp) = page {

--- a/crates/office2pdf/src/parser/pptx_slide_feature_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_slide_feature_tests.rs
@@ -362,3 +362,95 @@ fn test_slide_filter_range_beyond_total() {
         "Range beyond total slides should produce empty document"
     );
 }
+
+// ── Hidden slide tests ───────────────────────────────────────────────
+
+/// Slide XML whose root `<p:sld>` carries a `show` attribute.
+fn make_slide_xml_with_show(show: &str, shapes: &[String]) -> String {
+    let mut xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?><p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" show="{show}"><p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/>"#
+    );
+    for shape in shapes {
+        xml.push_str(shape);
+    }
+    xml.push_str("</p:spTree></p:cSld></p:sld>");
+    xml
+}
+
+fn page_texts(doc: &Document) -> Vec<String> {
+    doc.pages
+        .iter()
+        .map(|page| {
+            let Page::Fixed(fixed) = page else {
+                panic!("Expected FixedPage");
+            };
+            fixed
+                .elements
+                .iter()
+                .filter_map(|element| match &element.kind {
+                    FixedElementKind::TextBox(text_box) => Some(
+                        text_box
+                            .content
+                            .iter()
+                            .filter_map(|block| match block {
+                                Block::Paragraph(paragraph) => Some(
+                                    paragraph
+                                        .runs
+                                        .iter()
+                                        .map(|run| run.text.clone())
+                                        .collect::<String>(),
+                                ),
+                                _ => None,
+                            })
+                            .collect::<String>(),
+                    ),
+                    _ => None,
+                })
+                .collect::<String>()
+        })
+        .collect()
+}
+
+#[test]
+fn test_hidden_slide_is_skipped() {
+    // PowerPoint omits hidden slides (show="0") from PDF export.
+    let slides = vec![
+        make_slide_xml(&[make_text_box(0, 0, 5_000_000, 500_000, "First")]),
+        make_slide_xml_with_show("0", &[make_text_box(0, 0, 5_000_000, 500_000, "Hidden")]),
+        make_slide_xml(&[make_text_box(0, 0, 5_000_000, 500_000, "Third")]),
+    ];
+    let data = build_test_pptx(SLIDE_CX, SLIDE_CY, &slides);
+
+    let parser = PptxParser;
+    let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
+
+    assert_eq!(page_texts(&doc), vec!["First", "Third"]);
+}
+
+#[test]
+fn test_hidden_slide_with_false_literal_is_skipped() {
+    let slides = vec![
+        make_slide_xml(&[make_text_box(0, 0, 5_000_000, 500_000, "First")]),
+        make_slide_xml_with_show("false", &[make_text_box(0, 0, 5_000_000, 500_000, "Hidden")]),
+    ];
+    let data = build_test_pptx(SLIDE_CX, SLIDE_CY, &slides);
+
+    let parser = PptxParser;
+    let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
+
+    assert_eq!(page_texts(&doc), vec!["First"]);
+}
+
+#[test]
+fn test_visible_show_attribute_keeps_slide() {
+    let slides = vec![make_slide_xml_with_show(
+        "1",
+        &[make_text_box(0, 0, 5_000_000, 500_000, "Visible")],
+    )];
+    let data = build_test_pptx(SLIDE_CX, SLIDE_CY, &slides);
+
+    let parser = PptxParser;
+    let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
+
+    assert_eq!(page_texts(&doc), vec!["Visible"]);
+}

--- a/crates/office2pdf/src/parser/pptx_slide_feature_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_slide_feature_tests.rs
@@ -431,7 +431,10 @@ fn test_hidden_slide_is_skipped() {
 fn test_hidden_slide_with_false_literal_is_skipped() {
     let slides = vec![
         make_slide_xml(&[make_text_box(0, 0, 5_000_000, 500_000, "First")]),
-        make_slide_xml_with_show("false", &[make_text_box(0, 0, 5_000_000, 500_000, "Hidden")]),
+        make_slide_xml_with_show(
+            "false",
+            &[make_text_box(0, 0, 5_000_000, 500_000, "Hidden")],
+        ),
     ];
     let data = build_test_pptx(SLIDE_CX, SLIDE_CY, &slides);
 

--- a/crates/office2pdf/src/parser/pptx_slides.rs
+++ b/crates/office2pdf/src/parser/pptx_slides.rs
@@ -186,7 +186,25 @@ fn resolve_slide_background(
 
 // ── Public entry point ──────────────────────────────────────────────────
 
+/// True when the slide's root `<p:sld>` element carries `show="0"` or
+/// `show="false"` — PowerPoint omits such hidden slides from PDF export.
+fn is_hidden_slide(slide_xml: &str) -> bool {
+    let mut reader: Reader<&[u8]> = Reader::from_str(slide_xml);
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                return e.local_name().as_ref() == b"sld"
+                    && get_attr_str(e, b"show").is_some_and(|v| v == "0" || v == "false");
+            }
+            Ok(Event::Eof) | Err(_) => return false,
+            _ => {}
+        }
+    }
+}
+
 /// Parse a single slide from the archive, returning a Page or an error.
+/// Returns `Ok(None)` for hidden slides, which PowerPoint excludes from
+/// PDF export.
 ///
 /// Resolves the inheritance chain (slide -> layout -> master) and
 /// prepends master/layout elements behind slide elements.
@@ -197,8 +215,13 @@ pub(super) fn parse_single_slide<R: Read + std::io::Seek>(
     theme: &ThemeData,
     table_styles: &table_styles::TableStyleMap,
     archive: &mut ZipArchive<R>,
-) -> Result<(Page, Vec<ConvertWarning>), ConvertError> {
+) -> Result<Option<(Page, Vec<ConvertWarning>)>, ConvertError> {
     let chain: SlideInheritanceChain = resolve_inheritance_chain(slide_path, theme, archive)?;
+
+    if is_hidden_slide(&chain.slide_xml) {
+        tracing::debug!(slide = slide_label, "skipping hidden slide");
+        return Ok(None);
+    }
 
     let slide_images: SlideImageMap = load_slide_images(slide_path, archive);
     let mut warnings: Vec<ConvertWarning> = Vec::new();
@@ -270,7 +293,7 @@ pub(super) fn parse_single_slide<R: Read + std::io::Seek>(
 
     let (background_color, background_gradient) = resolve_slide_background(&chain, theme);
 
-    Ok((
+    Ok(Some((
         Page::Fixed(FixedPage {
             size: slide_size,
             elements,
@@ -278,7 +301,7 @@ pub(super) fn parse_single_slide<R: Read + std::io::Seek>(
             background_gradient,
         }),
         warnings,
-    ))
+    )))
 }
 
 fn describe_assets(assets: impl IntoIterator<Item = String>) -> String {


### PR DESCRIPTION
## Summary

- skip slides whose root `<p:sld>` element carries `show="0"` or `show="false"`, matching Microsoft PowerPoint's PDF export behavior
- detect the flag before parsing the slide layer, so hidden slides cost no layout work
- add coverage for `show="0"`, `show="false"`, and the explicit `show="1"` visible case

## Verification

- `cargo test -p office2pdf`
- `cargo clippy -p office2pdf --all-targets -- -D warnings`
- `git diff --check`
- `poi/2411-Performance_Up.pptx` now converts to 46 pages, exactly matching the PowerPoint GT export (was 48: the two extras were hidden slides 13 and 48, offsetting every later page by one)

Related: #227, #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)