### PR TITLE
ci: build x86_64 macOS release binary on macos-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,9 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             archive: tar.gz
-          - os: macos-13
+          # Intel macOS runners (macos-13) are retired; cross-compile from
+          # the Apple Silicon runner instead.
+          - os: macos-latest
             target: x86_64-apple-darwin
             archive: tar.gz
           - os: windows-latest


### PR DESCRIPTION
## Summary

Move the `x86_64-apple-darwin` release binary build from `macos-13` to `macos-latest` (Apple Silicon), cross-compiling for Intel.

GitHub retired the `macos-13` Intel runners. The backfill run for v0.6.2 ([29746577851](https://github.com/developer0hye/office2pdf/actions/runs/29746577851)) built and uploaded 5 of 6 targets, but the `x86_64-apple-darwin` job sat in the queue for 24h with no runner to pick it up, so the Intel macOS asset never shipped.

The `Build` step already passes `--target ${{ matrix.target }}` and `dtolnay/rust-toolchain` installs the target, so cross-compilation needs no further changes.

## Related issue

Related: #343

## Testing

- CI-only change; no code paths affected. Verified the remaining 5 targets built and uploaded successfully in run [29746577851](https://github.com/developer0hye/office2pdf/actions/runs/29746577851).
- After merge: re-dispatch `release.yml` with `tag=v0.6.2` and confirm the `x86_64-apple-darwin` asset is attached.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: CI workflow config only; no parser/codegen/rendering code touched.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
