### PR TITLE
fix(tools): report a line's own baseline, not its 1pt bucket key

### DIFF
--- a/scripts/compare_render.py
+++ b/scripts/compare_render.py
@@ -105,7 +105,7 @@ def baseline_lines(pdf: Path) -> list[TextLine]:
         return []
     lines: list[TextLine] = []
     for page_index, page in enumerate(TRACE_PAGE_RE.split(trace.stdout)[1:]):
-        rows: dict[int, list[tuple[float, str]]] = {}
+        rows: dict[int, list[tuple[float, float, str]]] = {}
         for match in FILL_TEXT_RE.finditer(page):
             scale_x, scale_y = float(match.group(1)), float(match.group(2))
             translate_x, translate_y = float(match.group(3)), float(match.group(4))
@@ -115,14 +115,23 @@ def baseline_lines(pdf: Path) -> list[TextLine]:
                     continue
                 baseline = translate_y + scale_y * float(glyph.group(3))
                 rows.setdefault(round(baseline), []).append(
-                    (translate_x + scale_x * float(glyph.group(2)), char)
+                    (translate_x + scale_x * float(glyph.group(2)), baseline, char)
                 )
         for key in sorted(rows):
             glyphs = sorted(rows[key])
-            text = re.sub(r"\s+", " ", "".join(glyph[1] for glyph in glyphs)).strip()
+            text = re.sub(r"\s+", " ", "".join(glyph[2] for glyph in glyphs)).strip()
             if text:
+                # The 1pt bucket only groups glyphs into a line; reporting its
+                # key as the position would quantise every measurement to 1pt
+                # and hide the sub-point row-pitch differences this axis exists
+                # to find. Report the line's own baseline instead.
                 lines.append(
-                    TextLine(page_index, min(g[0] for g in glyphs), float(key), text)
+                    TextLine(
+                        page_index,
+                        min(g[0] for g in glyphs),
+                        min(g[1] for g in glyphs),
+                        text,
+                    )
                 )
     return lines
 


### PR DESCRIPTION
## Summary

Follow-up to #506. `baseline_lines` buckets glyphs to 1pt to group them into visual lines, but then reported the **bucket key** as each line's position. Every geometry measurement was therefore quantised to 1pt.

That hides what this axis exists to find: the row-pitch defects in #500 and #503 are 0.5pt and 1.06pt per row, at or below the quantum. Reading the re-measured pitches back, GT and output rows both landed on whole points — an artifact, not the data.

## Key changes

- The row tuple carries each glyph's true baseline alongside its x and character.
- The line reports `min` of those baselines instead of `float(key)`.
- Grouping is untouched: `round(baseline)` still only decides which glyphs share a line.

## Related issue

Related: #505

## Testing

- Re-ran the tool over the business golden mocks. Values shift by fractions of a point, as expected from removing a 1pt quantisation: 02_contract_ko 7.00 → 6.78, 10_research_report_ko 8.24 → 8.22, 05_technical_manual_en 0.77 → 0.80, 08_newsletter_en 2.71 → 2.70.
- No Rust code changes, so the cargo suite is unaffected.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Touches only `scripts/compare_render.py`. Nothing under `crates/` changes, so no PDF output moves.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue