### PR TITLE
ci: require rendered visual previews

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,6 +33,20 @@
 - After: `assets/bugfixes/issue-<!-- N -->/after.jpg`
 - Compare: `assets/bugfixes/issue-<!-- N -->/compare.jpg`
 
+### Visual comparison
+
+<!-- Replace each cell comment with rendered Markdown image syntax using a stable commit-pinned raw URL or GitHub attachment URL. -->
+
+| GT | Before | After |
+| --- | --- | --- |
+| <!-- ![GT](IMAGE_URL) --> | <!-- ![Before](IMAGE_URL) --> | <!-- ![After](IMAGE_URL) --> |
+
+<!-- Defect mode only: replace the cell comment with the rendered Compare image and remove the GT/Before/After table. -->
+
+| Compare |
+| --- |
+| <!-- ![Compare](IMAGE_URL) --> |
+
 ### Required inspection
 
 - [ ] Rendered all evidence at 150 DPI or higher

--- a/scripts/check_visual_pr.py
+++ b/scripts/check_visual_pr.py
@@ -42,6 +42,8 @@ INSPECTION_ITEMS = (
     "Inventoried hairlines and border dash styles",
     "Inventoried font weight, italic, and underline emphasis",
 )
+FIX_PREVIEW_LABELS = ("GT", "Before", "After")
+DEFECT_PREVIEW_LABELS = ("Compare",)
 ALLOWED_RESULTS = ("Matches GT", "Fixed", "No deviation observed")
 
 
@@ -85,6 +87,21 @@ def audit_table(section: str) -> dict[str, str]:
         if len(cells) == 2 and cells[0] in AUDIT_ROWS:
             rows[cells[0]] = cells[1]
     return rows
+
+
+def rendered_preview_urls(section: str, labels: tuple[str, ...]) -> dict[str, str]:
+    rendered_markup = re.sub(r"(?s)<!--.*?-->", "", section)
+    rendered_markup = re.sub(r"(?s)```.*?```", "", rendered_markup)
+    rendered_markup = re.sub(r"`[^`\n]*`", "", rendered_markup)
+    urls: dict[str, str] = {}
+    for label in labels:
+        match = re.search(
+            rf"!\[{re.escape(label)}\]\((?P<url>https?://[^\s)]+)\)",
+            rendered_markup,
+        )
+        if match:
+            urls[label] = match.group("url")
+    return urls
 
 
 def validate_pr_body(body: str, changed_paths: list[str]) -> list[str]:
@@ -140,6 +157,23 @@ def validate_pr_body(body: str, changed_paths: list[str]) -> list[str]:
             expected_path = f"assets/bugfixes/issue-{issue_number}/{basename}.jpg"
             if field(audit, field_name) != expected_path:
                 errors.append(f"Visual audit > {field_name} must be `{expected_path}`.")
+
+    preview_labels: tuple[str, ...] = ()
+    if mode == "fix":
+        preview_labels = FIX_PREVIEW_LABELS
+    elif mode == "defect":
+        preview_labels = DEFECT_PREVIEW_LABELS
+    preview_urls = rendered_preview_urls(audit, preview_labels)
+    for label in preview_labels:
+        if label not in preview_urls:
+            errors.append(
+                f"Visual audit must include a rendered preview for {label}: "
+                f"![{label}](https://...)."
+            )
+    if len(preview_urls) == len(preview_labels) and len(set(preview_urls.values())) != len(
+        preview_labels
+    ):
+        errors.append("Each rendered preview must reference a different evidence image.")
 
     follow_up_value = field(audit, "New follow-up issues found in this audit")
     if not follow_up_value:

--- a/scripts/tests/test_check_visual_pr.py
+++ b/scripts/tests/test_check_visual_pr.py
@@ -17,7 +17,7 @@ from scripts.check_visual_pr import (
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def visual_body(result_overrides=None):
+def visual_body(result_overrides=None, include_previews=True):
     results = {row: "Matches GT" for row in AUDIT_ROWS}
     results.update(result_overrides or {})
     follow_ups = sorted(
@@ -26,6 +26,17 @@ def visual_body(result_overrides=None):
     follow_up_value = ", ".join(follow_ups) if follow_ups else "None"
     inspections = "\n".join(f"- [x] {item}" for item in INSPECTION_ITEMS)
     rows = "\n".join(f"| {row} | {results[row]} |" for row in AUDIT_ROWS)
+    previews = (
+        """### Visual comparison
+
+| GT | Before | After |
+| --- | --- | --- |
+| ![GT](https://example.com/gt.jpg) | ![Before](https://example.com/before.jpg) | ![After](https://example.com/after.jpg) |
+
+"""
+        if include_previews
+        else ""
+    )
     return f"""## Visual impact
 
 - [ ] No rendered PDF change
@@ -44,6 +55,7 @@ def visual_body(result_overrides=None):
 - Before: `assets/bugfixes/issue-186/before.jpg`
 - After: `assets/bugfixes/issue-186/after.jpg`
 
+{previews}
 ### Required inspection
 
 {inspections}
@@ -54,6 +66,27 @@ def visual_body(result_overrides=None):
 | --- | --- |
 {rows}
 """
+
+
+def defect_body():
+    return (
+        visual_body()
+        .replace("- Evidence mode: `fix`", "- Evidence mode: `defect`")
+        .replace(
+            """- GT: `assets/bugfixes/issue-186/gt.jpg`
+- Before: `assets/bugfixes/issue-186/before.jpg`
+- After: `assets/bugfixes/issue-186/after.jpg`""",
+            "- Compare: `assets/bugfixes/issue-186/compare.jpg`",
+        )
+        .replace(
+            """| GT | Before | After |
+| --- | --- | --- |
+| ![GT](https://example.com/gt.jpg) | ![Before](https://example.com/before.jpg) | ![After](https://example.com/after.jpg) |""",
+            """| Compare |
+| --- |
+| ![Compare](https://example.com/compare.jpg) |""",
+        )
+    )
 
 
 class PullRequestBodyTests(unittest.TestCase):
@@ -70,6 +103,44 @@ class PullRequestBodyTests(unittest.TestCase):
         errors = validate_pr_body(
             visual_body({"Fill": "Remaining: #328"}),
             ["assets/bugfixes/issue-186/after.jpg"],
+        )
+        self.assertEqual(errors, [])
+
+    def test_visual_audit_requires_rendered_evidence_previews(self):
+        errors = validate_pr_body(
+            visual_body(include_previews=False),
+            ["assets/bugfixes/issue-186/after.jpg"],
+        )
+        self.assertTrue(any("rendered preview" in error for error in errors))
+
+    def test_visual_audit_requires_distinct_preview_urls(self):
+        body = visual_body().replace(
+            "https://example.com/before.jpg",
+            "https://example.com/gt.jpg",
+        )
+        errors = validate_pr_body(body, ["assets/bugfixes/issue-186/after.jpg"])
+        self.assertTrue(any("different evidence image" in error for error in errors))
+
+    def test_commented_preview_does_not_count_as_rendered(self):
+        body = visual_body().replace(
+            "![GT](https://example.com/gt.jpg)",
+            "<!-- ![GT](https://example.com/gt.jpg) -->",
+        )
+        errors = validate_pr_body(body, ["assets/bugfixes/issue-186/after.jpg"])
+        self.assertTrue(any("rendered preview for GT" in error for error in errors))
+
+    def test_backticked_preview_does_not_count_as_rendered(self):
+        body = visual_body().replace(
+            "![GT](https://example.com/gt.jpg)",
+            "`![GT](https://example.com/gt.jpg)`",
+        )
+        errors = validate_pr_body(body, ["assets/bugfixes/issue-186/after.jpg"])
+        self.assertTrue(any("rendered preview for GT" in error for error in errors))
+
+    def test_defect_audit_requires_only_rendered_compare_preview(self):
+        errors = validate_pr_body(
+            defect_body(),
+            ["assets/bugfixes/issue-186/compare.jpg"],
         )
         self.assertEqual(errors, [])
 


### PR DESCRIPTION
## Summary

- Add rendered image placeholders to the pull request template for GT, Before, After, and defect-mode Compare evidence.
- Reject visual PR bodies that only list evidence paths without embedding the required images.
- Ignore image syntax left inside template comments and require distinct URLs for fix-mode previews.
- Preserve the existing defect workflow, which requires one rendered Compare image instead of the fix trio.

## Related issue

Related: #349

## Testing

- `python3 -m unittest discover -s scripts/tests -p 'test_check_visual_pr.py'`
- `python3 -m py_compile scripts/check_visual_pr.py scripts/tests/test_check_visual_pr.py`
- `git diff --check`

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: This only changes the pull request template and its CI validator.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
