### PR TITLE
ci: recheck visual audit after PR edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, edited]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Run the pull request CI workflow on `pull_request.edited` events so authors can fix a failing visual audit by updating the PR body without adding a no-op commit.

## Related issue

Follow-up to #332, discovered while applying the new gate to #187.

## Testing

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/tests -p 'test_check_visual_pr.py'` — 8 passed
- parsed `.github/workflows/ci.yml` with Ruby YAML
- `git diff --check -- .github/workflows/ci.yml`

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: This PR only changes the pull request event types that start CI.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
