### PR TITLE
refactor: extract DrawingML color primitives into shared module

### DIFF
--- a/crates/office2pdf/src/parser/drawingml.rs
+++ b/crates/office2pdf/src/parser/drawingml.rs
@@ -1,0 +1,244 @@
+//! Shared DrawingML color primitives: scheme-color resolution and OOXML
+//! color transforms (tint/shade/lumMod/lumOff/alpha).
+//!
+//! DrawingML color markup (`<a:srgbClr>`, `<a:schemeClr>`, `<a:sysClr>` with
+//! nested transform children) is identical across pptx, docx, and xlsx parts.
+//! This module holds the single implementation; format parsers supply their
+//! own theme palette and alias map through [`SchemeColors`].
+
+use std::collections::HashMap;
+
+use quick_xml::Reader;
+use quick_xml::events::{BytesStart, Event};
+
+use crate::ir::Color;
+use crate::parser::xml_util::{get_attr_i64, get_attr_str, parse_hex_color};
+
+/// A format-agnostic view of a theme's color scheme.
+///
+/// `aliases` carries part-level scheme aliases (the pptx `<p:clrMap>`); pass
+/// an empty map when the format has no alias layer (docx, xlsx).
+pub(crate) struct SchemeColors<'a> {
+    pub(crate) colors: &'a HashMap<String, Color>,
+    pub(crate) aliases: &'a HashMap<String, String>,
+}
+
+/// Resolve a scheme color name (e.g. `accent1`, `bg1`) against the theme.
+///
+/// The alias map is consulted first; if the aliased entry is missing, the raw
+/// name is tried so a partially populated theme still resolves.
+pub(crate) fn resolve_scheme_color(scheme: &SchemeColors<'_>, scheme_name: &str) -> Option<Color> {
+    let mapped_name = scheme
+        .aliases
+        .get(scheme_name)
+        .map(String::as_str)
+        .unwrap_or(scheme_name);
+
+    scheme
+        .colors
+        .get(mapped_name)
+        .copied()
+        .or_else(|| scheme.colors.get(scheme_name).copied())
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ColorTransform {
+    Tint(f64),
+    Shade(f64),
+    LumMod(f64),
+    LumOff(f64),
+}
+
+/// A parsed DrawingML color: the resolved RGB value plus an optional alpha.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ParsedColor {
+    pub(crate) color: Option<Color>,
+    pub(crate) alpha: Option<f64>,
+}
+
+fn parse_base_color(element: &BytesStart<'_>, scheme: &SchemeColors<'_>) -> Option<Color> {
+    match element.local_name().as_ref() {
+        b"srgbClr" => get_attr_str(element, b"val").and_then(|hex| parse_hex_color(&hex)),
+        b"schemeClr" => {
+            get_attr_str(element, b"val").and_then(|name| resolve_scheme_color(scheme, &name))
+        }
+        b"sysClr" => get_attr_str(element, b"lastClr").and_then(|hex| parse_hex_color(&hex)),
+        _ => None,
+    }
+}
+
+pub(crate) fn parse_color_transform(element: &BytesStart<'_>) -> Option<ColorTransform> {
+    let val = get_attr_i64(element, b"val")? as f64 / 100_000.0;
+    match element.local_name().as_ref() {
+        b"tint" => Some(ColorTransform::Tint(val)),
+        b"shade" => Some(ColorTransform::Shade(val)),
+        b"lumMod" => Some(ColorTransform::LumMod(val)),
+        b"lumOff" => Some(ColorTransform::LumOff(val)),
+        _ => None,
+    }
+}
+
+pub(crate) fn apply_color_transforms(color: Color, transforms: &[ColorTransform]) -> Color {
+    // Apply tint/shade in RGB space first (OOXML spec: blend toward white/black).
+    let mut r: f64 = color.r as f64;
+    let mut g: f64 = color.g as f64;
+    let mut b: f64 = color.b as f64;
+
+    for transform in transforms {
+        match transform {
+            ColorTransform::Tint(t) => {
+                r = 255.0 - (255.0 - r) * t;
+                g = 255.0 - (255.0 - g) * t;
+                b = 255.0 - (255.0 - b) * t;
+            }
+            ColorTransform::Shade(s) => {
+                r *= s;
+                g *= s;
+                b *= s;
+            }
+            _ => {}
+        }
+    }
+
+    let tinted = Color::new(
+        r.round().clamp(0.0, 255.0) as u8,
+        g.round().clamp(0.0, 255.0) as u8,
+        b.round().clamp(0.0, 255.0) as u8,
+    );
+
+    // Then apply luminance transforms in HSL space.
+    let has_lum_transforms: bool = transforms
+        .iter()
+        .any(|t| matches!(t, ColorTransform::LumMod(_) | ColorTransform::LumOff(_)));
+
+    if !has_lum_transforms {
+        return tinted;
+    }
+
+    let (mut hue, mut saturation, mut lightness) = rgb_to_hsl(tinted);
+
+    for transform in transforms {
+        match transform {
+            ColorTransform::LumMod(value) => {
+                lightness = (lightness * value).clamp(0.0, 1.0);
+            }
+            ColorTransform::LumOff(value) => {
+                lightness = (lightness + value).clamp(0.0, 1.0);
+            }
+            _ => {}
+        }
+    }
+
+    saturation = saturation.clamp(0.0, 1.0);
+    hue = hue.rem_euclid(360.0);
+    hsl_to_rgb(hue, saturation, lightness)
+}
+
+/// Parse a self-closing color element (no transform children possible).
+pub(crate) fn parse_color_from_empty(
+    element: &BytesStart<'_>,
+    scheme: &SchemeColors<'_>,
+) -> ParsedColor {
+    ParsedColor {
+        color: parse_base_color(element, scheme),
+        alpha: None,
+    }
+}
+
+/// Parse a color element with children, consuming events through its end tag
+/// and applying any nested transforms.
+pub(crate) fn parse_color_from_start(
+    reader: &mut Reader<&[u8]>,
+    element: &BytesStart<'_>,
+    scheme: &SchemeColors<'_>,
+) -> ParsedColor {
+    let base_color = parse_base_color(element, scheme);
+    let mut transforms: Vec<ColorTransform> = Vec::new();
+    let mut alpha: Option<f64> = None;
+    let mut depth: usize = 1;
+
+    while depth > 0 {
+        match reader.read_event() {
+            Ok(Event::Start(ref child)) => {
+                depth += 1;
+                if let Some(transform) = parse_color_transform(child) {
+                    transforms.push(transform);
+                } else if child.local_name().as_ref() == b"alpha" {
+                    alpha = get_attr_i64(child, b"val").map(|v| v as f64 / 100_000.0);
+                }
+            }
+            Ok(Event::Empty(ref child)) => {
+                if let Some(transform) = parse_color_transform(child) {
+                    transforms.push(transform);
+                } else if child.local_name().as_ref() == b"alpha" {
+                    alpha = get_attr_i64(child, b"val").map(|v| v as f64 / 100_000.0);
+                }
+            }
+            Ok(Event::End(_)) => {
+                depth -= 1;
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    let color = base_color.map(|base| apply_color_transforms(base, &transforms));
+
+    ParsedColor { color, alpha }
+}
+
+fn rgb_to_hsl(color: Color) -> (f64, f64, f64) {
+    let red = color.r as f64 / 255.0;
+    let green = color.g as f64 / 255.0;
+    let blue = color.b as f64 / 255.0;
+
+    let max = red.max(green.max(blue));
+    let min = red.min(green.min(blue));
+    let delta = max - min;
+    let lightness = (max + min) / 2.0;
+
+    if delta == 0.0 {
+        return (0.0, 0.0, lightness);
+    }
+
+    let saturation = delta / (1.0 - (2.0 * lightness - 1.0).abs());
+    let hue_sector = if max == red {
+        ((green - blue) / delta).rem_euclid(6.0)
+    } else if max == green {
+        ((blue - red) / delta) + 2.0
+    } else {
+        ((red - green) / delta) + 4.0
+    };
+
+    (60.0 * hue_sector, saturation, lightness)
+}
+
+fn hsl_to_rgb(hue: f64, saturation: f64, lightness: f64) -> Color {
+    if saturation == 0.0 {
+        let channel = (lightness * 255.0).round() as u8;
+        return Color::new(channel, channel, channel);
+    }
+
+    let chroma = (1.0 - (2.0 * lightness - 1.0).abs()) * saturation;
+    let hue_prime = hue / 60.0;
+    let secondary = chroma * (1.0 - ((hue_prime.rem_euclid(2.0)) - 1.0).abs());
+    let match_lightness = lightness - chroma / 2.0;
+
+    let (red, green, blue) = match hue_prime {
+        h if (0.0..1.0).contains(&h) => (chroma, secondary, 0.0),
+        h if (1.0..2.0).contains(&h) => (secondary, chroma, 0.0),
+        h if (2.0..3.0).contains(&h) => (0.0, chroma, secondary),
+        h if (3.0..4.0).contains(&h) => (0.0, secondary, chroma),
+        h if (4.0..5.0).contains(&h) => (secondary, 0.0, chroma),
+        _ => (chroma, 0.0, secondary),
+    };
+
+    let to_u8 = |value: f64| ((value + match_lightness).clamp(0.0, 1.0) * 255.0).round() as u8;
+
+    Color::new(to_u8(red), to_u8(green), to_u8(blue))
+}
+
+#[cfg(test)]
+#[path = "drawingml_tests.rs"]
+mod tests;

--- a/crates/office2pdf/src/parser/drawingml_tests.rs
+++ b/crates/office2pdf/src/parser/drawingml_tests.rs
@@ -1,0 +1,147 @@
+use std::collections::HashMap;
+
+use quick_xml::Reader;
+use quick_xml::events::Event;
+
+use super::*;
+use crate::ir::Color;
+
+fn scheme_with(colors: &[(&str, Color)], aliases: &[(&str, &str)]) -> (ColorsMap, AliasMap) {
+    let colors: ColorsMap = colors
+        .iter()
+        .map(|(name, color)| ((*name).to_string(), *color))
+        .collect();
+    let aliases: AliasMap = aliases
+        .iter()
+        .map(|(from, to)| ((*from).to_string(), (*to).to_string()))
+        .collect();
+    (colors, aliases)
+}
+
+type ColorsMap = HashMap<String, Color>;
+type AliasMap = HashMap<String, String>;
+
+#[test]
+fn resolve_scheme_color_direct_lookup() {
+    let (colors, aliases) = scheme_with(&[("accent1", Color::new(68, 114, 196))], &[]);
+    let scheme = SchemeColors {
+        colors: &colors,
+        aliases: &aliases,
+    };
+    assert_eq!(
+        resolve_scheme_color(&scheme, "accent1"),
+        Some(Color::new(68, 114, 196))
+    );
+    assert_eq!(resolve_scheme_color(&scheme, "accent2"), None);
+}
+
+#[test]
+fn resolve_scheme_color_follows_alias() {
+    // pptx clrMap maps bg1 → lt1 for typical slides.
+    let (colors, aliases) = scheme_with(&[("lt1", Color::new(255, 255, 255))], &[("bg1", "lt1")]);
+    let scheme = SchemeColors {
+        colors: &colors,
+        aliases: &aliases,
+    };
+    assert_eq!(
+        resolve_scheme_color(&scheme, "bg1"),
+        Some(Color::new(255, 255, 255))
+    );
+}
+
+#[test]
+fn resolve_scheme_color_falls_back_to_unaliased_name() {
+    // Alias points at a missing entry; the raw name still resolves.
+    let (colors, aliases) = scheme_with(&[("bg1", Color::new(1, 2, 3))], &[("bg1", "lt9")]);
+    let scheme = SchemeColors {
+        colors: &colors,
+        aliases: &aliases,
+    };
+    assert_eq!(
+        resolve_scheme_color(&scheme, "bg1"),
+        Some(Color::new(1, 2, 3))
+    );
+}
+
+#[test]
+fn tint_blends_toward_white() {
+    // OOXML tint 0.4: channel = 255 - (255 - c) * 0.4
+    let out = apply_color_transforms(Color::new(0, 100, 255), &[ColorTransform::Tint(0.4)]);
+    assert_eq!(out, Color::new(153, 193, 255));
+}
+
+#[test]
+fn shade_scales_toward_black() {
+    let out = apply_color_transforms(Color::new(200, 100, 50), &[ColorTransform::Shade(0.5)]);
+    assert_eq!(out, Color::new(100, 50, 25));
+}
+
+#[test]
+fn lum_mod_and_off_adjust_lightness_in_hsl() {
+    // lumMod 0.5 halves lightness; pure red keeps its hue.
+    let out = apply_color_transforms(Color::new(255, 0, 0), &[ColorTransform::LumMod(0.5)]);
+    assert_eq!(out, Color::new(128, 0, 0));
+
+    // lumOff +0.2 raises lightness toward a lighter red.
+    let out = apply_color_transforms(Color::new(255, 0, 0), &[ColorTransform::LumOff(0.2)]);
+    assert_eq!(out, Color::new(255, 102, 102));
+}
+
+#[test]
+fn no_transforms_is_identity() {
+    let color = Color::new(12, 34, 56);
+    assert_eq!(apply_color_transforms(color, &[]), color);
+}
+
+fn parse_first_color(xml: &str, colors: &ColorsMap, aliases: &AliasMap) -> ParsedColor {
+    let mut reader = Reader::from_str(xml);
+    let scheme = SchemeColors { colors, aliases };
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) => {
+                return parse_color_from_start(&mut reader, e, &scheme);
+            }
+            Ok(Event::Empty(ref e)) => {
+                return parse_color_from_empty(e, &scheme);
+            }
+            Ok(Event::Eof) => panic!("no color element in fixture"),
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn parse_srgb_color_with_lum_transforms() {
+    // Realistic DrawingML: accent fill darkened via lumMod as PowerPoint emits.
+    let (colors, aliases) = scheme_with(&[], &[]);
+    let parsed = parse_first_color(
+        r#"<a:srgbClr val="FF0000"><a:lumMod val="50000"/></a:srgbClr>"#,
+        &colors,
+        &aliases,
+    );
+    assert_eq!(parsed.color, Some(Color::new(128, 0, 0)));
+    assert_eq!(parsed.alpha, None);
+}
+
+#[test]
+fn parse_scheme_color_with_alpha() {
+    let (colors, aliases) = scheme_with(&[("accent1", Color::new(68, 114, 196))], &[]);
+    let parsed = parse_first_color(
+        r#"<a:schemeClr val="accent1"><a:alpha val="50000"/></a:schemeClr>"#,
+        &colors,
+        &aliases,
+    );
+    assert_eq!(parsed.color, Some(Color::new(68, 114, 196)));
+    assert_eq!(parsed.alpha, Some(0.5));
+}
+
+#[test]
+fn parse_sys_color_uses_last_clr() {
+    let (colors, aliases) = scheme_with(&[], &[]);
+    let parsed = parse_first_color(
+        r#"<a:sysClr val="windowText" lastClr="000000"/>"#,
+        &colors,
+        &aliases,
+    );
+    assert_eq!(parsed.color, Some(Color::new(0, 0, 0)));
+}

--- a/crates/office2pdf/src/parser/mod.rs
+++ b/crates/office2pdf/src/parser/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod chart;
 pub(crate) mod cond_fmt;
 pub mod docx;
+pub(crate) mod drawingml;
 pub(crate) mod embedded_fonts;
 #[path = "pptx_emf.rs"]
 pub(crate) mod emf;

--- a/crates/office2pdf/src/parser/pptx_theme.rs
+++ b/crates/office2pdf/src/parser/pptx_theme.rs
@@ -28,19 +28,8 @@ pub(super) struct ColorMapData {
     pub(super) aliases: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
-pub(super) struct ParsedColor {
-    pub(super) color: Option<Color>,
-    pub(super) alpha: Option<f64>,
-}
-
-#[derive(Debug, Clone, Copy)]
-enum ColorTransform {
-    Tint(f64),
-    Shade(f64),
-    LumMod(f64),
-    LumOff(f64),
-}
+pub(super) use crate::parser::drawingml::ParsedColor;
+use crate::parser::drawingml::{self, SchemeColors};
 
 const COLOR_MAP_KEYS: &[&str] = &[
     "bg1", "tx1", "bg2", "tx2", "accent1", "accent2", "accent3", "accent4", "accent5", "accent6",
@@ -177,98 +166,15 @@ pub(super) fn resolve_scheme_color(
     color_map: &ColorMapData,
     scheme_name: &str,
 ) -> Option<Color> {
-    let mapped_name = color_map
-        .aliases
-        .get(scheme_name)
-        .map(String::as_str)
-        .unwrap_or(scheme_name);
-
-    theme
-        .colors
-        .get(mapped_name)
-        .copied()
-        .or_else(|| theme.colors.get(scheme_name).copied())
+    drawingml::resolve_scheme_color(&scheme_colors(theme, color_map), scheme_name)
 }
 
-fn parse_base_color(
-    element: &BytesStart<'_>,
-    theme: &ThemeData,
-    color_map: &ColorMapData,
-) -> Option<Color> {
-    match element.local_name().as_ref() {
-        b"srgbClr" => get_attr_str(element, b"val").and_then(|hex| parse_hex_color(&hex)),
-        b"schemeClr" => get_attr_str(element, b"val")
-            .and_then(|name| resolve_scheme_color(theme, color_map, &name)),
-        b"sysClr" => get_attr_str(element, b"lastClr").and_then(|hex| parse_hex_color(&hex)),
-        _ => None,
+/// Adapt pptx theme + clrMap to the shared DrawingML color scheme view.
+fn scheme_colors<'a>(theme: &'a ThemeData, color_map: &'a ColorMapData) -> SchemeColors<'a> {
+    SchemeColors {
+        colors: &theme.colors,
+        aliases: &color_map.aliases,
     }
-}
-
-fn parse_color_transform(element: &BytesStart<'_>) -> Option<ColorTransform> {
-    let val = get_attr_i64(element, b"val")? as f64 / 100_000.0;
-    match element.local_name().as_ref() {
-        b"tint" => Some(ColorTransform::Tint(val)),
-        b"shade" => Some(ColorTransform::Shade(val)),
-        b"lumMod" => Some(ColorTransform::LumMod(val)),
-        b"lumOff" => Some(ColorTransform::LumOff(val)),
-        _ => None,
-    }
-}
-
-fn apply_color_transforms(color: Color, transforms: &[ColorTransform]) -> Color {
-    // Apply tint/shade in RGB space first (OOXML spec: blend toward white/black).
-    let mut r: f64 = color.r as f64;
-    let mut g: f64 = color.g as f64;
-    let mut b: f64 = color.b as f64;
-
-    for transform in transforms {
-        match transform {
-            ColorTransform::Tint(t) => {
-                r = 255.0 - (255.0 - r) * t;
-                g = 255.0 - (255.0 - g) * t;
-                b = 255.0 - (255.0 - b) * t;
-            }
-            ColorTransform::Shade(s) => {
-                r *= s;
-                g *= s;
-                b *= s;
-            }
-            _ => {}
-        }
-    }
-
-    let tinted = Color::new(
-        r.round().clamp(0.0, 255.0) as u8,
-        g.round().clamp(0.0, 255.0) as u8,
-        b.round().clamp(0.0, 255.0) as u8,
-    );
-
-    // Then apply luminance transforms in HSL space.
-    let has_lum_transforms: bool = transforms
-        .iter()
-        .any(|t| matches!(t, ColorTransform::LumMod(_) | ColorTransform::LumOff(_)));
-
-    if !has_lum_transforms {
-        return tinted;
-    }
-
-    let (mut hue, mut saturation, mut lightness) = rgb_to_hsl(tinted);
-
-    for transform in transforms {
-        match transform {
-            ColorTransform::LumMod(value) => {
-                lightness = (lightness * value).clamp(0.0, 1.0);
-            }
-            ColorTransform::LumOff(value) => {
-                lightness = (lightness + value).clamp(0.0, 1.0);
-            }
-            _ => {}
-        }
-    }
-
-    saturation = saturation.clamp(0.0, 1.0);
-    hue = hue.rem_euclid(360.0);
-    hsl_to_rgb(hue, saturation, lightness)
 }
 
 pub(super) fn parse_color_from_empty(
@@ -276,10 +182,7 @@ pub(super) fn parse_color_from_empty(
     theme: &ThemeData,
     color_map: &ColorMapData,
 ) -> ParsedColor {
-    ParsedColor {
-        color: parse_base_color(element, theme, color_map),
-        alpha: None,
-    }
+    drawingml::parse_color_from_empty(element, &scheme_colors(theme, color_map))
 }
 
 pub(super) fn parse_color_from_start(
@@ -288,91 +191,7 @@ pub(super) fn parse_color_from_start(
     theme: &ThemeData,
     color_map: &ColorMapData,
 ) -> ParsedColor {
-    let base_color = parse_base_color(element, theme, color_map);
-    let mut transforms: Vec<ColorTransform> = Vec::new();
-    let mut alpha: Option<f64> = None;
-    let mut depth: usize = 1;
-
-    while depth > 0 {
-        match reader.read_event() {
-            Ok(Event::Start(ref child)) => {
-                depth += 1;
-                if let Some(transform) = parse_color_transform(child) {
-                    transforms.push(transform);
-                } else if child.local_name().as_ref() == b"alpha" {
-                    alpha = get_attr_i64(child, b"val").map(|v| v as f64 / 100_000.0);
-                }
-            }
-            Ok(Event::Empty(ref child)) => {
-                if let Some(transform) = parse_color_transform(child) {
-                    transforms.push(transform);
-                } else if child.local_name().as_ref() == b"alpha" {
-                    alpha = get_attr_i64(child, b"val").map(|v| v as f64 / 100_000.0);
-                }
-            }
-            Ok(Event::End(_)) => {
-                depth -= 1;
-            }
-            Ok(Event::Eof) => break,
-            Err(_) => break,
-            _ => {}
-        }
-    }
-
-    let color = base_color.map(|base| apply_color_transforms(base, &transforms));
-
-    ParsedColor { color, alpha }
-}
-
-fn rgb_to_hsl(color: Color) -> (f64, f64, f64) {
-    let red = color.r as f64 / 255.0;
-    let green = color.g as f64 / 255.0;
-    let blue = color.b as f64 / 255.0;
-
-    let max = red.max(green.max(blue));
-    let min = red.min(green.min(blue));
-    let delta = max - min;
-    let lightness = (max + min) / 2.0;
-
-    if delta == 0.0 {
-        return (0.0, 0.0, lightness);
-    }
-
-    let saturation = delta / (1.0 - (2.0 * lightness - 1.0).abs());
-    let hue_sector = if max == red {
-        ((green - blue) / delta).rem_euclid(6.0)
-    } else if max == green {
-        ((blue - red) / delta) + 2.0
-    } else {
-        ((red - green) / delta) + 4.0
-    };
-
-    (60.0 * hue_sector, saturation, lightness)
-}
-
-fn hsl_to_rgb(hue: f64, saturation: f64, lightness: f64) -> Color {
-    if saturation == 0.0 {
-        let channel = (lightness * 255.0).round() as u8;
-        return Color::new(channel, channel, channel);
-    }
-
-    let chroma = (1.0 - (2.0 * lightness - 1.0).abs()) * saturation;
-    let hue_prime = hue / 60.0;
-    let secondary = chroma * (1.0 - ((hue_prime.rem_euclid(2.0)) - 1.0).abs());
-    let match_lightness = lightness - chroma / 2.0;
-
-    let (red, green, blue) = match hue_prime {
-        h if (0.0..1.0).contains(&h) => (chroma, secondary, 0.0),
-        h if (1.0..2.0).contains(&h) => (secondary, chroma, 0.0),
-        h if (2.0..3.0).contains(&h) => (0.0, chroma, secondary),
-        h if (3.0..4.0).contains(&h) => (0.0, secondary, chroma),
-        h if (4.0..5.0).contains(&h) => (secondary, 0.0, chroma),
-        _ => (chroma, 0.0, secondary),
-    };
-
-    let to_u8 = |value: f64| ((value + match_lightness).clamp(0.0, 1.0) * 255.0).round() as u8;
-
-    Color::new(to_u8(red), to_u8(green), to_u8(blue))
+    drawingml::parse_color_from_start(reader, element, &scheme_colors(theme, color_map))
 }
 
 /// Parse a theme XML string to extract the color scheme and font scheme.


### PR DESCRIPTION
## Summary

DrawingML color markup (`srgbClr`/`schemeClr`/`sysClr` with nested `tint`/`shade`/`lumMod`/`lumOff`/`alpha` children) is the same across pptx, docx, and xlsx parts, but the codebase has three diverging implementations. Only `pptx_theme.rs` implements the full OOXML transform math; `docx_context_shape.rs` has a weaker theme-color map without transforms, and `xlsx_drawing.rs` hardcodes `schemeClr` to a black/white fallback.

This PR moves the pptx implementation — scheme-color resolution with alias fallback, transform parsing/application, the color-element readers, and rgb↔hsl conversion — verbatim into a new format-agnostic `parser/drawingml.rs` behind a `SchemeColors` view (theme palette + optional alias map). `pptx_theme.rs` keeps its signatures as thin delegating wrappers, so ~20 pptx call sites are untouched.

This is the groundwork PR: routing docx/xlsx through the shared math changes rendered output and will follow as separate visually-verified fixes.

## Related issue

None — part of the ongoing refactoring series (#426–#429).

## Testing

- 10 new unit tests for the shared module (scheme resolution incl. alias fallback, tint/shade/lumMod/lumOff math, element parsing with alpha)
- `cargo test --workspace`: 1801 passed, 0 failed — golden/fixture output unchanged
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo check --target wasm32-unknown-unknown -p office2pdf --features wasm`: 0 warnings
- `cargo fmt --all --check`: clean
- Documentation freshness audit: PASS

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Logic moved verbatim behind delegating wrappers with unchanged signatures; docx/xlsx are intentionally not yet routed through the shared module. The unchanged fixture/golden suite confirms identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)