### PR TITLE
ci: record visual follow-up discoveries

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,7 @@
 - Page(s): <!-- compared page numbers -->
 - Renderer and DPI: <!-- e.g. pdftoppm, 150 DPI -->
 - Evidence mode: `fix` <!-- `fix` requires gt/before/after; `defect` requires compare -->
+- New follow-up issues found in this audit: <!-- #N, #N or None; create issues before completing the audit -->
 - GT: `assets/bugfixes/issue-<!-- N -->/gt.jpg`
 - Before: `assets/bugfixes/issue-<!-- N -->/before.jpg`
 - After: `assets/bugfixes/issue-<!-- N -->/after.jpg`

--- a/scripts/check_visual_pr.py
+++ b/scripts/check_visual_pr.py
@@ -141,6 +141,22 @@ def validate_pr_body(body: str, changed_paths: list[str]) -> list[str]:
             if field(audit, field_name) != expected_path:
                 errors.append(f"Visual audit > {field_name} must be `{expected_path}`.")
 
+    follow_up_value = field(audit, "New follow-up issues found in this audit")
+    if not follow_up_value:
+        errors.append("Visual audit must summarize newly discovered follow-up issues or say None.")
+    elif follow_up_value != "None":
+        follow_up_issues = {int(number) for number in re.findall(r"#(\d+)", follow_up_value)}
+        if not follow_up_issues:
+            errors.append("New follow-up issues must use issue references such as #123, or None.")
+        else:
+            remaining_issues = remaining_issue_numbers(body)
+            unclassified = follow_up_issues - remaining_issues
+            if unclassified:
+                references = ", ".join(f"#{number}" for number in sorted(unclassified))
+                errors.append(
+                    f"New follow-up issues must also classify a Remaining deviation: {references}."
+                )
+
     for item in INSPECTION_ITEMS:
         if not checked(audit, item):
             errors.append(f"Required visual inspection is not checked: {item}.")

--- a/scripts/tests/test_check_visual_pr.py
+++ b/scripts/tests/test_check_visual_pr.py
@@ -1,4 +1,5 @@
 import io
+import re
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -19,6 +20,10 @@ ROOT = Path(__file__).resolve().parents[2]
 def visual_body(result_overrides=None):
     results = {row: "Matches GT" for row in AUDIT_ROWS}
     results.update(result_overrides or {})
+    follow_ups = sorted(
+        {number for result in results.values() for number in re.findall(r"#\d+", result)}
+    )
+    follow_up_value = ", ".join(follow_ups) if follow_ups else "None"
     inspections = "\n".join(f"- [x] {item}" for item in INSPECTION_ITEMS)
     rows = "\n".join(f"| {row} | {results[row]} |" for row in AUDIT_ROWS)
     return f"""## Visual impact
@@ -34,6 +39,7 @@ def visual_body(result_overrides=None):
 - Page(s): 1
 - Renderer and DPI: pdftoppm, 150 DPI
 - Evidence mode: `fix`
+- New follow-up issues found in this audit: {follow_up_value}
 - GT: `assets/bugfixes/issue-186/gt.jpg`
 - Before: `assets/bugfixes/issue-186/before.jpg`
 - After: `assets/bugfixes/issue-186/after.jpg`
@@ -73,6 +79,14 @@ class PullRequestBodyTests(unittest.TestCase):
             ["assets/bugfixes/issue-186/after.jpg"],
         )
         self.assertTrue(any("Remaining deviation must reference an issue" in error for error in errors))
+
+    def test_new_follow_up_must_classify_a_remaining_deviation(self):
+        body = visual_body().replace(
+            "New follow-up issues found in this audit: None",
+            "New follow-up issues found in this audit: #328",
+        )
+        errors = validate_pr_body(body, ["assets/bugfixes/issue-186/after.jpg"])
+        self.assertTrue(any("must also classify a Remaining deviation" in error for error in errors))
 
     def test_visual_assets_cannot_be_marked_non_visual(self):
         body = """## Visual impact


### PR DESCRIPTION
## Summary

- add an explicit `New follow-up issues found in this audit` field to the visual PR template
- require each newly discovered issue to classify at least one `Remaining:` deviation
- keep verifying all remaining issue references are real, open GitHub issues

## Related issue

Follow-up to #332, requested while applying the visual audit workflow to #187.

## Testing

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/tests -p 'test_check_visual_pr.py'` — 9 passed
- `python3 -m py_compile scripts/check_visual_pr.py scripts/tests/test_check_visual_pr.py`
- `git diff --check` on the three changed files

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: This PR changes visual audit metadata and validation only.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
