### PR TITLE
feat(tools): add --lines to report every matched line's baseline

### DIFF
--- a/scripts/compare_render.py
+++ b/scripts/compare_render.py
@@ -178,15 +178,22 @@ def text_lines(pdf: Path) -> list[TextLine]:
     return descriptor_box_lines(pdf)
 
 
+def unique_lines(lines: list[TextLine]) -> dict[str, TextLine]:
+    """Lines keyed by their text, keeping only texts that occur exactly once.
+
+    A repeated string cannot be paired between two renderings without guessing
+    which occurrence is which, so repeats are dropped rather than mismatched.
+    """
+    seen: dict[str, list[TextLine]] = {}
+    for line in lines:
+        seen.setdefault(line.text, []).append(line)
+    return {text: found[0] for text, found in seen.items() if len(found) == 1}
+
+
 def report_geometry(gt: Path, other: Path) -> dict[str, float]:
     """Vertical and horizontal drift of every line matched by unique text."""
-    def unique(lines: list[TextLine]) -> dict[str, TextLine]:
-        seen: dict[str, list[TextLine]] = {}
-        for line in lines:
-            seen.setdefault(line.text, []).append(line)
-        return {text: found[0] for text, found in seen.items() if len(found) == 1}
-
-    gt_lines, other_lines = unique(text_lines(gt)), unique(text_lines(other))
+    gt_lines = unique_lines(text_lines(gt))
+    other_lines = unique_lines(text_lines(other))
     dy: list[float] = []
     dx: list[float] = []
     page_mismatch = 0
@@ -440,12 +447,51 @@ def diagnose(geometry: dict[str, float], histogram_result: dict[str, float]) -> 
         print("  toward its true size overlaps GT less, not more.")
 
 
+def report_matched_lines(gt: Path, other: Path) -> None:
+    """Per-line baselines for every line matched by unique text.
+
+    Aggregate drift says a page is wrong; this says which line. Pairing the two
+    PDFs by hand — taking the topmost line, or grepping for a prefix — silently
+    matches the wrong line and produces impossible numbers, so the pairing here
+    is the same unique-text match the geometry axis already trusts.
+    """
+    gt_lines = unique_lines(text_lines(gt))
+    other_lines = unique_lines(text_lines(other))
+    rows: list[tuple[TextLine, TextLine]] = [
+        (reference, other_lines[text])
+        for text, reference in gt_lines.items()
+        if text in other_lines and other_lines[text].page == reference.page
+    ]
+    rows.sort(key=lambda pair: (pair[0].page, pair[0].y_min))
+
+    print("## Matched lines — baseline of each, and the pitch between them")
+    if not rows:
+        print("  none matched by unique text")
+        return
+    print(f"  {'page':>4} {'GT':>9} {'output':>9} {'delta':>8} "
+          f"{'GT pitch':>9} {'out pitch':>9}  text")
+    previous: tuple[float, float] | None = None
+    for reference, candidate in rows:
+        gt_pitch = "" if previous is None else f"{reference.y_min - previous[0]:9.2f}"
+        out_pitch = "" if previous is None else f"{candidate.y_min - previous[1]:9.2f}"
+        print(f"  {reference.page + 1:>4} {reference.y_min:9.2f} {candidate.y_min:9.2f} "
+              f"{candidate.y_min - reference.y_min:+8.2f} {gt_pitch:>9} {out_pitch:>9}  "
+              f"{reference.text[:44]}")
+        previous = (reference.y_min, candidate.y_min)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     parser.add_argument("gt", type=Path, help="native Office export")
     parser.add_argument("output", type=Path, help="office2pdf output")
     parser.add_argument("--page", type=int, default=1)
     parser.add_argument("--dpi", type=int, default=150, help="at least 150")
+    parser.add_argument(
+        "--lines",
+        action="store_true",
+        help="list every matched line's baselines, so a single paragraph can be "
+        "inspected without hand-pairing text between the two PDFs",
+    )
     args = parser.parse_args()
 
     if args.dpi < 150:
@@ -457,6 +503,9 @@ def main() -> None:
 
     geometry = report_geometry(args.gt, args.output)
     print()
+    if args.lines:
+        report_matched_lines(args.gt, args.output)
+        print()
     with tempfile.TemporaryDirectory() as raw_dir:
         out_dir = Path(raw_dir)
         gt_png = render_page(args.gt, args.page, args.dpi, out_dir, "gt")


### PR DESCRIPTION
## Summary

Aggregate drift says a page is wrong; it does not say which line. Investigating a single paragraph therefore meant pairing the two PDFs by hand, and every ad-hoc attempt at that during #508 mismatched lines and produced impossible figures — ascents larger than the line box containing them. Two different pairing heuristics failed in opposite directions: taking the topmost line below the top margin, then matching on a text prefix.

`--lines` reuses the unique-text pairing the geometry axis already trusts and prints, for each matched line, both baselines, their delta, and the pitch to the previous line on each side.

```
  page        GT    output    delta  GT pitch out pitch  text
     1     81.12     80.19    -0.93                      JAMIEPARKER
     1     94.08     93.38    -0.70     12.96     13.19  SeniorSoftwareEngineer·Berlin…
     1    128.64    126.04    -2.60     34.56     32.67  EXPERIENCE
     1    148.32    145.76    -2.56     19.68     19.72  StaffEngineer—RenderlyGmbH…
```

The pitch columns are the part that matters: they separate a constant offset inherited from above from an error accumulating line by line, which is exactly the distinction that decided #500 and #503 and that a single MAD number cannot express.

## Key changes

- `report_matched_lines` prints the table above, sorted by page then position, for lines whose text is unique on both sides.
- `unique_lines` is lifted out of `report_geometry` so both axes pair lines identically rather than growing a second, subtly different matcher.

## Related issue

Related: #508

## Testing

- Ran against `04_resume_en`, `06_official_letter_ko` and `02_contract_ko`; all report 100% line coverage and the per-line output reconciles with the aggregate MAD.
- Used it immediately to re-derive the figures I had withdrawn on #508 as unreliable: they were correct, and it was my hand-pairing that was wrong.
- No Rust code changes, so the cargo suite is unaffected.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Touches only `scripts/compare_render.py`. Nothing under `crates/` changes, so no PDF output moves.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue