### PR TITLE
docs: add pre-commit freshness reviewers

### DIFF
--- a/.claude/agents/documentation-freshness-reviewer.md
+++ b/.claude/agents/documentation-freshness-reviewer.md
@@ -1,0 +1,21 @@
+---
+name: documentation-freshness-reviewer
+description: Read-only pre-commit reviewer that verifies documentation, examples, and code comments against current code and configuration. Use before every commit and require PASS.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+permissionMode: dontAsk
+effort: medium
+maxTurns: 20
+---
+
+Act as a fail-closed documentation freshness reviewer before a commit.
+
+Inspect the staged diff, unstaged diff, and affected code paths. Verify factual claims in existing documentation, examples, and code comments against authoritative code, manifests, configuration, generated help, and tests. Search beyond changed files for project-wide facts affected by the change, including versions, commands, APIs, behavior, defaults, paths, architecture, and limitations.
+
+Do not flag intentionally historical material such as changelogs, dated audits, migration notes, or pinned regression fixtures unless it claims to describe the current state. Do not edit files, commit, push, or perform GitHub mutations.
+
+If an external current-state fact cannot be verified in the read-only environment, return `BLOCK:` with the exact evidence required. Re-evaluate when the parent supplies the command, source, and output used to verify it.
+
+## Output contract
+
+Your entire final response must begin with the verdict. Line 1 must be exactly `PASS:` or `BLOCK:`. Never put audit narration, a heading, a summary, or an explanation before line 1. Put evidence after the verdict. Use `PASS:` only when no stale or unverifiable current-state claim remains. After `BLOCK:`, provide concise `file:line` findings, the contradictory source evidence, and the required update.

--- a/.codex/agents/documentation-freshness-reviewer.toml
+++ b/.codex/agents/documentation-freshness-reviewer.toml
@@ -1,0 +1,16 @@
+name = "documentation_freshness_reviewer"
+description = "Read-only pre-commit reviewer that verifies documentation, examples, and code comments against the current code and configuration."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Act as a fail-closed documentation freshness reviewer before a commit.
+
+Inspect the staged diff, unstaged diff, and affected code paths. Verify factual claims in existing documentation, examples, and code comments against authoritative code, manifests, configuration, generated help, and tests. Search beyond changed files for project-wide facts affected by the change, including versions, commands, APIs, behavior, defaults, paths, architecture, and limitations.
+
+Do not flag intentionally historical material such as changelogs, dated audits, migration notes, or pinned regression fixtures unless it claims to describe the current state. Do not edit files, commit, push, or perform GitHub mutations.
+
+If an external current-state fact cannot be verified in the read-only sandbox, return `BLOCK:` with the exact evidence required. Re-evaluate when the parent supplies the command, source, and output used to verify it.
+
+Return `PASS:` on the first line only when no stale or unverifiable current-state claim remains. Otherwise return `BLOCK:` on the first line, followed by concise `file:line` findings, the contradictory source evidence, and the required update.
+"""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 - Always read and follow the rules defined in `CLAUDE.md` before starting any task.
 - For visual bug fixes, store reproducible before/after images under `assets/bugfixes/issue-<number>/`.
 - If a dependency limitation or bug breaks PDF conversion, clone that library, fix and test it upstream, and open a PR. Follow its repository conventions and match the tone and scope of its recently merged PRs.
-- Before every commit, delegate a read-only freshness audit to `documentation_freshness_reviewer` and wait for `PASS:`. Compare existing documentation, examples, and code comments with the current code and configuration; update or remove stale versions, commands, APIs, behavior, defaults, paths, architecture, limitations, and unverified claims in the same commit.
+- Before every commit, delegate a read-only freshness audit and wait for `PASS:`. Codex must use `documentation_freshness_reviewer`; Claude Code must use `documentation-freshness-reviewer`. Compare existing documentation, examples, and code comments with the current code and configuration; update or remove stale versions, commands, APIs, behavior, defaults, paths, architecture, limitations, and unverified claims in the same commit.
 
 ## Release Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 - Always read and follow the rules defined in `CLAUDE.md` before starting any task.
 - For visual bug fixes, store reproducible before/after images under `assets/bugfixes/issue-<number>/`.
 - If a dependency limitation or bug breaks PDF conversion, clone that library, fix and test it upstream, and open a PR. Follow its repository conventions and match the tone and scope of its recently merged PRs.
+- Before every commit, delegate a read-only freshness audit to `documentation_freshness_reviewer` and wait for `PASS:`. Compare existing documentation, examples, and code comments with the current code and configuration; update or remove stale versions, commands, APIs, behavior, defaults, paths, architecture, limitations, and unverified claims in the same commit.
 
 ## Release Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 - When editing `CLAUDE.md`, use the minimum words and sentences needed to convey 100% of the meaning.
 - After completing each planned task, run tests and commit before moving to the next task. **Skip tests if the change has no impact on runtime behavior** (e.g., docs, comments, CI config). Changes to runtime config files (YAML, JSON, etc. read by code) must still trigger tests.
 - **After any code change (feature addition, bug fix, refactoring, PR merge), check if `README.md` needs updating.** If project description, usage, setup, architecture, or API changed, update `README.md` with clear, concise language. Keep it minimal — only document what users need to know.
-- **Before every commit, delegate a read-only freshness audit to `documentation_freshness_reviewer` and wait for `PASS:`.** Compare existing documentation, examples, and code comments with the current code and configuration; update or remove stale versions, commands, APIs, behavior, defaults, paths, architecture, limitations, and unverified claims in the same commit.
+- **Before every commit, delegate a read-only freshness audit and wait for `PASS:`.** Codex must use `documentation_freshness_reviewer`; Claude Code must use `documentation-freshness-reviewer`. Compare existing documentation, examples, and code comments with the current code and configuration; update or remove stale versions, commands, APIs, behavior, defaults, paths, architecture, limitations, and unverified claims in the same commit.
 
 ## Testing (TDD)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 - When editing `CLAUDE.md`, use the minimum words and sentences needed to convey 100% of the meaning.
 - After completing each planned task, run tests and commit before moving to the next task. **Skip tests if the change has no impact on runtime behavior** (e.g., docs, comments, CI config). Changes to runtime config files (YAML, JSON, etc. read by code) must still trigger tests.
 - **After any code change (feature addition, bug fix, refactoring, PR merge), check if `README.md` needs updating.** If project description, usage, setup, architecture, or API changed, update `README.md` with clear, concise language. Keep it minimal — only document what users need to know.
+- **Before every commit, delegate a read-only freshness audit to `documentation_freshness_reviewer` and wait for `PASS:`.** Compare existing documentation, examples, and code comments with the current code and configuration; update or remove stale versions, commands, APIs, behavior, defaults, paths, architecture, limitations, and unverified claims in the same commit.
 
 ## Testing (TDD)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ No LibreOffice, no Chromium, no Docker — just a single binary powered by [Typs
 
 ```toml
 [dependencies]
-office2pdf = "0.4"
+office2pdf = "0.6.4"
 ```
 
 ### CLI
@@ -51,7 +51,7 @@ Every [GitHub release](https://github.com/developer0hye/office2pdf/releases) shi
 On Linux and macOS, download, extract, and place the binary on your `PATH`:
 
 ```sh
-VERSION=v0.6.2
+VERSION=v0.6.4
 TARGET=x86_64-unknown-linux-gnu  # pick your platform's target from the table above
 curl -L "https://github.com/developer0hye/office2pdf/releases/download/${VERSION}/office2pdf-${VERSION}-${TARGET}.tar.gz" | tar xz
 sudo install "office2pdf-${VERSION}-${TARGET}/office2pdf" /usr/local/bin/


### PR DESCRIPTION
## Summary

Add equivalent project-scoped, read-only documentation freshness reviewers for Codex and Claude Code, and require the matching reviewer’s `PASS:` result before every commit.

- Codex: `.codex/agents/documentation-freshness-reviewer.toml`
- Claude Code: `.claude/agents/documentation-freshness-reviewer.md`
- update `AGENTS.md` and `CLAUDE.md` with platform-specific invocation names
- update stale README dependency and release examples to the verified current `0.6.4`

The Claude definition follows Anthropic’s project subagent format and uses an allowlisted tool surface with `dontAsk`, so commands requiring permission are denied rather than blocking a non-interactive pre-commit audit.

## Related issue

None.

## Testing

- parsed the Codex TOML and validated required fields plus `sandbox_mode = "read-only"`
- verified Claude Code 2.1.217 loads `documentation-freshness-reviewer`
- exercised the real Claude Agent delegation path; the Sonnet subagent used four read-only Bash checks, made zero edits, and returned first-line `PASS:`
- exercised the Codex reviewer against both staged commits; final result: `PASS:`
- `cargo metadata --no-deps --format-version 1` reports `0.6.4` for both workspace packages
- verified the public `v0.6.4` GitHub Release, all six binary assets, and both crates.io packages
- `git diff --check`
- runtime tests skipped because the changes affect documentation and agent configuration only

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: documentation and agent configuration only

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue (not applicable)
