### PR TITLE
fix(scripts): let the visual PR gate skip evidence bookkeeping files

### DIFF
--- a/assets/bugfixes/README.md
+++ b/assets/bugfixes/README.md
@@ -1,6 +1,12 @@
 # Bug-fix evidence
 
-Store visual regression evidence in an issue-numbered directory:
+Visual evidence lives in an issue-numbered directory and is checked by the Visual
+PR Contract job (`scripts/check_visual_pr.py`). There are two modes; a pull
+request declares which one it uses in `Visual audit > Evidence mode`.
+
+## Evidence mode: `fix`
+
+A pull request that fixes a visual defect commits all three images:
 
 ```text
 assets/bugfixes/issue-<number>/gt.jpg
@@ -8,6 +14,54 @@ assets/bugfixes/issue-<number>/before.jpg
 assets/bugfixes/issue-<number>/after.jpg
 ```
 
-Generate all images from the same input document, page, resolution, and renderer. Use progressive JPEG quality 86 with metadata stripped.
+Touching any one of them makes the gate require and validate all three, so the
+trio always lands together. Generate them from the same input document, page,
+resolution, and renderer.
 
-Tracking issues may store discovery evidence under `audit/<case>/` with `gt.jpg` and `before.jpg`; focused child fixes add their own `after.jpg`.
+## Evidence mode: `defect`
+
+A pull request that files a visual defect commits a single side-by-side image —
+ground truth on the left, office2pdf output at filing time on the right:
+
+```text
+assets/bugfixes/issue-<number>/compare.jpg
+```
+
+Both panels come from the same page and resolution, so `compare.jpg` must be an
+even number of pixels wide for the halves to split evenly.
+
+## JPEG rules the gate enforces
+
+Every committed image must be:
+
+- **progressive** — baseline JPEG is rejected;
+- **at least 150 DPI** in the JFIF density header, and rendered at that DPI
+  rather than upscaled afterwards;
+- **free of metadata** — APP1 (Exif/XMP), APP2 (ICC), APP13 (Photoshop/IPTC), and
+  COM markers must all be absent.
+
+Use quality 86 and preserve the source pixel dimensions. Set the density *after*
+`-strip`, because `-strip` also drops the JFIF header that carries it:
+
+```sh
+magick page.png -strip -density 150 -units PixelsPerInch \
+  -interlace Plane -quality 86 assets/bugfixes/issue-<number>/after.jpg
+```
+
+Validate locally before pushing:
+
+```sh
+python3 scripts/check_visual_pr.py --event event.json --base main --head HEAD \
+  --repository developer0hye/office2pdf --root .
+```
+
+## Non-image files
+
+Markdown and text files under `assets/bugfixes/` — this README included — are
+bookkeeping, not evidence. The gate skips them, so a pull request that changes
+only such a file may check `No rendered PDF change`.
+
+Anything else in the directory is treated as evidence and must match one of the
+layouts above. The nested `issue-<number>/audit/<case>/` layout used by the early
+tracking issues (#213, #214) predates the gate and is not accepted for new
+evidence.

--- a/scripts/check_visual_pr.py
+++ b/scripts/check_visual_pr.py
@@ -13,13 +13,18 @@ import sys
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 
 VISUAL_ROOT = Path("assets/bugfixes")
 EVIDENCE_PATH = re.compile(
     r"^assets/bugfixes/issue-(?P<issue>\d+)/(?P<name>gt|before|after|compare)\.(?P<ext>[^/]+)$"
 )
+# Prose living under assets/bugfixes/ carries no pixels, so it is neither evidence
+# to validate nor a rendered change to audit. Without this the file documenting the
+# evidence convention could never be edited (#539). Image suffixes stay outside the
+# set so a stray screenshot is still rejected rather than silently waved through.
+BOOKKEEPING_SUFFIXES = frozenset({".md", ".txt"})
 AUDIT_ROWS = (
     "Page count/order",
     "Element presence",
@@ -104,12 +109,19 @@ def rendered_preview_urls(section: str, labels: tuple[str, ...]) -> dict[str, st
     return urls
 
 
+def is_visual_asset(path: str) -> bool:
+    """Report whether a changed path is an image under the visual evidence root."""
+    if not path.startswith(f"{VISUAL_ROOT.as_posix()}/"):
+        return False
+    return PurePosixPath(path).suffix.lower() not in BOOKKEEPING_SUFFIXES
+
+
 def validate_pr_body(body: str, changed_paths: list[str]) -> list[str]:
     errors: list[str] = []
     impact = extract_section(body, "## Visual impact")
     no_change = checked(impact, "No rendered PDF change")
     visual = checked(impact, "Rendered PDF change or visual evidence added")
-    visual_assets_changed = any(path.startswith(f"{VISUAL_ROOT.as_posix()}/") for path in changed_paths)
+    visual_assets_changed = any(is_visual_asset(path) for path in changed_paths)
 
     if no_change == visual:
         errors.append("Select exactly one Visual impact checkbox.")
@@ -332,7 +344,7 @@ def validate_evidence(changed_paths: list[str], root: Path) -> list[str]:
     touched: dict[str, set[str]] = {}
 
     for raw_path in changed_paths:
-        if not raw_path.startswith(f"{VISUAL_ROOT.as_posix()}/"):
+        if not is_visual_asset(raw_path):
             continue
         match = EVIDENCE_PATH.fullmatch(raw_path)
         if not match:

--- a/scripts/tests/test_check_visual_pr.py
+++ b/scripts/tests/test_check_visual_pr.py
@@ -169,6 +169,15 @@ class PullRequestBodyTests(unittest.TestCase):
         errors = validate_pr_body(body, ["assets/bugfixes/issue-186/after.jpg"])
         self.assertTrue(any("assets/bugfixes changes require" in error for error in errors))
 
+    def test_evidence_documentation_is_not_a_rendered_change(self):
+        body = """## Visual impact
+
+- [x] No rendered PDF change
+- [ ] Rendered PDF change or visual evidence added
+- Reason: Documents the evidence convention
+"""
+        self.assertEqual(validate_pr_body(body, ["assets/bugfixes/README.md"]), [])
+
 
 class EvidenceTests(unittest.TestCase):
     def test_repository_evidence_is_progressive_150_dpi_jpeg(self):
@@ -191,6 +200,19 @@ class EvidenceTests(unittest.TestCase):
             ROOT,
         )
         self.assertTrue(any(".jpg extension" in error for error in errors))
+
+    def test_evidence_readme_is_not_evidence(self):
+        self.assertEqual(validate_evidence(["assets/bugfixes/README.md"], ROOT), [])
+
+    def test_issue_directory_notes_are_not_evidence(self):
+        self.assertEqual(
+            validate_evidence(["assets/bugfixes/issue-186/notes.txt"], ROOT),
+            [],
+        )
+
+    def test_unnamed_image_is_still_rejected(self):
+        errors = validate_evidence(["assets/bugfixes/issue-186/extra.jpg"], ROOT)
+        self.assertTrue(any("visual evidence must be" in error for error in errors))
 
 
 class OpenIssueTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

`validate_evidence` (`scripts/check_visual_pr.py`) walked every changed path under `assets/bugfixes/` and required it to match `issue-<number>/{gt,before,after,compare}.jpg`. `assets/bugfixes/README.md` lives in that directory, so the file documenting the evidence convention could never be edited — it failed the Visual PR Contract job with:

```
::error::assets/bugfixes/README.md: visual evidence must be gt.jpg, before.jpg,
after.jpg, or compare.jpg under assets/bugfixes/issue-<number>/.
```

`validate_pr_body` had the matching problem: a README-only change tripped `assets/bugfixes changes require 'Rendered PDF change or visual evidence added'` even though prose renders no PDF.

Both checks now share `is_visual_asset`, which treats `.md` and `.txt` under the evidence root as bookkeeping and skips it. Image suffixes stay outside `BOOKKEEPING_SUFFIXES` on purpose, so a stray screenshot in the wrong place is still rejected rather than silently waved through.

With the gate unblocked, the drifted README is brought back in line with what the gate actually enforces:

- both evidence modes — the `fix` gt/before/after trio and the `defect` `compare.jpg`, which the old text never mentioned despite 71 tracked files using it;
- the progressive, ≥150 DPI density, stripped APP1/APP2/APP13/COM, and even-`compare.jpg`-width rules;
- a `magick` invocation that sets density *after* `-strip`, and the local command for running the gate before pushing.

## Related issue

Closes #539
Related: #350, #538

## Testing

- `python3 -m unittest discover -s scripts/tests -p 'test_check_visual_pr.py'` — 18 passed, including four new cases: the README and an issue-directory `.txt` are skipped, a README-only PR may declare no rendered change, and a wrongly-named `.jpg` is still rejected.
- Reproduced the issue's scenario end to end on this branch: `python3 scripts/check_visual_pr.py --event event.json --base main --head HEAD --repository developer0hye/office2pdf --root .` → `Visual pull request contract is complete.`
- Verified the newly documented `magick` command against the gate's own `read_jpeg_info`: `JpegInfo(progressive=True, density_dpi=(150.0, 150.0), metadata_markers=())`.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: CI gate script and its documentation only; no parser, renderer, or fixture is touched.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue