### PR TITLE
fix(tools): measure geometry from text baselines, not descriptor boxes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,11 +137,20 @@ Run `python3 scripts/compare_render.py <GT.pdf> <output.pdf> [--page N]` before
 judging a rendered difference. It reports geometry, colour histogram, and pixel
 difference together, then states what the combination means.
 
+**Install `mupdf-tools` first** (`brew install mupdf-tools`). Without `mutool`
+the geometry axis falls back to `pdftotext -bbox`, whose `yMin` is each glyph's
+font-descriptor box rather than its baseline. The two PDFs always embed
+different subsets, so that fallback carries an error proportional to font size —
+on the newsletter mock it reported +2.90pt for a 22pt heading whose baseline is
+really 1.07pt the other way, and issue #501 was filed against a defect that did
+not exist. The report labels itself APPROXIMATE when it falls back; do not quote
+those numbers in an issue or PR.
+
 No single measure is reliable, and each one's blind spot is another's strength:
 
 | Axis | Catches | Blind to |
 | --- | --- | --- |
-| Geometry (`pdftotext -bbox`) | position, size, row pitch, pagination | colour, missing elements |
+| Geometry (`mutool draw -F trace`) | position, size, row pitch, pagination | colour, missing elements |
 | Colour histogram | fill colour, recolouring, missing elements, ink coverage | position, size, font |
 
 Judge the colour axis on the reported **colour shift**, not on the bin-wise

--- a/scripts/compare_render.py
+++ b/scripts/compare_render.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -40,6 +41,13 @@ WORD_RE = re.compile(
     r'<word xMin="([\d.-]+)" yMin="([\d.-]+)" xMax="([\d.-]+)" yMax="([\d.-]+)">(.*?)</word>',
     re.S,
 )
+FILL_TEXT_RE = re.compile(
+    r'<fill_text[^>]*transform="([-0-9.]+) [-0-9.]+ [-0-9.]+ ([-0-9.]+) '
+    r'([-0-9.]+) ([-0-9.]+)"[^>]*>(.*?)</fill_text>',
+    re.S,
+)
+TRACE_PAGE_RE = re.compile(r'<page number="\d+')
+GLYPH_RE = re.compile(r'<g unicode="([^"]*)" glyph="[^"]*" x="([-0-9.]+)" y="([-0-9.]+)"')
 HISTOGRAM_BINS = 32
 
 
@@ -72,11 +80,62 @@ def render_page(pdf: Path, page: int, dpi: int, out_dir: Path, role: str) -> Pat
     return pages[0]
 
 
-def text_lines(pdf: Path) -> list[TextLine]:
-    """Text lines with their top-left corner, grouped from word boxes.
+def has_mutool() -> bool:
+    """Whether `mutool` is on PATH (it ships in `mupdf-tools`)."""
+    return shutil.which("mutool") is not None
 
-    Word baselines jitter by fractions of a point inside one visual line, so
-    the rows are bucketed to 1pt before being joined.
+
+def baseline_lines(pdf: Path) -> list[TextLine]:
+    """Text lines positioned by their true baseline, via `mutool draw -F trace`.
+
+    A `<fill_text>` carries the text-space matrix, so a glyph's baseline is
+    `ty + d * gy` and its x is `a * gx + tx`. Office exports on macOS place
+    text in a scaled space (`transform=".24 0 0 -.24 0 201.8"` with `trm="92"`
+    for 22pt text) while ours are plain translations; one formula covers both.
+
+    Baselines jitter by fractions of a point inside one visual line, so rows
+    are bucketed to 1pt before being joined.
+    """
+    trace = subprocess.run(
+        ["mutool", "draw", "-F", "trace", "-o", "-", str(pdf)],
+        capture_output=True,
+        text=True,
+    )
+    if trace.returncode != 0:
+        return []
+    lines: list[TextLine] = []
+    for page_index, page in enumerate(TRACE_PAGE_RE.split(trace.stdout)[1:]):
+        rows: dict[int, list[tuple[float, str]]] = {}
+        for match in FILL_TEXT_RE.finditer(page):
+            scale_x, scale_y = float(match.group(1)), float(match.group(2))
+            translate_x, translate_y = float(match.group(3)), float(match.group(4))
+            for glyph in GLYPH_RE.finditer(match.group(5)):
+                char = glyph.group(1)
+                if not char.strip():
+                    continue
+                baseline = translate_y + scale_y * float(glyph.group(3))
+                rows.setdefault(round(baseline), []).append(
+                    (translate_x + scale_x * float(glyph.group(2)), char)
+                )
+        for key in sorted(rows):
+            glyphs = sorted(rows[key])
+            text = re.sub(r"\s+", " ", "".join(glyph[1] for glyph in glyphs)).strip()
+            if text:
+                lines.append(
+                    TextLine(page_index, min(g[0] for g in glyphs), float(key), text)
+                )
+    return lines
+
+
+def descriptor_box_lines(pdf: Path) -> list[TextLine]:
+    """Fallback line tops from `pdftotext -bbox`, used only without `mutool`.
+
+    `yMin` is each glyph's *font-descriptor box*, not its ink or its baseline.
+    The two PDFs always embed different subsets, so the drift this yields
+    carries an error proportional to font size — on the newsletter mock it
+    reported +2.90pt for a 22pt heading whose baseline is really 1.07pt the
+    other way, which is how #501 came to be filed against a defect that did
+    not exist (issue #505).
     """
     xml = subprocess.run(
         ["pdftotext", "-bbox", str(pdf), "-"],
@@ -99,6 +158,15 @@ def text_lines(pdf: Path) -> list[TextLine]:
                              min(w[1] for w in words), text)
                 )
     return lines
+
+
+def text_lines(pdf: Path) -> list[TextLine]:
+    """Lines for the geometry axis, by true baseline where `mutool` allows."""
+    if has_mutool():
+        lines = baseline_lines(pdf)
+        if lines:
+            return lines
+    return descriptor_box_lines(pdf)
 
 
 def report_geometry(gt: Path, other: Path) -> dict[str, float]:
@@ -124,6 +192,10 @@ def report_geometry(gt: Path, other: Path) -> dict[str, float]:
         dx.append(candidate.x_min - reference.x_min)
 
     print("## Geometry — position, size, pitch")
+    if not has_mutool():
+        print("  APPROXIMATE: mutool absent, so positions come from font-descriptor")
+        print("  boxes rather than baselines. The error scales with font size and can")
+        print("  invert the sign. Install mupdf-tools before trusting these numbers.")
     if not dy:
         print("  no lines matched by unique text; compare pages manually")
         return {}


### PR DESCRIPTION
## Summary

`compare_render.py`'s geometry axis derived vertical drift from `pdftotext -bbox`, whose `yMin` is each glyph's **font-descriptor box** — not its ink, and not its baseline. The ground truth and our output always embed different font subsets, so the reported drift carried an error proportional to font size.

Page 1 of `08_newsletter_en`, tool output against baselines read from the content streams:

| line | font size | reported | true baseline delta | error |
| --- | ---: | ---: | ---: | ---: |
| THE MONTHLY RENDER | 22pt | **+2.90** | **−1.07** | 3.97 |
| Company Newsletter · Issue 14 | 9pt | +1.38 | −0.32 | 1.70 |
| User Growth Hits a New High | 13pt | −0.40 | −2.67 | 2.27 |
| Monthly active users crossed… | 10.5pt | −0.48 | −2.39 | 1.91 |

The sign inverts on the largest line, and the apparent "decay from +2.90 to −0.48 over two paragraphs" is not a layout effect at all — it is the bbox error shrinking as the font size drops. #501 was filed against that non-existent defect and is closed as invalid.

## Key changes

- `baseline_lines()` reads true baselines from `mutool draw -F trace`. A `<fill_text>` carries the text-space matrix, so a glyph's baseline is `ty + d·gy` and its x is `a·gx + tx`. Office exports on macOS place text in a scaled space (`transform=".24 0 0 -.24 0 201.8"`, `trm="92"` for 22pt) while ours are plain translations; one formula covers both. One `mutool` call per document, split on `<page number=`.
- `descriptor_box_lines()` keeps the old path for when `mutool` is absent, and the report then prints an **APPROXIMATE** banner explaining the bias, so the numbers are not quoted as measurements.
- `CLAUDE.md` names the new tool in the axis table and tells contributors to install `mupdf-tools` first.

## Related issue

Fixes #505

## Testing

- Ran the tool over all ten business golden mocks against the current `main` build; every fixture reports and the two that previously fell below the coverage floor now match 100% of their lines.
- Verified the fallback by checking the APPROXIMATE banner is gated on `shutil.which("mutool")`.
- No Rust code changes, so the cargo suite is unaffected. No workflow in `.github/workflows/` invokes this script, so none needs `mupdf-tools` added.

## Corpus re-measured

Every drift figure quoted in this repository up to now carried the bias. Corrected against the same build:

| fixture | as previously reported | true baselines |
| --- | ---: | ---: |
| 01_invoice_en | 5.96 | **6.67** |
| 02_contract_ko | 4.48 | **7.00** |
| 03_meeting_minutes_ko | 2.34 | **3.50** |
| 04_resume_en | 0.69 | **2.44** |
| 05_technical_manual_en | 1.43 | **0.77** |
| 06_official_letter_ko | 2.37 | **1.67** |
| 07_product_spec_en | 1.20 | **2.25** |
| 08_newsletter_en | 1.23 | **2.71** |
| 09_offer_letter_en | 1.41 | **0.35** |
| 10_research_report_ko | 10.42 | **8.24** |
| **mean** | 3.15 | **3.56** |

The bias runs in both directions — five fixtures were being reported better than they are and five worse — so it was not a constant that cancelled out of before/after comparisons. Issues #500 and #503 quote figures from the old path and need re-measuring before either is acted on.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Nothing under `crates/` changes. This touches only `scripts/compare_render.py` and `CLAUDE.md`, so no PDF output moves — what changes is how drift is measured, not what is rendered.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
