### PR TITLE
docs: require fine-detail image analysis in visual checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,16 @@ This project follows a **6-month rolling MSRV policy** (aligned with [tokio](htt
 - **Closing condition.** An issue may be closed only when a fresh GT comparison shows its specific defect gone. Every remaining visible deviation on that comparison must already have its own open issue — file the missing ones before closing.
 - **After images are re-audited.** When posting an after image, re-run the checklist on it; each still-visible deviation gets an issue reference in the PR body ("remaining, tracked in #N").
 
+### Fine-detail analysis (thin and small elements)
+
+Whole-page thumbnails at 80 DPI hide hairlines, dash patterns, font weight, and sub-pixel offsets. For every compared page:
+
+1. **High-DPI pass.** Render both sides at ≥150 DPI (`pdftoppm -r 150`) before judging any checklist item involving stroke width, dash style, font weight/italic, or small glyphs. Never mark those items "OK" from an 80 DPI image.
+2. **Region crops.** For each region containing text, lines, or decorations, cut matched crops from GT and output (`magick input.png -crop WxH+X+Y crop.png`) and view them side by side at full scale.
+3. **Pixel-difference sweep.** Run `magick compare -metric AE -fuzz 5% gt.png out.png diff.png` on size-normalized pages; view `diff.png` and inspect every highlighted cluster. A checklist pass is complete only when each cluster is either explained by an accepted rendering difference (fonts/antialiasing) or captured as an issue.
+4. **Hairline inventory.** Explicitly enumerate elements ≤1pt (rules, underlines, dashed/dotted lines, borders, tick marks) found in GT and confirm each exists in the output at matching position, width, and dash pattern.
+5. **Weight/emphasis inventory.** Enumerate bold/italic/underlined runs visible in GT (including CJK) and confirm the same emphasis in the output — weight differences must be checked on the high-DPI crops, not thumbnails.
+
 When comparing PDF output against ground truth (classified fixtures):
 
 1. Run `cargo test -p office2pdf --test artifact_generator -- --ignored --nocapture` to generate artifacts.


### PR DESCRIPTION
## Summary

- thin/small elements were repeatedly missed on 80 DPI whole-page thumbnails (group-rot's 0.5pt dashed axes → #274; in-cell bold runs → #275)
- extend the visual check discipline with a fine-detail protocol: ≥150 DPI renders for any stroke/dash/weight judgment, matched region crops at full scale, a `magick compare` pixel-difference sweep where every highlighted cluster must be explained or filed, and explicit hairline (≤1pt) and emphasis (bold/italic, incl. CJK) inventories

Related: #274, #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)