### PR TITLE
refactor: unify OPC .rels parsing on xml_util

### DIFF
--- a/crates/office2pdf/src/parser/chart.rs
+++ b/crates/office2pdf/src/parser/chart.rs
@@ -366,58 +366,24 @@ pub(crate) fn scan_chart_references(xml: &str) -> Vec<(usize, String)> {
 ///
 /// Returns a map from relationship ID to chart file path (e.g., "rId4" → "word/charts/chart1.xml").
 pub(crate) fn scan_chart_rels(rels_xml: &str) -> std::collections::HashMap<String, String> {
-    let mut map = std::collections::HashMap::new();
-    let mut reader = Reader::from_str(rels_xml);
-
-    loop {
-        match reader.read_event() {
-            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
-                if e.local_name().as_ref() == b"Relationship" {
-                    let mut id = None;
-                    let mut target = None;
-                    let mut is_chart = false;
-
-                    for attr in e.attributes().flatten() {
-                        match attr.key.local_name().as_ref() {
-                            b"Id" => {
-                                if let Ok(v) = attr.unescape_value() {
-                                    id = Some(v.to_string());
-                                }
-                            }
-                            b"Target" => {
-                                if let Ok(v) = attr.unescape_value() {
-                                    target = Some(v.to_string());
-                                }
-                            }
-                            b"Type" => {
-                                if let Ok(v) = attr.unescape_value()
-                                    && v.contains("chart")
-                                {
-                                    is_chart = true;
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-
-                    if is_chart && let (Some(id), Some(target)) = (id, target) {
-                        // Target is relative to word/ directory
-                        let full_path = if let Some(stripped) = target.strip_prefix('/') {
-                            stripped.to_string()
-                        } else {
-                            format!("word/{target}")
-                        };
-                        map.insert(id, full_path);
-                    }
-                }
-            }
-            Ok(Event::Eof) => break,
-            Err(_) => break,
-            _ => {}
-        }
-    }
-
-    map
+    crate::parser::xml_util::parse_relationships(rels_xml)
+        .into_iter()
+        .filter(|entry| {
+            entry
+                .rel_type
+                .as_deref()
+                .is_some_and(|rel_type| rel_type.contains("chart"))
+        })
+        .map(|entry| {
+            // Target is relative to word/ directory
+            let full_path = if let Some(stripped) = entry.target.strip_prefix('/') {
+                stripped.to_string()
+            } else {
+                format!("word/{}", entry.target)
+            };
+            (entry.id, full_path)
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/office2pdf/src/parser/docx_sections.rs
+++ b/crates/office2pdf/src/parser/docx_sections.rs
@@ -44,62 +44,22 @@ fn scan_header_footer_relationships(
 ) -> (HashMap<String, String>, HashMap<String, String>) {
     let mut headers: HashMap<String, String> = HashMap::new();
     let mut footers: HashMap<String, String> = HashMap::new();
-    let mut reader = quick_xml::Reader::from_str(rels_xml);
 
-    loop {
-        match reader.read_event() {
-            Ok(quick_xml::events::Event::Start(ref element))
-            | Ok(quick_xml::events::Event::Empty(ref element)) => {
-                if element.local_name().as_ref() != b"Relationship" {
-                    continue;
-                }
+    for entry in crate::parser::xml_util::parse_relationships(rels_xml) {
+        let Some(relationship_type) = entry.rel_type else {
+            continue;
+        };
 
-                let mut id: Option<String> = None;
-                let mut target: Option<String> = None;
-                let mut relationship_type: Option<String> = None;
+        let full_path = if let Some(stripped) = entry.target.strip_prefix('/') {
+            stripped.to_string()
+        } else {
+            format!("word/{}", entry.target)
+        };
 
-                for attribute in element.attributes().flatten() {
-                    match attribute.key.local_name().as_ref() {
-                        b"Id" => {
-                            if let Ok(value) = attribute.unescape_value() {
-                                id = Some(value.to_string());
-                            }
-                        }
-                        b"Target" => {
-                            if let Ok(value) = attribute.unescape_value() {
-                                target = Some(value.to_string());
-                            }
-                        }
-                        b"Type" => {
-                            if let Ok(value) = attribute.unescape_value() {
-                                relationship_type = Some(value.to_string());
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-
-                let Some(id) = id else { continue };
-                let Some(target) = target else { continue };
-                let Some(relationship_type) = relationship_type else {
-                    continue;
-                };
-
-                let full_path = if let Some(stripped) = target.strip_prefix('/') {
-                    stripped.to_string()
-                } else {
-                    format!("word/{target}")
-                };
-
-                if relationship_type.ends_with("/header") {
-                    headers.insert(id, full_path);
-                } else if relationship_type.ends_with("/footer") {
-                    footers.insert(id, full_path);
-                }
-            }
-            Ok(quick_xml::events::Event::Eof) => break,
-            Err(_) => break,
-            _ => {}
+        if relationship_type.ends_with("/header") {
+            headers.insert(entry.id, full_path);
+        } else if relationship_type.ends_with("/footer") {
+            footers.insert(entry.id, full_path);
         }
     }
 

--- a/crates/office2pdf/src/parser/pptx_package.rs
+++ b/crates/office2pdf/src/parser/pptx_package.rs
@@ -320,34 +320,18 @@ fn handle_presentation_element(
 }
 
 fn parse_relationships_xml(xml: &str) -> HashMap<String, Relationship> {
-    let mut map = HashMap::new();
-    let mut reader = Reader::from_str(xml);
-
-    loop {
-        match reader.read_event() {
-            Ok(Event::Empty(ref element)) | Ok(Event::Start(ref element)) => {
-                if element.local_name().as_ref() == b"Relationship"
-                    && let (Some(id), Some(target)) = (
-                        get_attr_str(element, b"Id"),
-                        get_attr_str(element, b"Target"),
-                    )
-                {
-                    map.insert(
-                        id,
-                        Relationship {
-                            target,
-                            rel_type: get_attr_str(element, b"Type"),
-                        },
-                    );
-                }
-            }
-            Ok(Event::Eof) => break,
-            Err(_) => break,
-            _ => {}
-        }
-    }
-
-    map
+    crate::parser::xml_util::parse_relationships(xml)
+        .into_iter()
+        .map(|entry| {
+            (
+                entry.id,
+                Relationship {
+                    target: entry.target,
+                    rel_type: entry.rel_type,
+                },
+            )
+        })
+        .collect()
 }
 
 pub(super) fn parse_rels_xml(xml: &str) -> HashMap<String, String> {

--- a/crates/office2pdf/src/parser/xlsx_cond_fmt_raw.rs
+++ b/crates/office2pdf/src/parser/xlsx_cond_fmt_raw.rs
@@ -42,28 +42,7 @@ fn read_zip_text(
 }
 
 fn parse_relationships(xml: &str) -> HashMap<String, String> {
-    let mut relationships = HashMap::new();
-    let mut reader = Reader::from_str(xml);
-    reader.config_mut().trim_text(true);
-
-    loop {
-        match reader.read_event() {
-            Ok(Event::Start(element) | Event::Empty(element))
-                if element.local_name().as_ref() == b"Relationship" =>
-            {
-                if let (Some(id), Some(target)) = (
-                    attr_value(&reader, &element, b"Id"),
-                    attr_value(&reader, &element, b"Target"),
-                ) {
-                    relationships.insert(id, target);
-                }
-            }
-            Ok(Event::Eof) | Err(_) => break,
-            _ => {}
-        }
-    }
-
-    relationships
+    crate::parser::xml_util::parse_rels_id_target(xml)
 }
 
 fn parse_sheet_relationships(xml: &str) -> Vec<(String, String)> {

--- a/crates/office2pdf/src/parser/xml_util.rs
+++ b/crates/office2pdf/src/parser/xml_util.rs
@@ -99,35 +99,32 @@ pub(crate) fn resolve_relative_path(base_dir: &str, relative: &str) -> String {
     parts.join("/")
 }
 
-/// Parse a .rels XML file and return a map of Id → Target.
-pub(crate) fn parse_rels_id_target(xml: &str) -> std::collections::HashMap<String, String> {
-    let mut map = std::collections::HashMap::new();
+/// One `<Relationship>` entry from an OPC `.rels` part.
+pub(crate) struct RelationshipEntry {
+    pub id: String,
+    pub target: String,
+    pub rel_type: Option<String>,
+}
+
+/// Parse an OPC `.rels` part into its `<Relationship>` entries in document
+/// order. Entries without an `Id` or `Target` are dropped; a missing `Type`
+/// is kept as `None` (some producers omit it).
+pub(crate) fn parse_relationships(xml: &str) -> Vec<RelationshipEntry> {
+    let mut entries: Vec<RelationshipEntry> = Vec::new();
     let mut reader = Reader::from_str(xml);
 
     loop {
         match reader.read_event() {
             Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
-                if e.local_name().as_ref() == b"Relationship" {
-                    let mut id = None;
-                    let mut target = None;
-                    for attr in e.attributes().flatten() {
-                        match attr.key.local_name().as_ref() {
-                            b"Id" => {
-                                if let Ok(v) = attr.unescape_value() {
-                                    id = Some(v.to_string());
-                                }
-                            }
-                            b"Target" => {
-                                if let Ok(v) = attr.unescape_value() {
-                                    target = Some(v.to_string());
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                    if let (Some(id), Some(target)) = (id, target) {
-                        map.insert(id, target);
-                    }
+                if e.local_name().as_ref() == b"Relationship"
+                    && let (Some(id), Some(target)) =
+                        (get_attr_str(e, b"Id"), get_attr_str(e, b"Target"))
+                {
+                    entries.push(RelationshipEntry {
+                        id,
+                        target,
+                        rel_type: get_attr_str(e, b"Type"),
+                    });
                 }
             }
             Ok(Event::Eof) => break,
@@ -136,7 +133,15 @@ pub(crate) fn parse_rels_id_target(xml: &str) -> std::collections::HashMap<Strin
         }
     }
 
-    map
+    entries
+}
+
+/// Parse a .rels XML file and return a map of Id → Target.
+pub(crate) fn parse_rels_id_target(xml: &str) -> std::collections::HashMap<String, String> {
+    parse_relationships(xml)
+        .into_iter()
+        .map(|entry| (entry.id, entry.target))
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/office2pdf/src/parser/xml_util_tests.rs
+++ b/crates/office2pdf/src/parser/xml_util_tests.rs
@@ -138,3 +138,47 @@ fn get_attr_i64_parses_integer() {
         _ => panic!("expected Empty event"),
     }
 }
+
+#[test]
+fn parse_relationships_returns_id_target_type_entries() {
+    let xml = r#"<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/>
+</Relationships>"#;
+    let entries = parse_relationships(xml);
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].id, "rId1");
+    assert_eq!(entries[0].target, "slides/slide1.xml");
+    assert!(
+        entries[0]
+            .rel_type
+            .as_deref()
+            .is_some_and(|t| t.ends_with("/slide"))
+    );
+    assert_eq!(entries[1].id, "rId2");
+    assert_eq!(entries[1].target, "../charts/chart1.xml");
+}
+
+#[test]
+fn parse_relationships_tolerates_missing_type_and_unescapes() {
+    let xml = r#"<Relationships>
+  <Relationship Id="rId1" Target="media/a&amp;b.png"/>
+  <Relationship Id="rId2" Type="t"/>
+</Relationships>"#;
+    let entries = parse_relationships(xml);
+    // rId2 has no Target and is dropped; rId1 has no Type but is kept.
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].target, "media/a&b.png");
+    assert_eq!(entries[0].rel_type, None);
+}
+
+#[test]
+fn parse_rels_id_target_last_duplicate_wins() {
+    let xml = r#"<Relationships>
+  <Relationship Id="rId1" Target="first.xml"/>
+  <Relationship Id="rId1" Target="second.xml"/>
+</Relationships>"#;
+    let map = parse_rels_id_target(xml);
+    assert_eq!(map.get("rId1").map(String::as_str), Some("second.xml"));
+}


### PR DESCRIPTION
## Summary

Five hand-rolled `<Relationship>` parsers duplicated the same attribute-extraction loop: `xml_util::parse_rels_id_target`, `pptx_package::parse_relationships_xml`, `chart::scan_chart_rels`, `docx_sections::scan_header_footer_relationships`, and `xlsx_cond_fmt_raw::parse_relationships`.

This adds `xml_util::parse_relationships(xml) -> Vec<RelationshipEntry {id, target, rel_type}>` as the single OPC rels parser and delegates all five to it. Caller-side policies (chart-type filtering, `word/` path prefixing, header/footer split by Type suffix) remain at their call sites.

## Related issue

None — from the refactoring plan (cross-format parser duplication).

## Testing

- TDD: 3 new unit tests for `parse_relationships` / `parse_rels_id_target` written first (entry extraction, missing-Type tolerance + unescaping, last-duplicate-wins)
- `cargo test --workspace`: 1782 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo check --target wasm32-unknown-unknown -p office2pdf --features wasm`: 0 warnings
- `cargo fmt --all --check`: clean
- Documentation freshness audit: PASS

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Pure deduplication — the unified parser reproduces the exact Id/Target/Type extraction and unescaping semantics of each removed loop; the unchanged fixture/golden suite confirms identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)