### PR TITLE
chore: warn when too few lines matched to trust the geometry

### DIFF
--- a/scripts/compare_render.py
+++ b/scripts/compare_render.py
@@ -129,12 +129,20 @@ def report_geometry(gt: Path, other: Path) -> dict[str, float]:
         return {}
     mad_y = sum(abs(value) for value in dy) / len(dy)
     mad_x = sum(abs(value) for value in dx) / len(dx)
-    print(f"  matched lines      {len(dy)}")
+    coverage = len(dy) / len(gt_lines) if gt_lines else 0.0
+    print(f"  matched lines      {len(dy)} of {len(gt_lines)} "
+          f"({coverage * 100:.0f}% of the GT's unique lines)")
     print(f"  vertical   MAD {mad_y:7.2f}pt   worst {max(dy, key=abs):+8.2f}pt")
     print(f"  horizontal MAD {mad_x:7.2f}pt   worst {max(dx, key=abs):+8.2f}pt")
     if page_mismatch:
         print(f"  on a different page: {page_mismatch} line(s) — pagination differs")
-    return {"mad_y": mad_y, "mad_x": mad_x, "page_mismatch": float(page_mismatch)}
+    return {
+        "mad_y": mad_y,
+        "mad_x": mad_x,
+        "page_mismatch": float(page_mismatch),
+        "matched": float(len(dy)),
+        "coverage": coverage,
+    }
 
 
 def histogram(png: Path) -> tuple[list[int], int]:
@@ -238,6 +246,21 @@ def diagnose(geometry: dict[str, float], histogram_result: dict[str, float]) -> 
         print("  Geometry could not be measured, so the other axes stand alone.")
         print("  Compare the pages by eye before trusting them.")
         return
+
+    # A drift figure averaged over a handful of lines is noise. Korean
+    # sheets match poorly because word segmentation differs between the two
+    # PDFs, and one such page reported 4.11pt of "drift" from nine matched
+    # lines out of sixty — a number with no meaning that would have sent the
+    # next investigation chasing a row-height bug that is not there.
+    matched: float = geometry.get("matched", 0.0)
+    coverage: float = geometry.get("coverage", 0.0)
+    if matched < 10 or coverage < 0.25:
+        print(f"  Only {matched:.0f} lines matched ({coverage * 100:.0f}% of the GT).")
+        print("  Treat the geometry figures as unreliable: too few samples, and")
+        print("  the ones that matched are not a random selection. Compare the")
+        print("  pages by eye, or measure a specific element directly, before")
+        print("  drawing any conclusion from the drift above.")
+        print()
 
     mad_y: float = geometry["mad_y"]
     mad_x: float = geometry["mad_x"]


### PR DESCRIPTION
## Summary

- report the geometry match count as a share of the GT's unique lines
- say plainly in `## Reading` when the sample is too small or too partial to support a conclusion

## Why

The geometry axis averages drift over lines matched by unique text. When few match, that average is noise — but the tool presented it with the same confidence as a figure drawn from a full page.

Found while auditing the XLSX golden mocks after #487. All four Korean sheets reported vertical drift while every English one was clean:

| Sheet | reported drift |
| --- | ---: |
| 01_quotation_ko | 4.11pt |
| 04_payroll_ko | 3.47pt |
| 07_attendance_ko | 4.45pt |
| 08_budget_ko | 3.47pt |
| all six English sheets | no material difference |

That pattern reads as a CJK row-height defect, and it would have been the obvious thing to open next. It is not real: Korean pages match poorly because word segmentation differs between the two PDFs, and `01_quotation_ko` averaged its 4.11pt from **nine matched lines out of twenty-one**, clustered rather than spread.

## After

```
## Geometry — position, size, pitch
  matched lines      9 of 21 (43% of the GT's unique lines)
  vertical   MAD    4.11pt   worst    +6.58pt

## Reading
  Only 9 lines matched (43% of the GT).
  Treat the geometry figures as unreliable: too few samples, and
  the ones that matched are not a random selection. Compare the
  pages by eye, or measure a specific element directly, before
  drawing any conclusion from the drift above.
```

The threshold is fewer than 10 matched lines or under 25% coverage — loose on purpose, since it routes attention rather than deciding anything.

## Testing

- `python3 -m py_compile scripts/compare_render.py`
- re-ran the ten XLSX and ten PPTX golden mocks; the warning fires on exactly the four Korean sheets whose match counts are low and stays quiet on the rest

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: changes an analysis script only; no renderer code is touched.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue