### PR TITLE
fix(xlsx): read self-closing drawing run properties

### DIFF
--- a/crates/office2pdf/src/parser/xlsx_drawing.rs
+++ b/crates/office2pdf/src/parser/xlsx_drawing.rs
@@ -746,6 +746,35 @@ fn resolved_or_legacy(
     })
 }
 
+/// Apply an `<a:rPr>` element's size and emphasis attributes to a run
+/// style. Called from both the `Start` and `Empty` arms of the drawing
+/// reader: Excel writes shape-label run properties as a self-closing
+/// element, which quick-xml reports as `Empty`, and reading them on `Start`
+/// alone dropped every attribute (issue #466).
+fn apply_run_properties(
+    style: &mut crate::ir::TextStyle,
+    element: &quick_xml::events::BytesStart<'_>,
+) {
+    for attr in element.attributes().flatten() {
+        match attr.key.local_name().as_ref() {
+            b"sz" => {
+                if let Ok(value) = attr.unescape_value()
+                    && let Ok(hundredths_pt) = value.parse::<f64>()
+                {
+                    style.font_size = Some(hundredths_pt / 100.0);
+                }
+            }
+            b"b" if attr.unescape_value().ok().as_deref() == Some("1") => {
+                style.bold = Some(true);
+            }
+            b"i" if attr.unescape_value().ok().as_deref() == Some("1") => {
+                style.italic = Some(true);
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Parse `<xdr:sp>` text boxes from a worksheet drawing, resolving scheme
 /// colors against the workbook theme palette and run typefaces against its
 /// font scheme.
@@ -846,26 +875,7 @@ pub(super) fn parse_drawing_text_boxes(
                         in_run = true;
                         current_style = TextStyle::default();
                     }
-                    b"rPr" if in_run => {
-                        for attr in e.attributes().flatten() {
-                            match attr.key.local_name().as_ref() {
-                                b"sz" => {
-                                    if let Ok(v) = attr.unescape_value()
-                                        && let Ok(sz) = v.parse::<f64>()
-                                    {
-                                        current_style.font_size = Some(sz / 100.0);
-                                    }
-                                }
-                                b"b" if attr.unescape_value().ok().as_deref() == Some("1") => {
-                                    current_style.bold = Some(true);
-                                }
-                                b"i" if attr.unescape_value().ok().as_deref() == Some("1") => {
-                                    current_style.italic = Some(true);
-                                }
-                                _ => {}
-                            }
-                        }
-                    }
+                    b"rPr" if in_run => apply_run_properties(&mut current_style, e),
                     b"t" if in_run => in_text = true,
                     b"srgbClr" | b"schemeClr" => {
                         let parsed =
@@ -905,6 +915,7 @@ pub(super) fn parse_drawing_text_boxes(
                             current_style.font_family = Some(family);
                         }
                     }
+                    b"rPr" if in_run => apply_run_properties(&mut current_style, e),
                     b"pPr" if current_para.is_some() => {
                         for attr in e.attributes().flatten() {
                             if attr.key.local_name().as_ref() == b"algn"

--- a/crates/office2pdf/src/parser/xlsx_drawing_tests.rs
+++ b/crates/office2pdf/src/parser/xlsx_drawing_tests.rs
@@ -261,3 +261,47 @@ fn theme_font_scheme_ignores_empty_typefaces() {
     let fonts = crate::parser::drawingml::parse_theme_font_scheme(theme_xml);
     assert_eq!(fonts, ThemeFontScheme::default());
 }
+
+/// `(font_size, bold, italic)` of the single run the fixture produces.
+fn run_emphasis(run_properties: &str) -> (Option<f64>, Option<bool>, Option<bool>) {
+    let boxes = parse_drawing_text_boxes(
+        &drawing_with_run_properties(run_properties),
+        &HashMap::new(),
+        &ThemeFontScheme::default(),
+    );
+    assert_eq!(boxes.len(), 1, "fixture should yield one text box");
+    let style = &boxes[0].paragraphs[0].runs[0].style;
+    (style.font_size, style.bold, style.italic)
+}
+
+#[test]
+fn self_closing_run_properties_still_carry_size_and_emphasis() {
+    // Excel writes shape-label run properties as a self-closing element,
+    // which quick-xml reports as `Event::Empty`; reading them only on
+    // `Event::Start` dropped every attribute (issue #466).
+    assert_eq!(
+        run_emphasis(r#"<a:rPr lang="en-US" sz="1400" b="1" i="1"/>"#),
+        (Some(14.0), Some(true), Some(true))
+    );
+}
+
+#[test]
+fn run_properties_with_children_keep_working() {
+    // Triangulation: the same attributes on an element that has children
+    // must resolve identically, so the fix cannot special-case one spelling.
+    assert_eq!(
+        run_emphasis(
+            r#"<a:rPr lang="en-US" sz="1400" b="1" i="1"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:rPr>"#
+        ),
+        (Some(14.0), Some(true), Some(true))
+    );
+}
+
+#[test]
+fn run_properties_omit_emphasis_when_disabled() {
+    // `b="0"`/`i="0"` mean "not bold"/"not italic"; they must not set the flag.
+    assert_eq!(
+        run_emphasis(r#"<a:rPr lang="en-US" sz="900" b="0" i="0"/>"#),
+        (Some(9.0), None, None)
+    );
+}


### PR DESCRIPTION
## Summary

- extract the `<a:rPr>` attribute loop into `apply_run_properties`
- call it from the reader's `Event::Empty` arm as well as `Event::Start`, so a self-closing `<a:rPr/>` keeps its size, bold, and italic

## Related issue

Fixes #466

## Details

Excel writes a shape label's run properties as a self-closing element, `<a:rPr lang="en-US" sz="1100"/>`, which quick-xml reports as `Event::Empty`. The drawing reader matched `rPr` only in its `Event::Start` arm, so every attribute on that spelling was discarded and the run fell back to the renderer's default 11pt regular.

That default happens to equal the common `sz="1100"`, which hid the defect until a label used another size or weight. Parsing the same attributes in both spellings showed the split:

| Run properties | font_size | bold | italic |
| --- | --- | --- | --- |
| `<a:rPr lang="en-US" sz="1400" b="1" i="1"/>` | `None` | `None` | `None` |
| `<a:rPr … ><a:solidFill>…</a:solidFill></a:rPr>` | `Some(14.0)` | `Some(true)` | `Some(true)` |

Only the presence of a child element changed the outcome, which is not a distinction DrawingML makes. The new tests assert both spellings resolve identically, and that `b="0"`/`i="0"` still mean "not bold"/"not italic".

## Testing

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features`
- rendered all 68 committed XLSX fixtures before and after and compared `pdftotext -bbox` output

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: no committed fixture exercises the defect. The only self-closing run properties in the corpus use `sz="1100"`, which equals the renderer default. Rendering all 68 XLSX fixtures before and after leaves 67 byte-identical in `pdftotext -bbox` layout; the 68th (`tests/fixtures/xlsx/WithDrawing.xlsx`) differs only by 1e-5 pt on two word coordinates, from taking Typst's explicit-11pt path instead of its default-11pt path. Documents outside the corpus that use another size, bold, or italic on a self-closing `<a:rPr/>` will render differently — correctly — after this change.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
