### PR TITLE
CI: fix qpdf smoke-test temp file collision

### DIFF
--- a/crates/office2pdf/tests/common/mod.rs
+++ b/crates/office2pdf/tests/common/mod.rs
@@ -39,14 +39,20 @@ pub fn validate_pdf_with_qpdf(pdf_bytes: &[u8]) -> bool {
         }
     }
 
-    // Write PDF bytes to a temp file
+    // Write PDF bytes to a temp file. Tests run in parallel threads within
+    // one process, so a timestamp alone can collide — two tests would then
+    // overwrite each other's file and qpdf would see a damaged PDF. A
+    // process-wide counter makes each name unique.
+    static TEMP_FILE_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let unique_id: u64 = TEMP_FILE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let temp_path = std::env::temp_dir().join(format!(
-        "office2pdf_test_{}_{}.pdf",
+        "office2pdf_test_{}_{}_{}.pdf",
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
-            .as_nanos()
+            .as_nanos(),
+        unique_id
     ));
 
     std::fs::write(&temp_path, pdf_bytes).expect("should write temp PDF file");


### PR DESCRIPTION
## Summary

- `assert_valid_pdf` named its qpdf temp file with pid + timestamp only; parallel test threads that hit the write within the same clock tick shared one path, overwrote each other's PDF bytes, and qpdf reported `file is damaged`
- observed in the PR #244 CI run: `smoke_formatting` and `smoke_formula_issue` failed together while checking the identical temp path on all three platforms, while the suite passes locally and the change under test touched only PPTX parsing
- append a process-wide atomic counter to the temp name so every validation writes a unique file

## Verification

- `OFFICE2PDF_VALIDATE_PDF=1 cargo test -p office2pdf --test xlsx_fixtures` (validation actually exercised, 141 passed)
- `cargo clippy -p office2pdf --all-targets -- -D warnings`
- `git diff --check`

Related: #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)