### PR TITLE
ci: enforce visual pull request audits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,67 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Related issue
+
+<!-- Use "Fixes #N" when this PR fully resolves an issue. -->
+
+## Testing
+
+<!-- List the exact commands and manual checks run. -->
+
+## Visual impact
+
+<!-- Select exactly one. A reason is required when selecting no rendered change. -->
+
+- [ ] No rendered PDF change
+- [ ] Rendered PDF change or visual evidence added
+- Reason: <!-- Required for "No rendered PDF change" -->
+
+## Visual audit
+
+<!-- Required when rendered output changes or assets/bugfixes/ is modified. Delete only when "No rendered PDF change" is selected. -->
+
+- Issue: #<!-- N -->
+- Fixture: <!-- repository path -->
+- Page(s): <!-- compared page numbers -->
+- Renderer and DPI: <!-- e.g. pdftoppm, 150 DPI -->
+- Evidence mode: `fix` <!-- `fix` requires gt/before/after; `defect` requires compare -->
+- GT: `assets/bugfixes/issue-<!-- N -->/gt.jpg`
+- Before: `assets/bugfixes/issue-<!-- N -->/before.jpg`
+- After: `assets/bugfixes/issue-<!-- N -->/after.jpg`
+- Compare: `assets/bugfixes/issue-<!-- N -->/compare.jpg`
+
+### Required inspection
+
+- [ ] Rendered all evidence at 150 DPI or higher
+- [ ] Stored progressive JPEG quality 86 assets with metadata stripped
+- [ ] Inspected matched region crops at full resolution
+- [ ] Ran the 5% fuzz pixel-difference sweep
+- [ ] Inventoried hairlines and border dash styles
+- [ ] Inventoried font weight, italic, and underline emphasis
+
+### Deviation audit
+
+<!-- Every result must start with: Matches GT, Fixed, No deviation observed, or Remaining: #N. -->
+
+| Check | Result |
+| --- | --- |
+| Page count/order | <!-- status --> |
+| Element presence | <!-- status --> |
+| Position/size | <!-- status --> |
+| Rotation/flip | <!-- status --> |
+| Fill | <!-- status --> |
+| Stroke/border | <!-- status --> |
+| Text content | <!-- status --> |
+| Font family/weight/style | <!-- status --> |
+| Text color | <!-- status --> |
+| Alignment | <!-- status --> |
+| Line/paragraph spacing | <!-- status --> |
+| Clipping/overflow | <!-- status --> |
+
+## Checklist
+
+- [ ] Commits include a `Signed-off-by` line
+- [ ] PR scope contains one root cause
+- [ ] Remaining visual deviations each reference an open issue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,31 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  visual-pr-contract:
+    name: Visual PR Contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Test visual PR validator
+        run: python3 -m unittest discover -s scripts/tests -p 'test_check_visual_pr.py'
+      - name: Validate visual PR contract
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 scripts/check_visual_pr.py
+          --event "${GITHUB_EVENT_PATH}"
+          --base "${{ github.event.pull_request.base.sha }}"
+          --head "${{ github.event.pull_request.head.sha }}"
+          --repository "${{ github.repository }}"
+
   check:
     name: Check
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ docs/
 # Ralph (local-only automation, never push to remote)
 scripts/ralph/
 .DS_Store
+__pycache__/
+*.py[cod]

--- a/scripts/check_visual_pr.py
+++ b/scripts/check_visual_pr.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Fail a pull request when its visual audit or evidence is incomplete."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import struct
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+
+VISUAL_ROOT = Path("assets/bugfixes")
+EVIDENCE_PATH = re.compile(
+    r"^assets/bugfixes/issue-(?P<issue>\d+)/(?P<name>gt|before|after|compare)\.(?P<ext>[^/]+)$"
+)
+AUDIT_ROWS = (
+    "Page count/order",
+    "Element presence",
+    "Position/size",
+    "Rotation/flip",
+    "Fill",
+    "Stroke/border",
+    "Text content",
+    "Font family/weight/style",
+    "Text color",
+    "Alignment",
+    "Line/paragraph spacing",
+    "Clipping/overflow",
+)
+INSPECTION_ITEMS = (
+    "Rendered all evidence at 150 DPI or higher",
+    "Stored progressive JPEG quality 86 assets with metadata stripped",
+    "Inspected matched region crops at full resolution",
+    "Ran the 5% fuzz pixel-difference sweep",
+    "Inventoried hairlines and border dash styles",
+    "Inventoried font weight, italic, and underline emphasis",
+)
+ALLOWED_RESULTS = ("Matches GT", "Fixed", "No deviation observed")
+
+
+@dataclass(frozen=True)
+class JpegInfo:
+    width: int
+    height: int
+    progressive: bool
+    density_dpi: tuple[float, float] | None
+    metadata_markers: tuple[str, ...]
+
+
+def extract_section(body: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"(?ms)^{re.escape(heading)}\s*$\n(?P<section>.*?)(?=^##\s|\Z)"
+    )
+    match = pattern.search(body)
+    return match.group("section") if match else ""
+
+
+def checked(section: str, label: str) -> bool:
+    return bool(re.search(rf"(?mi)^- \[[xX]\] {re.escape(label)}\s*$", section))
+
+
+def field(section: str, name: str) -> str | None:
+    match = re.search(rf"(?mi)^- {re.escape(name)}:\s*(.*?)\s*$", section)
+    if not match:
+        return None
+    value = match.group(1).strip().strip("`")
+    if not value or "<!--" in value:
+        return None
+    return value
+
+
+def audit_table(section: str) -> dict[str, str]:
+    rows: dict[str, str] = {}
+    for line in section.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) == 2 and cells[0] in AUDIT_ROWS:
+            rows[cells[0]] = cells[1]
+    return rows
+
+
+def validate_pr_body(body: str, changed_paths: list[str]) -> list[str]:
+    errors: list[str] = []
+    impact = extract_section(body, "## Visual impact")
+    no_change = checked(impact, "No rendered PDF change")
+    visual = checked(impact, "Rendered PDF change or visual evidence added")
+    visual_assets_changed = any(path.startswith(f"{VISUAL_ROOT.as_posix()}/") for path in changed_paths)
+
+    if no_change == visual:
+        errors.append("Select exactly one Visual impact checkbox.")
+        return errors
+
+    if no_change:
+        reason = field(impact, "Reason")
+        if not reason:
+            errors.append("Explain why the PR has no rendered PDF change in Visual impact > Reason.")
+        if visual_assets_changed:
+            errors.append("assets/bugfixes changes require 'Rendered PDF change or visual evidence added'.")
+        return errors
+
+    audit = extract_section(body, "## Visual audit")
+    if not audit:
+        return ["Rendered changes require a ## Visual audit section."]
+
+    issue_value = field(audit, "Issue")
+    issue_match = re.fullmatch(r"#(\d+)", issue_value or "")
+    if not issue_match:
+        errors.append("Visual audit > Issue must be a single issue reference such as #123.")
+        issue_number = None
+    else:
+        issue_number = issue_match.group(1)
+
+    for name in ("Fixture", "Page(s)"):
+        if not field(audit, name):
+            errors.append(f"Visual audit > {name} is required.")
+
+    renderer = field(audit, "Renderer and DPI")
+    dpi_match = re.search(r"(?i)(\d+(?:\.\d+)?)\s*DPI", renderer or "")
+    if not dpi_match or float(dpi_match.group(1)) < 150:
+        errors.append("Visual audit > Renderer and DPI must record at least 150 DPI.")
+
+    mode = field(audit, "Evidence mode")
+    if mode not in {"fix", "defect"}:
+        errors.append("Visual audit > Evidence mode must be `fix` or `defect`.")
+    elif issue_number:
+        expected = (
+            ("GT", "gt"),
+            ("Before", "before"),
+            ("After", "after"),
+        ) if mode == "fix" else (("Compare", "compare"),)
+        for field_name, basename in expected:
+            expected_path = f"assets/bugfixes/issue-{issue_number}/{basename}.jpg"
+            if field(audit, field_name) != expected_path:
+                errors.append(f"Visual audit > {field_name} must be `{expected_path}`.")
+
+    for item in INSPECTION_ITEMS:
+        if not checked(audit, item):
+            errors.append(f"Required visual inspection is not checked: {item}.")
+
+    rows = audit_table(audit)
+    for row in AUDIT_ROWS:
+        result = rows.get(row, "")
+        if not result or "<!--" in result:
+            errors.append(f"Deviation audit row is incomplete: {row}.")
+        elif result.startswith("Remaining:"):
+            if not re.search(r"#\d+", result):
+                errors.append(f"Remaining deviation must reference an issue: {row}.")
+        elif not result.startswith(ALLOWED_RESULTS):
+            errors.append(
+                f"Deviation audit row '{row}' must start with Matches GT, Fixed, "
+                "No deviation observed, or Remaining: #N."
+            )
+
+    if not visual_assets_changed:
+        errors.append("Rendered visual changes require evidence under assets/bugfixes/issue-<number>/.")
+
+    return errors
+
+
+def remaining_issue_numbers(body: str) -> set[int]:
+    audit = extract_section(body, "## Visual audit")
+    numbers: set[int] = set()
+    for result in audit_table(audit).values():
+        if result.startswith("Remaining:"):
+            numbers.update(int(number) for number in re.findall(r"#(\d+)", result))
+    return numbers
+
+
+def validate_open_issues(issue_numbers: set[int], repository: str, token: str | None) -> list[str]:
+    if not issue_numbers:
+        return []
+    if not token:
+        return ["GITHUB_TOKEN is required to verify remaining visual issues."]
+
+    errors: list[str] = []
+    for number in sorted(issue_numbers):
+        url = f"https://api.github.com/repos/{repository}/issues/{number}"
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "User-Agent": "office2pdf-visual-pr-gate",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=15) as response:
+                issue = json.load(response)
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as exc:
+            errors.append(f"Could not verify remaining visual issue #{number}: {exc}.")
+            continue
+        if "pull_request" in issue:
+            errors.append(f"Remaining reference #{number} is a pull request, not an issue.")
+        elif issue.get("state") != "open":
+            errors.append(f"Remaining visual issue #{number} is not open.")
+    return errors
+
+
+def read_jpeg_info(path: Path) -> JpegInfo:
+    data = path.read_bytes()
+    if not data.startswith(b"\xff\xd8"):
+        raise ValueError("not a JPEG file")
+
+    offset = 2
+    width = height = None
+    progressive = False
+    density: tuple[float, float] | None = None
+    metadata: list[str] = []
+
+    while offset + 1 < len(data):
+        if data[offset] != 0xFF:
+            offset += 1
+            continue
+        while offset < len(data) and data[offset] == 0xFF:
+            offset += 1
+        if offset >= len(data):
+            break
+        marker = data[offset]
+        offset += 1
+        if marker in {0xD8, 0xD9, 0x01} or 0xD0 <= marker <= 0xD7:
+            continue
+        if offset + 2 > len(data):
+            raise ValueError("truncated JPEG segment")
+        length = struct.unpack(">H", data[offset : offset + 2])[0]
+        if length < 2 or offset + length > len(data):
+            raise ValueError("invalid JPEG segment length")
+        payload = data[offset + 2 : offset + length]
+        offset += length
+
+        if marker == 0xE0 and payload.startswith(b"JFIF\x00") and len(payload) >= 12:
+            units = payload[7]
+            x_density = struct.unpack(">H", payload[8:10])[0]
+            y_density = struct.unpack(">H", payload[10:12])[0]
+            if units == 1:
+                density = (float(x_density), float(y_density))
+            elif units == 2:
+                density = (x_density * 2.54, y_density * 2.54)
+        elif marker in {0xE1, 0xE2, 0xED, 0xFE}:
+            metadata.append({0xE1: "APP1", 0xE2: "APP2", 0xED: "APP13", 0xFE: "COM"}[marker])
+        elif marker in {0xC0, 0xC1, 0xC2} and len(payload) >= 5:
+            height = struct.unpack(">H", payload[1:3])[0]
+            width = struct.unpack(">H", payload[3:5])[0]
+            progressive = marker == 0xC2
+        elif marker == 0xDA:
+            break
+
+    if width is None or height is None:
+        raise ValueError("JPEG dimensions were not found")
+    return JpegInfo(width, height, progressive, density, tuple(metadata))
+
+
+def validate_jpeg(path: Path) -> list[str]:
+    try:
+        info = read_jpeg_info(path)
+    except (OSError, ValueError) as exc:
+        return [f"{path}: {exc}"]
+
+    errors: list[str] = []
+    if not info.progressive:
+        errors.append(f"{path}: evidence must be a progressive JPEG.")
+    if not info.density_dpi or min(info.density_dpi) < 150:
+        errors.append(f"{path}: JPEG density must be at least 150 DPI.")
+    if info.metadata_markers:
+        markers = ", ".join(info.metadata_markers)
+        errors.append(f"{path}: metadata was not stripped ({markers}).")
+    if path.name == "compare.jpg" and info.width % 2:
+        errors.append(f"{path}: side-by-side comparison width must split into equal panels.")
+    return errors
+
+
+def validate_evidence(changed_paths: list[str], root: Path) -> list[str]:
+    errors: list[str] = []
+    touched: dict[str, set[str]] = {}
+
+    for raw_path in changed_paths:
+        if not raw_path.startswith(f"{VISUAL_ROOT.as_posix()}/"):
+            continue
+        match = EVIDENCE_PATH.fullmatch(raw_path)
+        if not match:
+            errors.append(
+                f"{raw_path}: visual evidence must be gt.jpg, before.jpg, after.jpg, or compare.jpg "
+                "under assets/bugfixes/issue-<number>/."
+            )
+            continue
+        issue = match.group("issue")
+        name = match.group("name")
+        if match.group("ext").lower() != "jpg":
+            errors.append(f"{raw_path}: visual evidence must use the .jpg extension.")
+            continue
+        touched.setdefault(issue, set()).add(name)
+
+    for issue, names in touched.items():
+        issue_dir = root / VISUAL_ROOT / f"issue-{issue}"
+        required = {"gt", "before", "after"} if names & {"gt", "before", "after"} else set()
+        for name in sorted(required | ({"compare"} if "compare" in names else set())):
+            path = issue_dir / f"{name}.jpg"
+            if not path.is_file():
+                errors.append(f"{path}: required evidence file is missing.")
+            else:
+                errors.extend(validate_jpeg(path))
+
+    return errors
+
+
+def git_changed_paths(base: str, head: str, root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", base, head],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", type=Path, required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+
+    event = json.loads(args.event.read_text(encoding="utf-8"))
+    body = event.get("pull_request", {}).get("body") or ""
+    changed_paths = git_changed_paths(args.base, args.head, args.root)
+    errors = validate_pr_body(body, changed_paths)
+    errors.extend(validate_evidence(changed_paths, args.root))
+    errors.extend(
+        validate_open_issues(
+            remaining_issue_numbers(body),
+            args.repository,
+            os.environ.get("GITHUB_TOKEN"),
+        )
+    )
+
+    if errors:
+        for error in errors:
+            print(f"::error::{error}")
+        return 1
+
+    print("Visual pull request contract is complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_visual_pr.py
+++ b/scripts/tests/test_check_visual_pr.py
@@ -1,0 +1,121 @@
+import io
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.check_visual_pr import (
+    AUDIT_ROWS,
+    INSPECTION_ITEMS,
+    read_jpeg_info,
+    validate_evidence,
+    validate_open_issues,
+    validate_pr_body,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def visual_body(result_overrides=None):
+    results = {row: "Matches GT" for row in AUDIT_ROWS}
+    results.update(result_overrides or {})
+    inspections = "\n".join(f"- [x] {item}" for item in INSPECTION_ITEMS)
+    rows = "\n".join(f"| {row} | {results[row]} |" for row in AUDIT_ROWS)
+    return f"""## Visual impact
+
+- [ ] No rendered PDF change
+- [x] Rendered PDF change or visual evidence added
+- Reason:
+
+## Visual audit
+
+- Issue: #186
+- Fixture: tests/fixtures/xlsx/pr_186_contributor_acceptance.xlsx
+- Page(s): 1
+- Renderer and DPI: pdftoppm, 150 DPI
+- Evidence mode: `fix`
+- GT: `assets/bugfixes/issue-186/gt.jpg`
+- Before: `assets/bugfixes/issue-186/before.jpg`
+- After: `assets/bugfixes/issue-186/after.jpg`
+
+### Required inspection
+
+{inspections}
+
+### Deviation audit
+
+| Check | Result |
+| --- | --- |
+{rows}
+"""
+
+
+class PullRequestBodyTests(unittest.TestCase):
+    def test_non_visual_pr_requires_reason(self):
+        body = """## Visual impact
+
+- [x] No rendered PDF change
+- [ ] Rendered PDF change or visual evidence added
+- Reason: Documentation-only workflow change
+"""
+        self.assertEqual(validate_pr_body(body, ["README.md"]), [])
+
+    def test_complete_visual_audit_passes(self):
+        errors = validate_pr_body(
+            visual_body({"Fill": "Remaining: #328"}),
+            ["assets/bugfixes/issue-186/after.jpg"],
+        )
+        self.assertEqual(errors, [])
+
+    def test_remaining_deviation_requires_issue(self):
+        errors = validate_pr_body(
+            visual_body({"Fill": "Remaining: still different"}),
+            ["assets/bugfixes/issue-186/after.jpg"],
+        )
+        self.assertTrue(any("Remaining deviation must reference an issue" in error for error in errors))
+
+    def test_visual_assets_cannot_be_marked_non_visual(self):
+        body = """## Visual impact
+
+- [x] No rendered PDF change
+- [ ] Rendered PDF change or visual evidence added
+- Reason: Documentation only
+"""
+        errors = validate_pr_body(body, ["assets/bugfixes/issue-186/after.jpg"])
+        self.assertTrue(any("assets/bugfixes changes require" in error for error in errors))
+
+
+class EvidenceTests(unittest.TestCase):
+    def test_repository_evidence_is_progressive_150_dpi_jpeg(self):
+        path = ROOT / "assets/bugfixes/issue-186/gt.jpg"
+        info = read_jpeg_info(path)
+        self.assertTrue(info.progressive)
+        self.assertEqual(info.density_dpi, (150.0, 150.0))
+        self.assertEqual(info.metadata_markers, ())
+
+    def test_changed_trio_validates_all_three_files(self):
+        errors = validate_evidence(
+            ["assets/bugfixes/issue-186/after.jpg"],
+            ROOT,
+        )
+        self.assertEqual(errors, [])
+
+    def test_png_evidence_is_rejected(self):
+        errors = validate_evidence(
+            ["assets/bugfixes/issue-186/after.png"],
+            ROOT,
+        )
+        self.assertTrue(any(".jpg extension" in error for error in errors))
+
+
+class OpenIssueTests(unittest.TestCase):
+    @patch("scripts.check_visual_pr.urllib.request.urlopen")
+    def test_remaining_issue_must_be_open(self, urlopen):
+        response = io.BytesIO(b'{"state":"closed"}')
+        urlopen.return_value = response
+        errors = validate_open_issues({328}, "developer0hye/office2pdf", "token")
+        self.assertEqual(errors, ["Remaining visual issue #328 is not open."])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a repository pull request template that makes visual impact explicit
- require fixture, page, renderer/DPI, evidence paths, fine-detail checks, and a complete deviation audit for visual PRs
- validate progressive 150 DPI JPEG evidence and reject metadata-bearing or incorrectly named assets
- verify every `Remaining: #N` reference points to an open GitHub issue

## Related issue

Follow-up process hardening from the #186 visual re-audit in #327.

## Testing

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/tests -p 'test_check_visual_pr.py'` — 8 passed
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_visual_pr.py --event /private/tmp/office2pdf-visual-pr-event.json --base HEAD --head HEAD --repository developer0hye/office2pdf`
- parsed `.github/workflows/ci.yml` with Ruby YAML
- `git diff --check`

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: This PR changes pull request review infrastructure only; it does not change conversion code or generated PDFs.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
