### PR TITLE
docs(render): describe what a header tab actually did before #579

### DIFF
--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -1407,10 +1407,15 @@ enum HeaderFooterTabLayout {
 
 /// Resolve a header or footer paragraph's tabs against its own tab stops.
 ///
-/// `generate_hf_elements` advanced every `<w:tab/>` by a fixed `#h(1em)`, so
-/// the segment a right stop should have pushed to the right margin sat next to
-/// the left one instead — on every page of a document that uses the idiom
-/// (issue #579).
+/// `generate_hf_elements` passed every `<w:tab/>` straight to `generate_run`,
+/// which writes the tab into the Typst source as a literal tab character.
+/// Typst's markup lexer treats that exactly as it treats a space, so the two
+/// segments ended up one space apart and the one a right stop should have
+/// pushed to the right margin sat beside the left one — on every page of a
+/// document that uses the idiom (issue #579).
+///
+/// The `#h(1em)` advance below is a different element: `w:ptab`, which states
+/// its own alignment rather than referring to a stop.
 fn header_footer_tab_layout(
     paragraph: &crate::ir::HeaderFooterParagraph,
 ) -> Option<HeaderFooterTabLayout> {

--- a/crates/office2pdf/src/render/typst_gen_paragraph_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_paragraph_tests.rs
@@ -1577,7 +1577,11 @@ fn test_header_tab_without_a_matching_stop_keeps_the_plain_advance() {
     let result = generate_typst(&doc).unwrap().source;
 
     assert!(
-        result.contains("#h(1em)") || !result.contains("#grid(columns: (1fr, auto)"),
+        !result.contains("#grid(columns: (1fr, auto)"),
         "a left stop is not the running-head idiom: {result}"
+    );
+    assert!(
+        result.contains('\t'),
+        "the tab stays a literal tab for Typst to collapse: {result}"
     );
 }


### PR DESCRIPTION
## Summary

The comment added with #579 said `generate_hf_elements` advanced every `<w:tab/>` by a fixed `#h(1em)`. It does not.

A `<w:tab/>` in a header run is parsed into an ordinary text run holding a tab character (`docx_sections.rs`, `RunChild::Tab` → `HFInline::Run { text: "\t" }`), which `generate_run` writes into the Typst source verbatim. Typst's markup lexer treats a raw tab exactly as it treats a space, so the two segments ended up one space apart, not one em.

`#h(1em)` is the fallback for `w:ptab` — a different element, which states its own alignment instead of referring to a stop — and that path is untouched.

## Key changes

- The comment now describes the real mechanism, and points at `w:ptab` as the thing `#h(1em)` belongs to.
- `test_header_tab_without_a_matching_stop_keeps_the_plain_advance` hedged on the same mistake: `contains("#h(1em)") || !contains(grid)` passed only through the second disjunct, because the first can never be true for a plain `<w:tab/>`. It now asserts the absence of the grid *and* the presence of the literal tab, which is what the untouched path actually emits.

## Related issue

Related: #579

## Testing

- `cargo test -p office2pdf --lib` — 1505 passed, 0 failed.
- `cargo fmt --check` clean, and `cargo +1.97 clippy --workspace --all-targets -- -D warnings` clean against CI's toolchain.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: corrects a code comment and tightens one assertion in an existing test. No parser or renderer behaviour is touched, and the test suite is unchanged apart from that assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)