### PR TITLE
ci: cache Git LFS objects instead of refetching the fixture corpus

### DIFF
--- a/.github/actions/lfs-fixtures/action.yml
+++ b/.github/actions/lfs-fixtures/action.yml
@@ -1,0 +1,49 @@
+name: Fetch LFS fixtures
+description: >-
+  Restore the Git LFS fixture corpus from the Actions cache and pull only the
+  objects the cache does not already hold.
+
+runs:
+  using: composite
+  steps:
+    # Key the cache on the LFS object manifest rather than a commit SHA: the corpus is
+    # immutable third-party data, so the key changes only when a fixture is actually
+    # added or replaced, not on every push.
+    - name: Resolve LFS object manifest
+      shell: bash
+      run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+    # restore-keys lets a manifest change reuse the previous corpus and pull only the
+    # delta, so adding one fixture costs one fixture of bandwidth, not the whole corpus.
+    - name: Restore LFS object cache
+      uses: actions/cache@v4
+      with:
+        path: .git/lfs
+        key: lfs-${{ runner.os }}-${{ hashFiles('.lfs-assets-id') }}
+        restore-keys: lfs-${{ runner.os }}-
+
+    # Reports cache-vs-network bytes so LFS bandwidth regressions are visible in the job
+    # log instead of only surfacing later as a billing block.
+    - name: Fetch missing LFS objects
+      shell: bash
+      run: |
+        set -euo pipefail
+        restored_kib="$(du -sk .git/lfs/objects 2>/dev/null | cut -f1 || echo 0)"
+        git lfs pull
+        final_kib="$(du -sk .git/lfs/objects | cut -f1)"
+        echo "LFS objects: ${restored_kib} KiB restored from cache, ${final_kib} KiB total, $((final_kib - restored_kib)) KiB downloaded from the LFS endpoint"
+
+    # Fixture tests call is_lfs_pointer() and silently `return` on an unfetched pointer
+    # (crates/office2pdf/tests/docx_fixtures.rs, xlsx_fixtures.rs), so an incomplete
+    # restore would turn real coverage into skipped tests behind a green check. Fail
+    # loudly here instead: `git lfs ls-files` marks a pointer-only entry with `-`.
+    - name: Verify every LFS object materialized
+      shell: bash
+      run: |
+        set -euo pipefail
+        unfetched="$(git lfs ls-files | awk '$2 == "-"' | wc -l | tr -d ' ')"
+        if [ "${unfetched}" -ne 0 ]; then
+          echo "::error::${unfetched} LFS object(s) still unfetched after pull; fixture tests would silently skip"
+          exit 1
+        fi
+        echo "All $(git lfs ls-files | wc -l | tr -d ' ') LFS objects materialized"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
+        env:
+          GIT_LFS_SKIP_SMUDGE: "1"
+      - uses: ./.github/actions/lfs-fixtures
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install qpdf
@@ -183,7 +186,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
+        env:
+          GIT_LFS_SKIP_SMUDGE: "1"
+      - uses: ./.github/actions/lfs-fixtures
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Compare fixture outcomes with baseline


### PR DESCRIPTION
## Summary

- check out the `test` and `bulk-test` jobs without LFS content and restore the fixture corpus from the Actions cache instead
- key the cache on the LFS object manifest, so the LFS endpoint is contacted only when a fixture actually changes
- fail the job when any LFS pointer survives the pull, because fixture tests skip silently on unfetched pointers
- log cache-versus-network KiB on every run so a bandwidth regression is visible in the job log

## Related issue

None — this is a CI cost defect found while diagnosing an LFS `HTTP 403`.

## Details

The `test` job runs a three-OS matrix and the `bulk-test` job runs once, and all four legs checked out with `lfs: true`. Every CI run therefore pulled the entire 2,695-file fixture corpus four times.

| | measured |
| --- | --- |
| unique LFS objects | 2,695 (0.0948 GiB per checkout) |
| full-corpus pulls per run | 4 |
| bandwidth per run | 0.379 GiB |
| CI runs in the last 30 days | 402 (244 `pull_request`, 158 `push`) |
| bandwidth per month | ~152 GiB |

The account's included LFS bandwidth is 10 GiB/month, so CI alone ran roughly fifteen times over the allowance and hard-blocked LFS with `HTTP 403: This repository exceeded its LFS budget`.

Two things make this avoidable rather than inherent. The corpus is immutable third-party data — it landed in a single commit on 2026-03-01 and no commit has touched `tests/fixtures/*/libreoffice/*` or `tests/fixtures/*/poi/*` since, against 397 commits elsewhere on `main` in the same window. And `cargo test --workspace` reads only a small curated subset of it; the whole corpus is genuinely needed only by the `#[ignore]`d gate in `bulk_conversion.rs`, which runs in `bulk-test`.

Caching keyed on the LFS object manifest therefore hits on essentially every run, and the `restore-keys` fallback means a future fixture addition pulls that one fixture rather than re-pulling all 97 MB.

The correctness half matters as much as the bandwidth half. `docx_fixtures.rs` and `xlsx_fixtures.rs` call `is_lfs_pointer()` and `return` early when a fixture is still a pointer:

```rust
if is_lfs_pointer(&path) {
    eprintln!("Skipping {}: Git LFS pointer (not fetched)", $fixture);
    return;
}
```

Under `lfs: true`, checkout guaranteed content was present. Under caching, a partial restore would convert real coverage into skipped tests behind a green check — a worse failure than the one being fixed. The action now fails the job if `git lfs ls-files` reports any pointer-only entry, so an incomplete restore is loud instead of silent.

The two jobs share a composite action rather than duplicated steps, so the two call sites cannot drift apart — drift here is invisible and costs money.

## Testing

- `python3 -c "yaml.safe_load(...)"` on `ci.yml` and the new `action.yml`
- verified no `lfs: true` remains anywhere under `.github/`
- verified the manifest command is deterministic across runs: 2,695 lines, all 64-hex oids, 0 malformed
- verified `git lfs pull` with the corpus already present downloads **0 KiB**, which is the mechanic the cache relies on
- executed the pointer guard against the real tree: `unfetched=0`, all 2,695 objects materialized

No `cargo` test run: per `CLAUDE.md`, CI pipeline configuration is not runtime code. The end-to-end verification is the CI runs on this PR — the first populates the cache, and a subsequent run must report `0 KiB downloaded from the LFS endpoint` on all four legs.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: CI workflow configuration only; no parser, layout, or codegen path is touched.
