### PR TITLE
chore: format row-height test assertions

### DIFF
--- a/crates/office2pdf/src/parser/xlsx_cell_format_tests.rs
+++ b/crates/office2pdf/src/parser/xlsx_cell_format_tests.rs
@@ -1030,8 +1030,7 @@ fn test_wrapping_row_without_custom_height_stays_auto() {
     let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
     let tp = get_sheet_page(&doc, 0);
     assert_eq!(
-        tp.table.rows[0].height,
-        None,
+        tp.table.rows[0].height, None,
         "auto-sized wrapping rows stay content-driven"
     );
 }


### PR DESCRIPTION
## Summary

- PR #305 was merged while its Format check was failing (my process error — the assets amend happened after the last \`cargo fmt\`); this restores rustfmt-clean formatting on main
- No behavior change (test assertion formatting only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)