### PR TITLE
chore: release 0.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ No LibreOffice, no Chromium, no Docker — just a single binary powered by [Typs
 
 ```toml
 [dependencies]
-office2pdf = "0.6.4"
+office2pdf = "0.6.5"
 ```
 
 ### CLI
@@ -51,7 +51,7 @@ Every [GitHub release](https://github.com/developer0hye/office2pdf/releases) shi
 On Linux and macOS, download, extract, and place the binary on your `PATH`:
 
 ```sh
-VERSION=v0.6.4
+VERSION=v0.6.5
 TARGET=x86_64-unknown-linux-gnu  # pick your platform's target from the table above
 curl -L "https://github.com/developer0hye/office2pdf/releases/download/${VERSION}/office2pdf-${VERSION}-${TARGET}.tar.gz" | tar xz
 sudo install "office2pdf-${VERSION}-${TARGET}/office2pdf" /usr/local/bin/

--- a/crates/office2pdf-cli/Cargo.toml
+++ b/crates/office2pdf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf-cli"
-version = "0.6.4"
+version = "0.6.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ path = "src/main.rs"
 server = ["tiny_http"]
 
 [dependencies]
-office2pdf = { version = "0.6.4", path = "../office2pdf", features = ["pdf-ops"] }
+office2pdf = { version = "0.6.5", path = "../office2pdf", features = ["pdf-ops"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 rayon = "1"

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf"
-version = "0.6.4"
+version = "0.6.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Version bump to 0.6.5. 48 fix and feature commits since v0.6.4, all fidelity work with no API change, so a patch bump: 23 DOCX, 12 XLSX, 5 PPTX, plus tooling and CI.

The vertical layout models for both Word and PowerPoint were rewritten against native exports over this cycle. Mean absolute baseline error over the ten business golden mocks, unique-text matched across all pages:

| corpus | before | after |
| --- | ---: | ---: |
| DOCX | 2.59pt | **0.96pt** |
| PPTX | 2.40pt | **0.91pt** |

The rules behind that, each measured on a purpose-built fixture exported by native Office rather than inferred from the corpus:

- Word gives an East Asian line **130% of the font's hhea height**, centred on the baseline, and a `w:docGrid` without `w:type` is not a grid at all (#518).
- A paragraph rule reserves its own `w:pBdr w:space`, not a fixed 4pt (#520).
- PowerPoint gives every line a **flat 1.2em**, splits it at the font's OS/2 `usWinAscent` share, and keeps a descent gap below a bottom-anchored box's last baseline (#513).
- Word adds a **quarter em** where East Asian text meets Latin with no literal space, except where justification absorbs it (#521).
- A slide list item keeps the gap it declares even when its siblings declare different ones (#524).

## Key changes

- `crates/office2pdf/Cargo.toml`: 0.6.4 → 0.6.5
- `crates/office2pdf-cli/Cargo.toml`: package version and the `office2pdf` dependency requirement
- `README.md`: the dependency pin and the CLI download `VERSION` move with it

## Testing

- `cargo test --offline --workspace` — 1436 lib tests plus every integration suite pass.
- `cargo metadata --offline --locked --no-deps` reports `office2pdf 0.6.5` and `office2pdf-cli 0.6.5` requiring `^0.6.5`.
- `git diff --check` clean.
- Preflight: `HEAD` equals `origin/main`, authenticated as `developer0hye`, 82 GiB free, and 0.6.5 exists in neither GitHub Releases nor crates.io.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: version metadata and README pins only; no code path is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)