### PR TITLE
refactor: seal library internals behind pub(crate)

### DIFF
--- a/crates/office2pdf/src/defaults.rs
+++ b/crates/office2pdf/src/defaults.rs
@@ -49,6 +49,8 @@ pub const TYPST_DEFAULT_FONT_SIZE_PT: f64 = 11.0;
 // ---------------------------------------------------------------------------
 
 /// Default chunk size (in rows) for XLSX streaming mode.
+// Streaming needs the pdf-ops merge path; builds without that feature never read this.
+#[cfg_attr(not(feature = "pdf-ops"), allow(dead_code))]
 pub const DEFAULT_STREAMING_CHUNK_SIZE: usize = 1000;
 
 // ---------------------------------------------------------------------------

--- a/crates/office2pdf/src/lib.rs
+++ b/crates/office2pdf/src/lib.rs
@@ -38,15 +38,28 @@
 //! ```
 
 pub mod config;
-pub mod defaults;
+pub(crate) mod defaults;
 pub mod error;
 pub mod ir;
-pub mod parser;
+pub(crate) mod parser;
 #[cfg(feature = "pdf-ops")]
 pub mod pdf_ops;
-pub mod render;
+pub(crate) mod render;
 #[cfg(feature = "wasm")]
 pub mod wasm;
+
+/// Implementation details re-exported for this crate's own integration tests.
+///
+/// Not part of the public API — no semver guarantees. Use [`convert`],
+/// [`convert_bytes`], or [`render_document`] instead.
+#[doc(hidden)]
+pub mod internal {
+    pub use crate::parser::Parser;
+    pub use crate::parser::docx::DocxParser;
+    pub use crate::parser::pptx::PptxParser;
+    pub use crate::parser::xlsx::XlsxParser;
+    pub use crate::render::typst_gen::{TypstOutput, generate_typst};
+}
 
 use config::{ConvertOptions, Format};
 use error::{ConvertError, ConvertResult};

--- a/crates/office2pdf/src/parser/embedded_fonts.rs
+++ b/crates/office2pdf/src/parser/embedded_fonts.rs
@@ -4,6 +4,10 @@
 //! them, deobfuscates using the GUID-based XOR scheme, and writes them to a
 //! temporary directory for use during PDF compilation.
 
+// Font discovery/embedding is native-only; on wasm32 these items are
+// compiled but unreachable (visibility sealing exposed them to dead_code).
+#![cfg_attr(target_arch = "wasm32", allow(dead_code))]
+
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::{Path, PathBuf};
 

--- a/crates/office2pdf/src/render/font_context.rs
+++ b/crates/office2pdf/src/render/font_context.rs
@@ -1,5 +1,11 @@
+// Font discovery/embedding is native-only; on wasm32 these items are
+// compiled but unreachable (visibility sealing exposed them to dead_code).
+#![cfg_attr(target_arch = "wasm32", allow(dead_code))]
+
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::Path;
+use std::path::PathBuf;
 
 #[cfg(not(target_arch = "wasm32"))]
 use typst_kit::fonts::FontSearcher;

--- a/crates/office2pdf/src/render/font_subst.rs
+++ b/crates/office2pdf/src/render/font_subst.rs
@@ -4,15 +4,20 @@
 //! When the requested font is unavailable, the substitutes are tried in order.
 //! Uses a `match` statement for zero-cost static lookup (no runtime allocation).
 
+// Font discovery/embedding is native-only; on wasm32 these items are
+// compiled but unreachable (visibility sealing exposed them to dead_code).
+#![cfg_attr(target_arch = "wasm32", allow(dead_code))]
+
 use std::cell::RefCell;
 use std::collections::BTreeSet;
+#[cfg(target_arch = "wasm32")]
 use std::path::PathBuf;
 
 use crate::ir::{
     Block, Document, FixedElementKind, HFInline, HeaderFooter, Page, Paragraph, Table,
 };
 
-use super::font_context::{FontSearchContext, resolve_font_search_context};
+use super::font_context::FontSearchContext;
 
 thread_local! {
     static ACTIVE_FONT_CONTEXT: RefCell<Option<FontSearchContext>> = const { RefCell::new(None) };
@@ -556,15 +561,6 @@ fn resolve_available_fallback(font_family: &str, context: &FontSearchContext) ->
     fallback_candidates(font_family, Some(context))
         .into_iter()
         .find(|candidate| context.has_family(candidate))
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub fn detect_missing_font_fallbacks(
-    doc: &Document,
-    font_paths: &[PathBuf],
-) -> Vec<(String, String)> {
-    let context = resolve_font_search_context(font_paths);
-    detect_missing_font_fallbacks_with_context(doc, &context)
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/office2pdf/src/render/pdf.rs
+++ b/crates/office2pdf/src/render/pdf.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex, OnceLock};
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::Mutex;
+use std::sync::{Arc, OnceLock};
 // `SystemTime::now()` panics on wasm32-unknown-unknown; web-time shims it there
 // and re-exports std elsewhere. Mirrors the `Instant` handling in lib_pipeline.
 #[cfg(not(target_arch = "wasm32"))]
@@ -245,6 +247,8 @@ enum FontSource {
     /// Reference to globally cached font data (common case).
     Cached(&'static CachedFontData),
     /// Shared cached font data for resolved extra font paths.
+    /// Only constructed on native (extra font paths need filesystem access).
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     Shared(Arc<CachedFontData>),
 }
 

--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -263,6 +263,9 @@ pub fn generate_typst(doc: &Document) -> Result<TypstOutput, ConvertError> {
 ///
 /// When `options.paper_size` is set, all pages use the specified paper size.
 /// When `options.landscape` is set, page orientation is forced.
+// Only the wasm pipeline branch calls this at runtime; native builds use the
+// font-context variant and reach this wrapper solely from tests.
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
 pub fn generate_typst_with_options(
     doc: &Document,
     options: &ConvertOptions,

--- a/crates/office2pdf/tests/docx_fixtures.rs
+++ b/crates/office2pdf/tests/docx_fixtures.rs
@@ -10,13 +10,13 @@ mod common;
 use std::path::PathBuf;
 
 use office2pdf::config::ConvertOptions;
+use office2pdf::internal::DocxParser;
+use office2pdf::internal::Parser;
 use office2pdf::ir::{
     ArrowHead, Block, BorderLineStyle, Color, FlowPage, FrameAnchor, HFInline, Insets, ListKind,
     Page, Paragraph, PositionedTabAlignment, PositionedTabRelativeTo, Run, ShapeKind,
     TextBoxVerticalAlign,
 };
-use office2pdf::parser::Parser;
-use office2pdf::parser::docx::DocxParser;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/crates/office2pdf/tests/pptx_fixtures.rs
+++ b/crates/office2pdf/tests/pptx_fixtures.rs
@@ -10,10 +10,10 @@ mod common;
 use std::path::PathBuf;
 
 use office2pdf::config::ConvertOptions;
+use office2pdf::internal::Parser;
+use office2pdf::internal::PptxParser;
+use office2pdf::internal::generate_typst;
 use office2pdf::ir::{Block, Color, FixedElementKind, FixedPage, Page};
-use office2pdf::parser::Parser;
-use office2pdf::parser::pptx::PptxParser;
-use office2pdf::render::typst_gen::generate_typst;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/crates/office2pdf/tests/xlsx_fixtures.rs
+++ b/crates/office2pdf/tests/xlsx_fixtures.rs
@@ -10,10 +10,10 @@ mod common;
 use std::path::PathBuf;
 
 use office2pdf::config::ConvertOptions;
+use office2pdf::internal::Parser;
+use office2pdf::internal::XlsxParser;
+use office2pdf::internal::generate_typst;
 use office2pdf::ir::{Alignment, Block, BorderLineStyle, Color, Page, SheetPage, TableCell};
-use office2pdf::parser::Parser;
-use office2pdf::parser::xlsx::XlsxParser;
-use office2pdf::render::typst_gen::generate_typst;
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## What changed

Demotes `parser`, `render`, and `defaults` modules in `crates/office2pdf/src/lib.rs` from `pub` to `pub(crate)`. The crate's own fixture integration tests keep access through a `#[doc(hidden)] pub mod internal` facade re-exporting exactly what they use (`Parser`, `DocxParser`, `PptxParser`, `XlsxParser`, `TypstOutput`, `generate_typst`).

## Why

Every parser/render internal (~50 modules) was reachable by downstream users, making any internal refactor a technical semver break. The public API is now the intended façade: `convert`, `convert_with_options`, `convert_bytes`, `render_document`, `config`, `error`, `ir`, `pdf_ops`, `wasm`. Verified the CLI consumes only that façade. This unblocks upcoming internal refactoring semver-safely.

## Key changes

- `lib.rs`: visibility demotion + hidden `internal` test facade
- Sealing exposed dead code that `pub` visibility previously masked:
  - removed the native `detect_missing_font_fallbacks` wrapper (only the wasm pipeline branch ever called the path-based variant)
  - `allow(dead_code)` on wasm for native-only font discovery (`embedded_fonts`, `font_context`, `font_subst`, `FontSource::Shared`)
  - `DEFAULT_STREAMING_CHUNK_SIZE` allow gated on the `pdf-ops` feature its only consumer requires
  - cfg-gated `Path`/`Mutex` imports used only by native code paths
- Fixture tests import via `office2pdf::internal`

## Verification

- `cargo test --workspace`: 1307 unit + all integration tests pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo check --target wasm32-unknown-unknown -p office2pdf` (with and without `--features wasm`): 0 warnings
- `cargo check -p office2pdf --no-default-features`: 0 warnings
- Documentation freshness audit: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Pure visibility refactor — module `pub` → `pub(crate)` demotion, a hidden test-only re-export facade, and dead-code cfg attributes. No parser, IR, codegen, or rendering logic changed; full test suite (1307 unit + integration) passes unchanged.
