### PR TITLE
fix(ci): stop attributing pre-existing LFS bytes to the cache

### DIFF
--- a/.github/actions/lfs-fixtures/action.yml
+++ b/.github/actions/lfs-fixtures/action.yml
@@ -16,22 +16,29 @@ runs:
     # restore-keys lets a manifest change reuse the previous corpus and pull only the
     # delta, so adding one fixture costs one fixture of bandwidth, not the whole corpus.
     - name: Restore LFS object cache
+      id: lfs-cache
       uses: actions/cache@v4
       with:
         path: .git/lfs
         key: lfs-${{ runner.os }}-${{ hashFiles('.lfs-assets-id') }}
         restore-keys: lfs-${{ runner.os }}-
 
-    # Reports cache-vs-network bytes so LFS bandwidth regressions are visible in the job
-    # log instead of only surfacing later as a billing block.
+    # Reports bytes actually pulled over the network so LFS bandwidth regressions are
+    # visible in the job log instead of only surfacing later as a billing block. The
+    # pre-pull figure is whatever is on disk, which is not the same as what the cache
+    # supplied — checkout can leave objects behind even on a miss — so it is labelled as
+    # such rather than attributed to the cache.
     - name: Fetch missing LFS objects
       shell: bash
+      env:
+        EXACT_CACHE_HIT: ${{ steps.lfs-cache.outputs.cache-hit }}
       run: |
         set -euo pipefail
-        restored_kib="$(du -sk .git/lfs/objects 2>/dev/null | cut -f1 || echo 0)"
+        before_kib="$(du -sk .git/lfs/objects 2>/dev/null | cut -f1 || echo 0)"
         git lfs pull
-        final_kib="$(du -sk .git/lfs/objects | cut -f1)"
-        echo "LFS objects: ${restored_kib} KiB restored from cache, ${final_kib} KiB total, $((final_kib - restored_kib)) KiB downloaded from the LFS endpoint"
+        after_kib="$(du -sk .git/lfs/objects | cut -f1)"
+        echo "LFS cache: exact key hit=${EXACT_CACHE_HIT:-false}"
+        echo "LFS objects: ${before_kib} KiB on disk before pull, ${after_kib} KiB after, $((after_kib - before_kib)) KiB downloaded from the LFS endpoint"
 
     # Fixture tests call is_lfs_pointer() and silently `return` on an unfetched pointer
     # (crates/office2pdf/tests/docx_fixtures.rs, xlsx_fixtures.rs), so an incomplete


### PR DESCRIPTION
## Summary

- report the pre-pull byte count as disk state instead of attributing it to the Actions cache
- read cache status from the cache step's own `cache-hit` output rather than inferring it from byte counts
- keep the `KiB downloaded from the LFS endpoint` wording unchanged, since `lfs-cost-advisor` reads that exact substring

## Related issue

None — follow-up to #477.

## Details

The `Fetch missing LFS objects` step measured `.git/lfs/objects` before pulling and labelled the result `restored from cache`. That figure is simply whatever is on disk at that moment, which is not the same as what the cache supplied — checkout leaves some objects behind even on a miss.

The result was a log that contradicted itself on the first real run. From CI run `30182375735`, attempt 1:

```
Cache not found for input keys: lfs-Linux-2d807950..., lfs-Linux-
LFS objects: 11572 KiB restored from cache, 116604 KiB total, 105032 KiB downloaded ...
```

The same empty-cache condition produced three different "restored from cache" values across the legs — `11572` on Linux, `864` on Windows, `0` on macOS — which is the tell that the number was measuring disk state, not cache behaviour.

The downloaded figure was always correct; only the attribution was wrong. This matters because the whole point of that log line is to make an LFS bandwidth regression visible before it becomes a billing block, and a reader reconciling `Cache not found` against `restored from cache` has to distrust the instrument.

After:

```
LFS cache: exact key hit=false
LFS objects: 11572 KiB on disk before pull, 116604 KiB after, 105032 KiB downloaded from the LFS endpoint
```

The status line is labelled **exact key hit** deliberately. Per the upstream `actions/cache` README, `cache-hit` is `true` only on a primary-key match and `false` both on a `restore-keys` partial restore and on a total miss. Those two cases are distinguished by the adjacent on-disk figure, which is nonzero for a partial restore.

## Testing

- `documentation-freshness-reviewer` returned `PASS:`, having verified `cache-hit` semantics against the upstream `actions/cache` README, confirmed the rewritten comment matches the code, and confirmed the `KiB downloaded from the LFS endpoint` substring is preserved so `.claude/agents/lfs-cost-advisor.md:20` is not broken by the rename
- grepped the tree for `restored_kib`, `final_kib`, and `restored from cache` — zero remaining references
- `python3 -c "yaml.safe_load(...)"` on the changed action
- rendered the new log lines locally against the real fixture tree: `exact key hit=true` / `105032 KiB on disk before pull, 105032 KiB after, 0 KiB downloaded from the LFS endpoint`

The end-to-end check is this PR's own CI, which should print the new format with `0 KiB downloaded` on all four fixture legs.

No `cargo` run: CI pipeline configuration only, no runtime code path touched.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: CI logging only; no parser, layout, or codegen path is touched.
