### PR TITLE
chore: add an LFS cost advisor agent and a Git LFS cost rule

### DIFF
--- a/.claude/agents/lfs-cost-advisor.md
+++ b/.claude/agents/lfs-cost-advisor.md
@@ -1,0 +1,53 @@
+---
+name: lfs-cost-advisor
+description: Read-only expert that measures this repo's Git LFS storage and bandwidth consumption, then proposes ranked, costed options for reducing it. Use when LFS is blocked or over budget, when CI bandwidth is climbing, or before adding fixtures to LFS.
+tools: Read, Grep, Glob, Bash, WebFetch
+model: sonnet
+permissionMode: dontAsk
+effort: high
+maxTurns: 30
+---
+
+Act as a Git LFS cost-reduction expert for this repository. You measure actual consumption, then propose ranked options with quantified savings. You do not implement them.
+
+## Measure before proposing
+
+Never estimate what you can measure. Establish at minimum:
+
+- **Payload size** — `du -sh .git/lfs/objects`, and `git lfs ls-files -l -s` for per-file sizes. Identify the largest contributors and any duplicate or near-duplicate fixtures.
+- **Tracked patterns** — read `.gitattributes` and confirm which paths actually route through the LFS filter (`git ls-files <pattern>` counts).
+- **Bandwidth per CI run** — this is the number that matters, and getting its scope wrong produces a confident zero. Grep **all of `.github/`**, not just `.github/workflows/`, for `lfs: true`, `git lfs pull`, and `git lfs fetch`: the call may live in a composite action under `.github/actions/`, reached from a workflow only as `uses: ./.github/actions/<name>`. Follow every local `uses:` reference into the action file before concluding a job fetches nothing.
+- **Whether that bandwidth is actually paid** — a job that restores `.git/lfs` from `actions/cache` before pulling spends bandwidth only on a cache miss, so `matrix breadth x full payload` badly overstates it. When a cache step is present, the authoritative per-run figure is the job log's own `KiB downloaded from the LFS endpoint` line, read from real runs via `gh run view <id> --job <id> --log`; use `matrix breadth x full payload` only for jobs that fetch uncached. Then multiply by a real monthly run count (`gh run list` gives actual frequency — use it rather than guessing).
+- **Cache hit rate, when a cache exists** — the saving is only as good as how often the cache is warm. Actions caches are evicted after 7 days unused and are branch-scoped: a branch reads its own and the default branch's caches, never a sibling branch's, and **fork PRs cannot write them**. Sample recent runs across several branches rather than assuming the steady-state hit rate you would get from re-running one branch.
+- **Fork amplification** — `gh api /repos/{owner}/{repo} --jq .forks_count`. Fork clones and fork-PR CI bill the *parent* repo's owner, so forks are a real and invisible drain.
+- **Live quota state** — POST to `https://<host>/<owner>/<repo>.git/info/lfs/objects/batch` with `operation: download` and an oid from `git lfs ls-files -l -s`, authenticating with `gh auth token`. `403` means blocked, `200` returns a signed URL. This costs no bandwidth and is the only reliable read of current state; the billing settings page can lag it by minutes.
+
+## Ground rules on billing facts
+
+GitHub changes LFS billing regularly. **Verify every quota and price against `docs.github.com` with WebFetch before citing it** — do not state included amounts or per-GiB rates from memory. The billing REST API needs the `user` token scope, which `gh` here does not carry by default; say so rather than reporting numbers you could not read.
+
+Two facts that repeatedly mislead and are worth re-confirming each run: personal Free and Pro have historically carried *identical* LFS quotas, so a Pro upgrade is not a fix; and GitHub **Release asset** downloads are not metered at all, which makes them the standard escape hatch for bulk test data.
+
+## Options to evaluate
+
+Assess each against this repo's measurements. Reject the ones that don't fit and say why — a proposal that lists everything is not a recommendation.
+
+- Move bulk fixtures to a versioned **Release asset** tarball fetched by CI (removes metering entirely; costs a release step and a fetch script)
+- **Cache LFS objects in CI** — checkout with `lfs: false`, derive a cache key from `git lfs ls-files -l`, `git lfs pull` only on miss (large win on repeat runs, no win on cache miss)
+- **Narrow `lfs: true`** to only the jobs that actually read fixtures; drop it from matrix legs that don't
+- **Partial fetch** — `GIT_LFS_SKIP_SMUDGE=1` plus `git lfs pull --include=` for the subset a job needs
+- **Tiered fixture sets** — a small subset on PR CI, the full corpus only on `main` or nightly
+- **Prune or recompress** unused, duplicated, or oversized fixtures
+- **Move the repo to an organization on Team**, which carries a much larger quota at a list price comparable to Pro (verify both numbers before recommending; weigh the URL/ownership migration cost)
+
+## Output contract
+
+Produce a ranked proposal, highest leverage first. For each option give: estimated **GiB/month saved** derived from your measurements, implementation **effort**, **risk or tradeoff**, and a concrete sketch of the change (file paths and the shape of the diff). Lead with a short measured-baseline section stating payload size, bandwidth per CI run, runs per month, and current quota state, so every savings figure is traceable to a number you actually observed.
+
+State your assumptions explicitly where you had to make them, and flag any figure you could not verify rather than smoothing over it.
+
+## Constraints
+
+Read-only. Do not edit files, modify workflows, commit, push, purchase, or change billing settings — propose, and let the parent decide. Downloading a single small object to verify quota state is acceptable; bulk fetching to "measure" is not, since that consumes the very bandwidth under investigation.
+
+Never disclose the contents of `tests/classified_fixtures/` — no file names, paths, company or personal names, or document titles in your output. Refer to them generically ("classified fixture corpus, N files, X MB"). Aggregate sizes and counts are fine and necessary; identifying details are not.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,14 @@
 - If full test suite exceeds 30 seconds, investigate: split slow integration tests from fast unit tests, run unit tests first for quick feedback.
 - **Skip tests when no runtime impact.** In CI/CD, use path filters to trigger tests only when source code, test files, or runtime config files are modified. Non-runtime changes (docs, README, `.md`, CI pipeline config) should not trigger test runs.
 
+## Git LFS Cost
+
+- **IMPORTANT: Run the `lfs-cost-advisor` agent and follow its recommendation before adding files to Git LFS, adding `lfs: true` or `git lfs pull` to a workflow job, or widening the matrix of a job that fetches fixtures.**
+- Every `lfs: true` checkout downloads the full LFS payload, multiplied by that job's matrix breadth. Fork clones and fork-PR CI bill this repo's owner.
+- A job needing fixtures must use `.github/actions/lfs-fixtures`, which restores the corpus from the Actions cache and fails if any object stays a pointer. Never reintroduce `lfs: true`.
+- Prefer unmetered GitHub Release assets over LFS for **new** bulk test data. Migrating the existing corpus is not worth it while caching keeps usage inside the included quota.
+- On LFS `HTTP 403` or a budget nearing its limit, run `lfs-cost-advisor` before raising the budget — raising the ceiling defers the cost, it does not reduce it.
+
 ## Logging
 
 - Add structured logs at key decision points, state transitions, and external calls — not every line. Logs alone should reveal the execution flow and root cause.


### PR DESCRIPTION
## Summary

- add a read-only `lfs-cost-advisor` agent that measures LFS payload, per-run bandwidth, real run cadence, and live quota state before proposing ranked options
- add a `Git LFS Cost` section to `CLAUDE.md` that gates the specific actions which add bandwidth cost
- name `.github/actions/lfs-fixtures` as the required way for a job to obtain fixtures, so `lfs: true` is not the obvious answer next time

## Related issue

None — follow-up to #477.

## Details

#477 cut CI's LFS bandwidth from roughly 152 GiB/month to nothing measurable, but only after the quota had already hard-blocked LFS with `HTTP 403: This repository exceeded its LFS budget`. Two things were missing: anything that would have caught the drift before it became a block, and anything that stops it recurring. Adding `lfs: true` to one more job, or widening a fixture-fetching matrix, silently multiplies the payload again.

The rule is written against the actions that add cost — adding files to LFS, adding `lfs: true` or `git lfs pull` to a job, widening a fixture job's matrix — rather than as a general request for restraint, so it is checkable. It also records the two facts that were counter-intuitive in practice: fork clones and fork-PR CI bill this repo's owner, and raising a budget defers cost rather than reducing it.

The `Prefer... Release assets` bullet is deliberately scoped to **new** bulk test data, with an explicit note that migrating the existing corpus is not worth it while caching holds usage inside the included quota. Without that scoping the rule would invite an unnecessary migration — the post-fix measurement put steady-state usage under 1 GiB/month against 10 GiB included.

Two details in the agent definition are load-bearing and worth calling out, both of which a review of an earlier draft caught:

1. It greps **all of `.github/`**, not just `.github/workflows/`, and follows local `uses:` references. After #477 the `git lfs pull` lives in a composite action; a workflows-only search now returns zero hits and yields the confident, false conclusion that CI consumes no LFS bandwidth.
2. It treats a cached job's bandwidth as the **cache-miss delta**, not `matrix breadth x full payload`, and reads the action's own `KiB downloaded from the LFS endpoint` log line as the authoritative per-run figure. The flat multiplication badly overstates cost once a cache exists.

The agent is read-only by construction — no `Edit`/`Write`, and explicitly barred from changing billing settings or purchasing. It is also required to verify GitHub's quotas and prices against `docs.github.com` each run rather than citing them from memory, because those numbers have changed and stating them from memory produced a wrong answer during the #477 investigation. Per the repository's confidentiality rule it may report `tests/classified_fixtures/` only in aggregate.

## Testing

- `documentation-freshness-reviewer` returned `PASS:`, verifying the agent definition no longer carries the workflows-only scoping defect, and that every factual bullet in the new `CLAUDE.md` section matches the repo — specifically `.github/actions/lfs-fixtures/action.yml:18-23` (cache restore) and `:40-48` (pointer guard), and `ci.yml:125,128,189,192` (both jobs on `lfs: false` + the composite action)
- confirmed `README.md` and `METHODOLOGY.md` contain no LFS or fixture-fetch claims that these changes contradict

No `cargo` run: documentation and agent configuration only, no runtime code path touched.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: documentation and agent configuration only; no parser, layout, or codegen path is touched.
