### PR TITLE
refactor: extract shared Typst value formatters into fmt module

### DIFF
--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -17,6 +17,7 @@ use crate::ir::{
 };
 
 use self::diagrams::{generate_chart, generate_smartart};
+use self::fmt::*;
 use self::lists::{
     can_render_fixed_text_list_inline, common_text_style, generate_fixed_text_list, generate_list,
     write_common_text_settings, write_fixed_text_default_par_settings,
@@ -31,6 +32,8 @@ use super::font_context::FontSearchContext;
 
 #[path = "typst_gen_diagrams.rs"]
 mod diagrams;
+#[path = "typst_gen_fmt.rs"]
+mod fmt;
 #[path = "typst_gen_lists.rs"]
 mod lists;
 #[path = "typst_gen_shapes.rs"]
@@ -419,12 +422,10 @@ fn generate_fixed_page(
     } else if let Some(ref bg) = page.background_color {
         let _ = writeln!(
             out,
-            "#set page(width: {}pt, height: {}pt, margin: 0pt, fill: rgb({}, {}, {}))",
+            "#set page(width: {}pt, height: {}pt, margin: 0pt, fill: {})",
             format_f64(size.width),
             format_f64(size.height),
-            bg.r,
-            bg.g,
-            bg.b,
+            rgb(bg),
         );
     } else {
         let _ = writeln!(
@@ -581,16 +582,14 @@ fn generate_sheet_anchor(out: &mut String, anchor: &SheetAnchor, ctx: &mut GenCt
                 format_f64(text_box.height),
             );
             if let Some(fill) = text_box.fill {
-                let _ = write!(out, ", fill: rgb({}, {}, {})", fill.r, fill.g, fill.b);
+                let _ = write!(out, ", fill: {}", rgb(&fill));
             }
             if let Some(ref border) = text_box.border {
                 let _ = write!(
                     out,
-                    ", stroke: {}pt + rgb({}, {}, {})",
+                    ", stroke: {}pt + {}",
                     format_f64(border.width),
-                    border.color.r,
-                    border.color.g,
-                    border.color.b,
+                    rgb(&border.color),
                 );
             }
             out.push_str(", inset: 4pt)[");
@@ -1292,11 +1291,9 @@ fn write_hf_border_line(out: &mut String, border: &BorderSide, is_primary_double
     let dash = border_line_style_to_typst(border.style);
     let _ = write!(
         out,
-        "block(height: {}pt)[#line(length: 100%, stroke: (paint: rgb({}, {}, {}), thickness: {}pt, dash: \"{}\"))]",
+        "block(height: {}pt)[#line(length: 100%, stroke: (paint: {}, thickness: {}pt, dash: \"{}\"))]",
         format_f64(width),
-        border.color.r,
-        border.color.g,
-        border.color.b,
+        rgb(&border.color),
         format_f64(width),
         if border.style == BorderLineStyle::Double {
             "solid"

--- a/crates/office2pdf/src/render/typst_gen_diagrams.rs
+++ b/crates/office2pdf/src/render/typst_gen_diagrams.rs
@@ -79,6 +79,19 @@ const CHART_SERIES_COLORS: [&str; 6] = [
     "rgb(112, 173, 71)",
 ];
 
+/// Category palette used by the bar-plot and pie-table fallbacks.
+///
+/// Intentionally distinct from [`CHART_SERIES_COLORS`]; unifying them would
+/// change rendered output and needs visual verification.
+const CHART_CATEGORY_COLORS: [&str; 6] = [
+    "rgb(66, 133, 244)",
+    "rgb(219, 68, 55)",
+    "rgb(244, 180, 0)",
+    "rgb(15, 157, 88)",
+    "rgb(171, 71, 188)",
+    "rgb(0, 172, 193)",
+];
+
 /// Format a chart value without floating-point noise (e.g. 8.2000001 → 8.2).
 pub(super) fn chart_value_label(value: f64) -> String {
     if value.fract().abs() < 1e-9 {
@@ -335,12 +348,7 @@ fn generate_chart_bar(out: &mut String, chart: &Chart) {
         .fold(0.0_f64, f64::max);
     let max_value: f64 = if max_value == 0.0 { 1.0 } else { max_value };
 
-    let colors: [&str; 4] = [
-        "rgb(66, 133, 244)",
-        "rgb(219, 68, 55)",
-        "rgb(244, 180, 0)",
-        "rgb(15, 157, 88)",
-    ];
+    let colors: &[&str] = &CHART_CATEGORY_COLORS[..4];
 
     for (row_index, category) in chart.categories.iter().enumerate() {
         let escaped_category: String = escape_typst(category);
@@ -532,14 +540,7 @@ fn generate_chart_pie(out: &mut String, chart: &Chart) {
     let total: f64 = series.values.iter().sum();
     let total: f64 = if total == 0.0 { 1.0 } else { total };
 
-    let colors: [&str; 6] = [
-        "rgb(66, 133, 244)",
-        "rgb(219, 68, 55)",
-        "rgb(244, 180, 0)",
-        "rgb(15, 157, 88)",
-        "rgb(171, 71, 188)",
-        "rgb(0, 172, 193)",
-    ];
+    let colors: &[&str] = &CHART_CATEGORY_COLORS;
 
     let _ = writeln!(out, "#table(");
     let _ = writeln!(out, "  columns: 3,");

--- a/crates/office2pdf/src/render/typst_gen_fmt.rs
+++ b/crates/office2pdf/src/render/typst_gen_fmt.rs
@@ -1,0 +1,55 @@
+//! Canonical Typst value formatters shared by the codegen modules.
+//!
+//! New color literals and stroke values in generated Typst source should be
+//! built with these helpers so the output stays uniform and golden tests
+//! don't drift on formatting details.
+
+use crate::ir::{BorderLineStyle, BorderSide, Color};
+
+/// Format a Typst `rgb(r, g, b)` color literal.
+pub(super) fn rgb(color: &Color) -> String {
+    format!("rgb({}, {}, {})", color.r, color.g, color.b)
+}
+
+/// Format a Typst `rgb(r, g, b, a)` color literal with an alpha channel.
+pub(super) fn rgb_with_alpha(color: &Color, alpha: u8) -> String {
+    format!("rgb({}, {}, {}, {})", color.r, color.g, color.b, alpha)
+}
+
+/// Format a stroke value: `Wpt + rgb(...)` for plain styles, a
+/// `(paint: ..., thickness: ..., dash: "...")` dict for patterned ones.
+///
+/// `double_is_plain` preserves an existing divergence: table borders render
+/// `Double` as a plain stroke, while shape strokes send it through the dash
+/// dict (where it maps to `dash: "solid"`). Unifying that is a visible-output
+/// change and belongs in its own visually-verified fix.
+pub(super) fn stroke_value(side: &BorderSide, double_is_plain: bool) -> String {
+    let is_plain = match side.style {
+        BorderLineStyle::Solid | BorderLineStyle::None => true,
+        BorderLineStyle::Double => double_is_plain,
+        _ => false,
+    };
+    if is_plain {
+        format!("{}pt + {}", format_f64(side.width), rgb(&side.color))
+    } else {
+        format!(
+            "(paint: {}, thickness: {}pt, dash: \"{}\")",
+            rgb(&side.color),
+            format_f64(side.width),
+            super::border_line_style_to_typst(side.style),
+        )
+    }
+}
+
+/// Format a float without a trailing `.0` on integral values.
+pub(super) fn format_f64(v: f64) -> String {
+    if v.fract() == 0.0 {
+        format!("{}", v as i64)
+    } else {
+        format!("{v}")
+    }
+}
+
+#[cfg(test)]
+#[path = "typst_gen_fmt_tests.rs"]
+mod tests;

--- a/crates/office2pdf/src/render/typst_gen_fmt_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_fmt_tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+use crate::ir::{BorderLineStyle, BorderSide, Color};
+
+#[test]
+fn test_rgb_literal() {
+    assert_eq!(rgb(&Color::new(66, 133, 244)), "rgb(66, 133, 244)");
+    assert_eq!(rgb(&Color::new(0, 0, 0)), "rgb(0, 0, 0)");
+}
+
+#[test]
+fn test_rgb_with_alpha_literal() {
+    assert_eq!(
+        rgb_with_alpha(&Color::new(255, 192, 0), 128),
+        "rgb(255, 192, 0, 128)"
+    );
+}
+
+#[test]
+fn test_stroke_value_solid() {
+    let side = BorderSide {
+        width: 1.5,
+        color: Color::new(10, 20, 30),
+        style: BorderLineStyle::Solid,
+    };
+    assert_eq!(stroke_value(&side, false), "1.5pt + rgb(10, 20, 30)");
+    assert_eq!(
+        stroke_value(&side, true),
+        "1.5pt + rgb(10, 20, 30)",
+        "double_is_plain must not affect Solid"
+    );
+}
+
+#[test]
+fn test_stroke_value_integral_width_has_no_decimal_point() {
+    let side = BorderSide {
+        width: 2.0,
+        color: Color::new(0, 0, 0),
+        style: BorderLineStyle::Solid,
+    };
+    assert_eq!(stroke_value(&side, false), "2pt + rgb(0, 0, 0)");
+}
+
+#[test]
+fn test_stroke_value_dashed() {
+    let side = BorderSide {
+        width: 0.75,
+        color: Color::new(200, 0, 0),
+        style: BorderLineStyle::Dashed,
+    };
+    assert_eq!(
+        stroke_value(&side, false),
+        "(paint: rgb(200, 0, 0), thickness: 0.75pt, dash: \"dashed\")"
+    );
+}
+
+#[test]
+fn test_stroke_value_dotted() {
+    let side = BorderSide {
+        width: 1.0,
+        color: Color::new(0, 0, 0),
+        style: BorderLineStyle::Dotted,
+    };
+    assert_eq!(
+        stroke_value(&side, true),
+        "(paint: rgb(0, 0, 0), thickness: 1pt, dash: \"dotted\")",
+        "double_is_plain must not affect genuinely dashed styles"
+    );
+}
+
+// Tables historically render Double borders as a plain stroke while shapes
+// send them through the dash dict (mapping to dash: "solid"). stroke_value
+// must preserve both behaviors until the divergence is fixed with visual
+// verification.
+#[test]
+fn test_stroke_value_double_preserves_caller_divergence() {
+    let side = BorderSide {
+        width: 1.0,
+        color: Color::new(5, 6, 7),
+        style: BorderLineStyle::Double,
+    };
+    assert_eq!(
+        stroke_value(&side, true),
+        "1pt + rgb(5, 6, 7)",
+        "table borders treat Double as plain"
+    );
+    assert_eq!(
+        stroke_value(&side, false),
+        "(paint: rgb(5, 6, 7), thickness: 1pt, dash: \"solid\")",
+        "shape strokes send Double through the dash dict"
+    );
+}
+
+#[test]
+fn test_format_f64_integral_drops_fraction() {
+    assert_eq!(format_f64(12.0), "12");
+    assert_eq!(format_f64(0.0), "0");
+    assert_eq!(format_f64(-3.0), "-3");
+}
+
+#[test]
+fn test_format_f64_fractional_keeps_value() {
+    assert_eq!(format_f64(1.5), "1.5");
+    assert_eq!(format_f64(0.75), "0.75");
+}

--- a/crates/office2pdf/src/render/typst_gen_shapes.rs
+++ b/crates/office2pdf/src/render/typst_gen_shapes.rs
@@ -261,13 +261,9 @@ fn write_shadow_shape(out: &mut String, shape: &Shape, width: f64, height: f64, 
 pub(super) fn write_fill_color(out: &mut String, fill: &Color, opacity: Option<f64>) {
     if let Some(op) = opacity {
         let alpha = (op * 255.0).round() as u8;
-        let _ = write!(
-            out,
-            ", fill: rgb({}, {}, {}, {})",
-            fill.r, fill.g, fill.b, alpha
-        );
+        let _ = write!(out, ", fill: {}", rgb_with_alpha(fill, alpha));
     } else {
-        let _ = write!(out, ", fill: rgb({}, {}, {})", fill.r, fill.g, fill.b);
+        let _ = write!(out, ", fill: {}", rgb(fill));
     }
 }
 
@@ -290,57 +286,13 @@ fn write_shape_params(out: &mut String, shape: &Shape, width: f64, height: f64) 
 /// Write stroke parameter for shapes, handling dash patterns.
 pub(super) fn write_shape_stroke(out: &mut String, stroke: &Option<BorderSide>) {
     if let Some(stroke) = stroke {
-        match stroke.style {
-            BorderLineStyle::Solid | BorderLineStyle::None => {
-                let _ = write!(
-                    out,
-                    ", stroke: {}pt + rgb({}, {}, {})",
-                    format_f64(stroke.width),
-                    stroke.color.r,
-                    stroke.color.g,
-                    stroke.color.b,
-                );
-            }
-            _ => {
-                let _ = write!(
-                    out,
-                    ", stroke: (paint: rgb({}, {}, {}), thickness: {}pt, dash: \"{}\")",
-                    stroke.color.r,
-                    stroke.color.g,
-                    stroke.color.b,
-                    format_f64(stroke.width),
-                    border_line_style_to_typst(stroke.style),
-                );
-            }
-        }
+        let _ = write!(out, ", stroke: {}", stroke_value(stroke, false));
     }
 }
 
 /// Write a border stroke value for image box wrapping (no leading comma).
 pub(super) fn write_image_border_stroke(out: &mut String, stroke: &BorderSide) {
-    match stroke.style {
-        BorderLineStyle::Solid | BorderLineStyle::None => {
-            let _ = write!(
-                out,
-                "{}pt + rgb({}, {}, {})",
-                format_f64(stroke.width),
-                stroke.color.r,
-                stroke.color.g,
-                stroke.color.b,
-            );
-        }
-        _ => {
-            let _ = write!(
-                out,
-                "(paint: rgb({}, {}, {}), thickness: {}pt, dash: \"{}\")",
-                stroke.color.r,
-                stroke.color.g,
-                stroke.color.b,
-                format_f64(stroke.width),
-                border_line_style_to_typst(stroke.style),
-            );
-        }
-    }
+    out.push_str(&stroke_value(stroke, false));
 }
 
 /// Write polygon vertex coordinates scaled to actual dimensions.
@@ -388,11 +340,7 @@ pub(super) fn write_gradient_fill(out: &mut String, gradient: &GradientFill) {
     // Fall back to solid fill if fewer than 2 stops.
     if gradient.stops.len() < 2 {
         if let Some(stop) = gradient.stops.first() {
-            let _ = write!(
-                out,
-                "rgb({}, {}, {})",
-                stop.color.r, stop.color.g, stop.color.b,
-            );
+            out.push_str(&rgb(&stop.color));
         }
         return;
     }
@@ -415,11 +363,7 @@ pub(super) fn write_gradient_fill(out: &mut String, gradient: &GradientFill) {
             out.push_str(", ");
         }
         let pos_pct = (stop.position * 100.0).round() as i64;
-        let _ = write!(
-            out,
-            "(rgb({}, {}, {}), {}%)",
-            stop.color.r, stop.color.g, stop.color.b, pos_pct,
-        );
+        let _ = write!(out, "({}, {}%)", rgb(&stop.color), pos_pct);
     }
     if gradient.angle.abs() > 0.001 {
         let _ = write!(out, ", angle: {}deg", format_f64(gradient.angle));
@@ -484,16 +428,14 @@ fn write_arrowhead_at(
     out.push_str("#place(top + left)[#polygon(");
     let _ = write!(
         out,
-        "({}pt, {}pt), ({}pt, {}pt), ({}pt, {}pt), fill: rgb({}, {}, {})",
+        "({}pt, {}pt), ({}pt, {}pt), ({}pt, {}pt), fill: {}",
         format_f64(v1.0),
         format_f64(v1.1),
         format_f64(v2.0),
         format_f64(v2.1),
         format_f64(v3.0),
         format_f64(v3.1),
-        stroke.color.r,
-        stroke.color.g,
-        stroke.color.b,
+        rgb(&stroke.color),
     );
     out.push_str(")]\n");
 }

--- a/crates/office2pdf/src/render/typst_gen_tables.rs
+++ b/crates/office2pdf/src/render/typst_gen_tables.rs
@@ -242,15 +242,11 @@ fn generate_table_cell(
         };
         let _ = write!(
             out,
-            "#place(left + horizon, box(width: {}%, height: {}, fill: gradient.linear(rgb({}, {}, {}), rgb({}, {}, {}).lighten(70%))))",
+            "#place(left + horizon, box(width: {}%, height: {}, fill: gradient.linear({}, {}.lighten(70%))))",
             format_f64(pct),
             bar_height,
-            db.color.r,
-            db.color.g,
-            db.color.b,
-            db.color.r,
-            db.color.g,
-            db.color.b,
+            rgb(&db.color),
+            rgb(&db.color),
         );
     }
 
@@ -264,8 +260,9 @@ fn generate_table_cell(
             Some(color) => {
                 let _ = write!(
                     out,
-                    "#place(left + horizon, text(fill: rgb({}, {}, {}), weight: \"bold\")[{}])",
-                    color.r, color.g, color.b, icon
+                    "#place(left + horizon, text(fill: {}, weight: \"bold\")[{}])",
+                    rgb(&color),
+                    icon
                 );
             }
             None => {
@@ -388,14 +385,12 @@ fn write_double_border_line(
 ) {
     let _ = write!(
         out,
-        "#place({align}, dx: {}pt, dy: {}pt, line(length: 100% + {}pt, angle: {angle}, stroke: {}pt + rgb({}, {}, {})))",
+        "#place({align}, dx: {}pt, dy: {}pt, line(length: 100% + {}pt, angle: {angle}, stroke: {}pt + {}))",
         format_geometry(dx),
         format_geometry(dy),
         format_geometry(length_extra),
         format_geometry(side.width),
-        side.color.r,
-        side.color.g,
-        side.color.b,
+        rgb(&side.color),
     );
 }
 
@@ -471,24 +466,7 @@ fn format_cell_stroke(border: &CellBorder) -> String {
 }
 
 fn format_border_side(side: &BorderSide) -> String {
-    let base = format!(
-        "{}pt + rgb({}, {}, {})",
-        format_f64(side.width),
-        side.color.r,
-        side.color.g,
-        side.color.b
-    );
-    match side.style {
-        BorderLineStyle::Solid | BorderLineStyle::Double | BorderLineStyle::None => base,
-        _ => format!(
-            "(paint: rgb({}, {}, {}), thickness: {}pt, dash: \"{}\")",
-            side.color.r,
-            side.color.g,
-            side.color.b,
-            format_f64(side.width),
-            border_line_style_to_typst(side.style),
-        ),
-    }
+    stroke_value(side, true)
 }
 
 fn generate_cell_content(

--- a/crates/office2pdf/src/render/typst_gen_text.rs
+++ b/crates/office2pdf/src/render/typst_gen_text.rs
@@ -283,11 +283,7 @@ fn write_block_params_continuation(out: &mut String, style: &ParagraphStyle) {
     }
     if let Some(background) = style.background {
         // Word paints w:pPr/w:shd across the full paragraph width.
-        let _ = write!(
-            out,
-            ", fill: rgb({}, {}, {})",
-            background.r, background.g, background.b
-        );
+        let _ = write!(out, ", fill: {}", rgb(&background));
     }
     if let Some(border) = &style.border {
         write_paragraph_border_params(out, border);
@@ -299,20 +295,9 @@ fn write_block_params_continuation(out: &mut String, style: &ParagraphStyle) {
 const PARAGRAPH_BORDER_GAP_PT: f64 = 4.0;
 
 fn stroke_literal(side: &BorderSide) -> String {
-    let paint = format!("rgb({}, {}, {})", side.color.r, side.color.g, side.color.b);
-    let dash = match side.style {
-        BorderLineStyle::Dotted => Some("dotted"),
-        BorderLineStyle::Dashed => Some("dashed"),
-        BorderLineStyle::DashDot | BorderLineStyle::DashDotDot => Some("dash-dotted"),
-        _ => None,
-    };
-    match dash {
-        Some(dash) => format!(
-            "(paint: {paint}, thickness: {}pt, dash: \"{dash}\")",
-            format_f64(side.width)
-        ),
-        None => format!("{}pt + {paint}", format_f64(side.width)),
-    }
+    // Callers skip Double sides (drawn as overlays), so for every reachable
+    // style this matches the table flavor of the shared stroke formatter.
+    stroke_value(side, true)
 }
 
 /// Emit `stroke:`/`inset:` block parameters for the paragraph's borders.
@@ -373,12 +358,10 @@ fn write_paragraph_double_border_overlays(out: &mut String, border: &Option<Box<
         for dy in [near_dy, far_dy] {
             let _ = write!(
                 out,
-                "#place({align}, dy: {}pt, line(length: 100%, stroke: {}pt + rgb({}, {}, {})))",
+                "#place({align}, dy: {}pt, line(length: 100%, stroke: {}pt + {}))",
                 format_f64(sign * dy),
                 format_f64(w),
-                side.color.r,
-                side.color.g,
-                side.color.b,
+                rgb(&side.color),
             );
         }
     }
@@ -910,10 +893,7 @@ fn collect_formatting_wrappers(run: &Run) -> Vec<String> {
         wrappers.push(format!("#link(\"{href}\")["));
     }
     if let Some(ref highlight) = style.highlight {
-        wrappers.push(format!(
-            "#highlight(fill: rgb({}, {}, {}))[",
-            highlight.r, highlight.g, highlight.b
-        ));
+        wrappers.push(format!("#highlight(fill: {})[", rgb(highlight)));
     }
     if matches!(style.strikethrough, Some(true)) {
         wrappers.push("#strike[".to_string());
@@ -1061,15 +1041,7 @@ pub(super) fn write_param(out: &mut String, first: &mut bool, param: &str) {
 }
 
 pub(super) fn format_color(color: &Color) -> String {
-    format!("fill: rgb({}, {}, {})", color.r, color.g, color.b)
-}
-
-pub(super) fn format_f64(v: f64) -> String {
-    if v.fract() == 0.0 {
-        format!("{}", v as i64)
-    } else {
-        format!("{v}")
-    }
+    format!("fill: {}", rgb(color))
 }
 
 pub(super) fn escape_typst(text: &str) -> String {


### PR DESCRIPTION
## Summary

The render layer hand-wrote `rgb(r, g, b)` color literals at ~22 emission sites and duplicated the stroke-format bodies (plain `Wpt + rgb(...)` vs `(paint: ..., thickness: ..., dash: ...)` dict) across four near-identical implementations (`write_shape_stroke`, `write_image_border_stroke`, `format_border_side`, `stroke_literal`).

This adds `render/typst_gen_fmt.rs` — `rgb`, `rgb_with_alpha`, `stroke_value`, and `format_f64` (moved from `typst_gen_text.rs`) — and routes every emission site through it. Zero hand-written `rgb({}, {}, {})` format sites remain in the render layer.

`stroke_value`'s `double_is_plain` flag deliberately preserves the existing table-vs-shape divergence for `Double` borders (tables emit a plain stroke; shapes emit a dash dict that maps to `dash: "solid"`). Both render identically solid in Typst, so unifying the syntax is out of scope for this byte-identical refactor; the flag is documented and unit-tested.

## Related issue

None — from the refactoring plan (render-layer duplication).

## Testing

- 9 new unit tests for the formatters (`typst_gen_fmt_tests.rs`)
- `cargo test --workspace`: 1788 passed, 0 failed — golden/fixture suite unchanged, confirming byte-identical output
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo check --target wasm32-unknown-unknown -p office2pdf --features wasm`: 0 warnings
- `cargo fmt --all --check`: clean
- Documentation freshness audit: PASS

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Pure deduplication refactor with byte-identical Typst output by design; the unchanged golden/fixture test suite verifies no emission changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)