### PR TITLE
fix: escape font family names in Typst font lists

### DIFF
--- a/crates/office2pdf/src/render/font_subst.rs
+++ b/crates/office2pdf/src/render/font_subst.rs
@@ -18,6 +18,7 @@ use crate::ir::{
 };
 
 use super::font_context::FontSearchContext;
+use super::typst_gen::escape_typst_string;
 
 thread_local! {
     static ACTIVE_FONT_CONTEXT: RefCell<Option<FontSearchContext>> = const { RefCell::new(None) };
@@ -322,10 +323,13 @@ fn font_with_fallbacks_for_context(
     context: Option<&FontSearchContext>,
 ) -> String {
     let fallbacks = fallback_candidates(font_family, context);
+    // Family names originate from parsed OOXML (document-controlled); escape
+    // them so `"` or `\` cannot break out of the Typst string literal.
+    let family = escape_typst_string(font_family);
     if fallbacks.is_empty() {
-        let mut result = String::with_capacity(font_family.len() + 2);
+        let mut result = String::with_capacity(family.len() + 2);
         result.push('"');
-        result.push_str(font_family);
+        result.push_str(&family);
         result.push('"');
         return result;
     }
@@ -333,11 +337,11 @@ fn font_with_fallbacks_for_context(
     let mut result = String::with_capacity(64);
     result.push('(');
     result.push('"');
-    result.push_str(font_family);
+    result.push_str(&family);
     result.push('"');
     for sub in fallbacks {
         result.push_str(", \"");
-        result.push_str(&sub);
+        result.push_str(&escape_typst_string(&sub));
         result.push('"');
     }
     result.push(')');

--- a/crates/office2pdf/src/render/font_subst_tests.rs
+++ b/crates/office2pdf/src/render/font_subst_tests.rs
@@ -213,6 +213,33 @@ fn test_font_with_fallbacks_single_substitute() {
     assert_eq!(result, r#"("Comic Sans MS", "Comic Neue")"#);
 }
 
+// Family names come from parsed OOXML, i.e. document-controlled input. A name
+// containing `"` or `\` must not break out of the generated Typst string
+// literal (it would corrupt the whole generated source).
+
+#[test]
+fn test_font_with_fallbacks_escapes_quotes_in_family_name() {
+    let result = font_with_fallbacks(r#"Weird "Quoted" Font"#);
+    assert_eq!(result, r#""Weird \"Quoted\" Font""#);
+}
+
+#[test]
+fn test_font_with_fallbacks_escapes_backslashes_in_family_name() {
+    let result = font_with_fallbacks(r"Fonts\Custom");
+    assert_eq!(result, r#""Fonts\\Custom""#);
+}
+
+#[test]
+fn test_font_with_fallbacks_escapes_quotes_in_fallback_array_head() {
+    // "Pretendard <anything>" resolves to the Pretendard substitute chain, so
+    // the raw (quote-carrying) name lands at the head of a Typst array literal.
+    let result = font_with_fallbacks(r#"Pretendard "Display""#);
+    assert!(
+        result.starts_with(r#"("Pretendard \"Display\"""#),
+        "array head must escape document-supplied quotes: {result}"
+    );
+}
+
 #[test]
 fn test_font_with_fallbacks_preserves_original_case() {
     // The original font name should appear as-is (not lowercased)

--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -250,7 +250,7 @@ fn parse_iso8601_date(s: &str) -> Option<(i32, u8, u8, u8, u8, u8)> {
 }
 
 /// Escape a string for use inside Typst double quotes.
-fn escape_typst_string(s: &str) -> String {
+pub(crate) fn escape_typst_string(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 


### PR DESCRIPTION
## Summary

`font_with_fallbacks` in `render/font_subst.rs` interpolated document-controlled font family names into double-quoted Typst string literals without escaping. A family name containing `"` or `\` — OOXML input is document-controlled — broke out of the string literal and corrupted the entire generated Typst source, failing the conversion or worse.

The existing `escape_typst_string` helper (already used for title/author metadata) is promoted to `pub(crate)` and applied to the family name and every fallback entry. This is the single emission path for font names (`write_text_params` → `font_with_fallbacks`), so the fix covers all formats.

## Related issue

None filed — found during the refactoring audit (render-layer escaping review).

## Testing

- TDD: 3 new unit tests written first (red), then the fix (green): quoted single-name path, backslash path, fallback-array head path
- `cargo test --workspace`: 1779 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo check --target wasm32-unknown-unknown -p office2pdf --features wasm`: 0 warnings
- `cargo fmt --all --check`: clean
- Documentation freshness audit: PASS

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Escaping only affects font family names containing `"` or `\`, which no fixture or realistic document uses with a well-formed name; normal names produce byte-identical Typst output, confirmed by the unchanged golden/fixture test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)