### PR TITLE
refactor(docx): state the grid line choice instead of a ceiling

### DIFF
--- a/crates/office2pdf/src/render/typst_gen_text.rs
+++ b/crates/office2pdf/src/render/typst_gen_text.rs
@@ -285,9 +285,16 @@ pub(super) fn word_cell_line_box_settings(
     // matching suppression of the trailing gap; the two must agree.
     let advance_em: f64 = match line_grid_pitch.filter(|pitch| *pitch > 0.0) {
         Some(pitch) if row_snaps_to_grid => {
-            let natural_pt: f64 = metric_em * font_size + style.space_after.unwrap_or(0.0);
-            let grid_lines: f64 = (natural_pt / pitch).ceil().max(1.0);
-            grid_lines * pitch / font_size
+            // Same two-way choice as the body path (issue #508), with the
+            // paragraph's `w:after` inside the quantity being compared, since
+            // Word snaps the line and that gap together (issues #500, #503).
+            let natural_pt: f64 = word_pitch_em * font_size + style.space_after.unwrap_or(0.0);
+            let advance_pt: f64 = if natural_pt <= pitch {
+                pitch
+            } else {
+                natural_pt
+            };
+            advance_pt / font_size
         }
         _ => word_pitch_em,
     };
@@ -347,9 +354,30 @@ pub(super) fn word_line_leading_pt(
             // but its real line is 1.33em = 22.6pt, and Word gives it that.
             // Snapping to the grid alone made the title 4.6pt short, which
             // is the whole title-to-body shortfall (issue #402).
-            let grid_lines: f64 = (line_box_pt / pitch).ceil().max(1.0);
+            // Word chooses between exactly two advances, never a multiple:
+            // the grid pitch when the font's natural line fits inside one grid
+            // line, otherwise the natural line untouched.
+            //
+            // Measured as baseline-to-baseline pitch in the Word exports, which
+            // quantise every coordinate to 0.24pt. 13pt Malgun has a 17.29pt
+            // natural line and advances 18.24pt, i.e. the 18pt grid. 16pt
+            // Malgun has a 21.28pt natural line and advances 21.12pt - the
+            // natural line to within one quantum, not the 36pt two grid lines
+            // a ceiling would give (issue #508).
+            //
+            // A `ceil()` over the metric box reached the same answer only
+            // because Typst reports a normalised metric sum for Malgun that is
+            // small enough to always land on one line, leaving the natural-line
+            // floor to supply the other branch. Stating the choice directly
+            // removes that dependence on the metric pair, which the baseline
+            // split needs to change independently.
             let natural_line_pt: f64 = word_pitch_em * font_size;
-            (grid_lines * pitch).max(natural_line_pt) - line_box_pt
+            let advance_pt: f64 = if natural_line_pt <= pitch {
+                pitch
+            } else {
+                natural_line_pt
+            };
+            advance_pt - line_box_pt
         }
         // Word's single spacing is the font's full hhea line (ascender +
         // descender + line gap); Typst's metric edges resolve the typo


### PR DESCRIPTION
## Summary

Both document-grid arms sized a line as `ceil(x / pitch) * pitch`. Measurement of the Word exports shows Word never takes two grid lines — it chooses between exactly two values:

> the grid pitch when the font's natural line fits inside one grid line, otherwise the natural line unchanged.

Baseline-to-baseline pitch in the ground truth, which quantises every coordinate to 0.24pt:

| font size | natural line | grid | Word's advance | Word's choice |
| ---: | ---: | ---: | ---: | --- |
| 13pt Malgun | 17.29 | 18 | 18.24 | snapped to the grid |
| 16pt Malgun | 21.28 | 18 | 21.12 | kept the natural line |
| 9.5pt Malgun (cell) | 12.64 | 18 | 18.44 | snapped to the grid |

A ceiling would have given 36pt for the 16pt case. None of the samples take a second grid line.

## Why the old expression looked right

```rust
let grid_lines: f64 = (line_box_pt / pitch).ceil().max(1.0);
(grid_lines * pitch).max(natural_line_pt) - line_box_pt
```

`line_box_pt` is `metric_em * font_size`. Typst reports a **normalised** metric pair for Malgun Gothic — its ascender and descender sum to exactly 1.0 — so `line_box_pt` was always small enough for the ceiling to land on one line, and the separate `.max(natural_line_pt)` floor supplied the other branch. Both halves of the real rule fell out of an expression that states neither.

## Why it is worth changing something that already works

The metric pair also decides where the baseline sits inside the line box, and #508 has that wrong by a font-dependent amount — 0.0005em on Arial, 0.20–0.21em on Malgun. Two attempts to correct it were reverted from this branch's ancestors because supplying the real metrics made the ceiling start returning 2: a 16pt title's box nearly doubled and `06_official_letter_ko` went from 1.66pt drift to 12.77pt.

With the choice stated directly, neither grid arm consumes `ascender_em`/`descender_em` any more. The grid decision and the baseline split are independent, so the split can be tested on its own — which is the prerequisite #508 has been blocked on.

## Related issue

Related: #508

## Testing

- `cargo test --workspace` — 1,873 tests, 0 failures.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets` — clean.
- **All ten business golden mocks report vertical drift identical to `main`**: 5.32, 6.68, 6.71, 2.31, 0.65, 1.66, 0.79, 2.41, 0.48, 2.42pt. The null result is the test — any movement would mean the rule stated above is incomplete.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Behaviour is unchanged by design and verified so on every fixture in the corpus, at identical drift to the hundredth of a point. The change restates an existing computation without altering its result.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue