### PR TITLE
refactor: consolidate verbatim-duplicated test fixture builders

### DIFF
--- a/crates/office2pdf/src/lib.rs
+++ b/crates/office2pdf/src/lib.rs
@@ -67,7 +67,7 @@ use error::{ConvertError, ConvertResult};
 mod pipeline;
 #[cfg(test)]
 #[path = "lib_test_support.rs"]
-mod test_support;
+pub(crate) mod test_support;
 
 #[cfg(test)]
 fn is_ole2(data: &[u8]) -> bool {

--- a/crates/office2pdf/src/lib_test_support.rs
+++ b/crates/office2pdf/src/lib_test_support.rs
@@ -202,3 +202,42 @@ pub(super) fn make_test_docx_bytes() -> Vec<u8> {
     docx.build().pack(&mut buf).unwrap();
     buf.into_inner()
 }
+
+// ── Shared OOXML fixture builders ───────────────────────────────────────
+// Builders used verbatim by more than one sibling `*_tests.rs` module live
+// here; single-use or diverging variants stay local to their test file.
+
+/// One `<a:tr>` PPTX table row with a plain text cell per entry.
+pub(crate) fn make_table_row(cells: &[&str]) -> String {
+    let mut xml = String::from(r#"<a:tr h="370840">"#);
+    for text in cells {
+        xml.push_str(&format!(
+            r#"<a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:rPr lang="en-US"/><a:t>{text}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>"#
+        ));
+    }
+    xml.push_str("</a:tr>");
+    xml
+}
+
+/// A `<p:graphicFrame>` wrapping a PPTX table with the given geometry (EMU).
+pub(crate) fn make_table_graphic_frame(
+    x: i64,
+    y: i64,
+    cx: i64,
+    cy: i64,
+    col_widths_emu: &[i64],
+    rows_xml: &str,
+) -> String {
+    let mut grid = String::new();
+    for width in col_widths_emu {
+        grid.push_str(&format!(r#"<a:gridCol w="{width}"/>"#));
+    }
+    format!(
+        r#"<p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="4" name="Table"/><p:cNvGraphicFramePr><a:graphicFrameLocks noGrp="1"/></p:cNvGraphicFramePr><p:nvPr/></p:nvGraphicFramePr><p:xfrm><a:off x="{x}" y="{y}"/><a:ext cx="{cx}" cy="{cy}"/></p:xfrm><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl><a:tblPr/><a:tblGrid>{grid}</a:tblGrid>{rows_xml}</a:tbl></a:graphicData></a:graphic></p:graphicFrame>"#
+    )
+}
+
+/// A minimal 1x1 red-rect SVG image.
+pub(crate) fn make_test_svg() -> Vec<u8> {
+    br##"<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" viewBox="0 0 1 1"><rect width="1" height="1" fill="#ff0000"/></svg>"##.to_vec()
+}

--- a/crates/office2pdf/src/parser/pptx_image_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_image_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::ir::ImageCrop;
+use crate::test_support::make_test_svg;
 use std::io::{Cursor, Write};
 use zip::write::FileOptions;
 
@@ -26,11 +27,6 @@ pub(super) fn make_test_bmp() -> Vec<u8> {
     // Pixel data: 1 pixel (BGR) + 1 byte padding to align to 4 bytes
     bmp.extend_from_slice(&[0x00, 0x00, 0xFF, 0x00]);
     bmp
-}
-
-/// Create a minimal valid SVG image for test images.
-fn make_test_svg() -> Vec<u8> {
-    br##"<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" viewBox="0 0 1 1"><rect width="1" height="1" fill="#ff0000"/></svg>"##.to_vec()
 }
 
 fn append_u32(out: &mut Vec<u8>, value: u32) {

--- a/crates/office2pdf/src/parser/pptx_table_style_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_table_style_tests.rs
@@ -1,36 +1,9 @@
 use super::*;
+use crate::test_support::{make_table_graphic_frame, make_table_row};
 use std::io::Write;
 use table_styles::{PptxTableProps, PptxTableStyleDef, TableCellRegionStyle, TableStyleMap};
 
 // ── Helpers ────────────────────────────────────────────────────────────
-
-fn make_table_graphic_frame(
-    x: i64,
-    y: i64,
-    cx: i64,
-    cy: i64,
-    col_widths_emu: &[i64],
-    rows_xml: &str,
-) -> String {
-    let mut grid = String::new();
-    for width in col_widths_emu {
-        grid.push_str(&format!(r#"<a:gridCol w="{width}"/>"#));
-    }
-    format!(
-        r#"<p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="4" name="Table"/><p:cNvGraphicFramePr><a:graphicFrameLocks noGrp="1"/></p:cNvGraphicFramePr><p:nvPr/></p:nvGraphicFramePr><p:xfrm><a:off x="{x}" y="{y}"/><a:ext cx="{cx}" cy="{cy}"/></p:xfrm><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl><a:tblPr/><a:tblGrid>{grid}</a:tblGrid>{rows_xml}</a:tbl></a:graphicData></a:graphic></p:graphicFrame>"#
-    )
-}
-
-fn make_table_row(cells: &[&str]) -> String {
-    let mut xml = String::from(r#"<a:tr h="370840">"#);
-    for text in cells {
-        xml.push_str(&format!(
-            r#"<a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:rPr lang="en-US"/><a:t>{text}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>"#
-        ));
-    }
-    xml.push_str("</a:tr>");
-    xml
-}
 
 fn table_element(elem: &FixedElement) -> &Table {
     match &elem.kind {

--- a/crates/office2pdf/src/parser/pptx_table_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_table_tests.rs
@@ -1,32 +1,5 @@
 use super::*;
-
-fn make_table_graphic_frame(
-    x: i64,
-    y: i64,
-    cx: i64,
-    cy: i64,
-    col_widths_emu: &[i64],
-    rows_xml: &str,
-) -> String {
-    let mut grid = String::new();
-    for width in col_widths_emu {
-        grid.push_str(&format!(r#"<a:gridCol w="{width}"/>"#));
-    }
-    format!(
-        r#"<p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="4" name="Table"/><p:cNvGraphicFramePr><a:graphicFrameLocks noGrp="1"/></p:cNvGraphicFramePr><p:nvPr/></p:nvGraphicFramePr><p:xfrm><a:off x="{x}" y="{y}"/><a:ext cx="{cx}" cy="{cy}"/></p:xfrm><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl><a:tblPr/><a:tblGrid>{grid}</a:tblGrid>{rows_xml}</a:tbl></a:graphicData></a:graphic></p:graphicFrame>"#
-    )
-}
-
-fn make_table_row(cells: &[&str]) -> String {
-    let mut xml = String::from(r#"<a:tr h="370840">"#);
-    for text in cells {
-        xml.push_str(&format!(
-            r#"<a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:rPr lang="en-US"/><a:t>{text}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>"#
-        ));
-    }
-    xml.push_str("</a:tr>");
-    xml
-}
+use crate::test_support::{make_table_graphic_frame, make_table_row};
 
 fn table_element(elem: &FixedElement) -> &Table {
     match &elem.kind {

--- a/crates/office2pdf/src/render/pdf_tests.rs
+++ b/crates/office2pdf/src/render/pdf_tests.rs
@@ -1,5 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))] // native-only unit tests (filesystem, system fonts)
 use super::*;
+use crate::test_support::make_test_svg;
 
 #[test]
 fn test_compile_simple_text() {
@@ -138,10 +139,6 @@ fn make_test_png() -> Vec<u8> {
     png.extend_from_slice(&png_crc32(iend_type, &[]).to_be_bytes());
 
     png
-}
-
-fn make_test_svg() -> Vec<u8> {
-    br##"<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1" viewBox="0 0 1 1"><rect width="1" height="1" fill="#ff0000"/></svg>"##.to_vec()
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Three test fixture builders were duplicated byte-for-byte across sibling `*_tests.rs` files: `make_table_row` and `make_table_graphic_frame` (pptx_table_tests ↔ pptx_table_style_tests) and `make_test_svg` (pptx_image_tests ↔ render/pdf_tests).

The crate's `#[cfg(test)] test_support` module is promoted to `pub(crate)` and the three builders move there; the four test files import them.

**Deliberately out of scope**: same-named builders whose bodies differ between files (`make_slide_xml`, `make_bar_chart_xml`, `make_master_xml`, `make_layout_xml`, `make_text_box`, `build_xlsx_with_rows`) — checksum comparison showed they are per-scenario variants, not duplication; forcing them into one parameterized builder would hurt test readability.

## Related issue

None — from the refactoring plan (test fixture duplication).

## Testing

- `cargo test --workspace`: 1788 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --all --check`: clean
- Documentation freshness audit: PASS

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Test-only change — no library or codegen source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)