### PR TITLE
feat(scripts): trace-based layout differ with per-page deviation vectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Test visual PR validator
         run: python3 -m unittest discover -s scripts/tests -p 'test_check_visual_pr.py'
+      - name: Test layout differ
+        run: python3 -m unittest discover -s scripts/tests -p 'test_compare_layout.py'
       - name: Validate visual PR contract
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,12 @@ Run `python3 scripts/compare_render.py <GT.pdf> <output.pdf> [--page N]` before
 judging a rendered difference. It reports geometry, colour histogram, and pixel
 difference together, then states what the combination means.
 
+For layout defects, run `python3 scripts/compare_layout.py <GT.pdf> <output.pdf>`
+first: it matches text lines from `mutool` traces and reports missing/extra/
+re-wrapped lines, baseline dy, pitch and width drift, and a rect census, with
+GT noise floors built in (`--noise-floor 0.12` Word, `0.5` Excel). Its numbers
+are assertable; pixel counts are only a tripwire.
+
 **Install `mupdf-tools` first** (`brew install mupdf-tools`). Without `mutool`
 the geometry axis falls back to `pdftotext -bbox`, whose `yMin` is each glyph's
 font-descriptor box rather than its baseline. The two PDFs always embed

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Trace-based layout differ: a per-page deviation vector instead of a pixel scalar.
+
+Parses ``mutool draw -F trace`` for a ground-truth PDF and an office2pdf
+output, reconstructs text lines and vector rects in device points, matches
+lines by their text, and reports typed deviations:
+
+- matched / missing / extra lines, and wrap-point differences (text that is
+  present but breaks at a different word) counted separately from real loss;
+- baseline dy statistics, per-line dx0, line-width drift, inter-line pitch
+  deltas between consecutive matched lines;
+- a fill/stroke rect census with nearest-match position deltas.
+
+A noise floor (default 0.12pt — native Word exports quantise coordinates to a
+0.24pt grid; use 0.5 for Excel GT, whose Quartz export rounds every advance to
+a whole point) separates measurement noise from deviations: raw statistics are
+always reported, but a line only counts as *deviant* past the floor.
+
+Pixel metrics (`compare_render.py`) remain the tripwire for whatever this tool
+does not model — colour, images, effects. This tool is the primary signal for
+position, size, pitch, wrap, and element presence, which is what actually
+changes when a layout defect is fixed.
+
+Usage:
+    compare_layout.py GT.pdf OUTPUT.pdf [--page N] [--noise-floor PT] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from pathlib import Path
+
+PAGE_RE = re.compile(r'<page number="\d+"[^>]*>(.*?)</page>', re.S)
+FILL_TEXT_RE = re.compile(r"<fill_text\b([^>]*)>(.*?)</fill_text>", re.S)
+SPAN_RE = re.compile(r"<span\b([^>]*)>(.*?)</span>", re.S)
+GLYPH_RE = re.compile(
+    r'<g unicode="([^"]*)" glyph="[^"]*" x="([-0-9.e]+)" y="([-0-9.e]+)" adv="([-0-9.e]+)"'
+)
+PATH_RE = re.compile(r"<(fill_path|stroke_path)\b([^>]*)>(.*?)</\1>", re.S)
+POINT_RE = re.compile(r'<(?:moveto|lineto|curveto)[^>]*x="([-0-9.e]+)" y="([-0-9.e]+)"')
+TRANSFORM_RE = re.compile(
+    r'transform="([-0-9.e]+) ([-0-9.e]+) ([-0-9.e]+) ([-0-9.e]+) ([-0-9.e]+) ([-0-9.e]+)"'
+)
+TRM_RE = re.compile(r'trm="([-0-9.e]+) ')
+
+LINE_Y_TOLERANCE_PT = 0.6
+RECT_MATCH_RADIUS_PT = 6.0
+XML_ESCAPES = {"&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&apos;": "'"}
+
+
+@dataclass(frozen=True)
+class Glyph:
+    x: float
+    y: float
+    unicode: str
+    size: float
+    advance: float
+
+
+@dataclass(frozen=True)
+class Rect:
+    kind: str  # "fill" | "stroke"
+    x0: float
+    y0: float
+    x1: float
+    y1: float
+
+    @property
+    def center(self) -> tuple[float, float]:
+        return ((self.x0 + self.x1) / 2, (self.y0 + self.y1) / 2)
+
+
+@dataclass
+class Line:
+    y: float
+    glyphs: list[Glyph] = field(default_factory=list)
+
+    @property
+    def text(self) -> str:
+        return "".join(g.unicode for g in self.glyphs)
+
+    @property
+    def key(self) -> str:
+        """Whitespace-free text; GT exports carry stray trailing space glyphs."""
+        return "".join(g.unicode for g in self.glyphs if not g.unicode.isspace())
+
+    @property
+    def x0(self) -> float:
+        return self.glyphs[0].x
+
+    @property
+    def x1(self) -> float:
+        last = self.glyphs[-1]
+        return last.x + last.advance
+
+    @property
+    def width(self) -> float:
+        return self.x1 - self.x0
+
+
+@dataclass
+class PageLayout:
+    lines: list[Line]
+    rects: list[Rect]
+
+
+def unescape(text: str) -> str:
+    for entity, char in XML_ESCAPES.items():
+        text = text.replace(entity, char)
+    return text
+
+
+def parse_transform(attrs: str) -> tuple[float, float, float, float, float, float] | None:
+    match = TRANSFORM_RE.search(attrs)
+    if not match:
+        return None
+    return tuple(float(value) for value in match.groups())  # type: ignore[return-value]
+
+
+def parse_trace(trace_xml: str) -> list[PageLayout]:
+    pages: list[PageLayout] = []
+    for page_match in PAGE_RE.finditer(trace_xml):
+        content = page_match.group(1)
+        glyphs: list[Glyph] = []
+        for op_attrs, op_body in FILL_TEXT_RE.findall(content):
+            transform = parse_transform(op_attrs)
+            if transform is None:
+                continue
+            a, _b, _c, d, e, f = transform
+            for span_attrs, span_body in SPAN_RE.findall(op_body):
+                trm = TRM_RE.search(span_attrs)
+                size_units = float(trm.group(1)) if trm else 0.0
+                size_pt = abs(size_units * a)
+                for unicode_char, gx, gy, adv in GLYPH_RE.findall(span_body):
+                    glyphs.append(
+                        Glyph(
+                            x=a * float(gx) + e,
+                            y=d * float(gy) + f,
+                            unicode=unescape(unicode_char),
+                            size=size_pt,
+                            advance=float(adv) * size_units * abs(a),
+                        )
+                    )
+        rects: list[Rect] = []
+        for kind, op_attrs, op_body in PATH_RE.findall(content):
+            transform = parse_transform(op_attrs) or (1, 0, 0, 1, 0, 0)
+            a, _b, _c, d, e, f = transform
+            xs: list[float] = []
+            ys: list[float] = []
+            for px, py in POINT_RE.findall(op_body):
+                xs.append(a * float(px) + e)
+                ys.append(d * float(py) + f)
+            if xs:
+                rects.append(
+                    Rect(
+                        kind="fill" if kind == "fill_path" else "stroke",
+                        x0=min(xs),
+                        y0=min(ys),
+                        x1=max(xs),
+                        y1=max(ys),
+                    )
+                )
+        pages.append(PageLayout(lines=build_lines(glyphs), rects=rects))
+    return pages
+
+
+def build_lines(glyphs: list[Glyph], y_tolerance: float = LINE_Y_TOLERANCE_PT) -> list[Line]:
+    lines: list[Line] = []
+    for glyph in sorted(glyphs, key=lambda g: (g.y, g.x)):
+        target = None
+        for line in lines:
+            if abs(line.y - glyph.y) <= y_tolerance:
+                target = line
+                break
+        if target is None:
+            target = Line(y=glyph.y)
+            lines.append(target)
+        target.glyphs.append(glyph)
+    for line in lines:
+        line.glyphs.sort(key=lambda g: g.x)
+        line.y = statistics.median(g.y for g in line.glyphs)
+    lines.sort(key=lambda line: (line.y, line.x0))
+    return [line for line in lines if line.key]
+
+
+def match_lines(
+    gt_lines: list[Line], out_lines: list[Line]
+) -> tuple[list[tuple[Line, Line]], list[Line], list[Line]]:
+    matcher = SequenceMatcher(
+        a=[line.key for line in gt_lines], b=[line.key for line in out_lines], autojunk=False
+    )
+    matches: list[tuple[Line, Line]] = []
+    missing: list[Line] = []
+    extra: list[Line] = []
+    for tag, a0, a1, b0, b1 in matcher.get_opcodes():
+        if tag == "equal":
+            matches.extend(zip(gt_lines[a0:a1], out_lines[b0:b1]))
+        else:
+            missing.extend(gt_lines[a0:a1])
+            extra.extend(out_lines[b0:b1])
+    return matches, missing, extra
+
+
+def take_wrap_differences(
+    missing: list[Line], extra: list[Line]
+) -> tuple[list[str], list[Line], list[Line]]:
+    """Pull re-wrapped paragraphs out of the missing/extra pools.
+
+    A wrap difference is text that exists on both sides but breaks at a
+    different point, so joined runs of unmatched lines carry the same
+    characters. Greedy prefix consumption keeps it linear and is sufficient
+    for the contiguous runs SequenceMatcher produces.
+    """
+    wraps: list[str] = []
+    remaining_missing = list(missing)
+    remaining_extra = list(extra)
+    while remaining_missing and remaining_extra:
+        gt_join = "".join(line.key for line in remaining_missing)
+        out_join = "".join(line.key for line in remaining_extra)
+        if not gt_join or gt_join != out_join:
+            break
+        wraps.append(remaining_missing[0].key[:60])
+        remaining_missing.clear()
+        remaining_extra.clear()
+    return wraps, remaining_missing, remaining_extra
+
+
+def take_reflows(missing: list[Line], extra: list[Line]) -> tuple[dict, list[Line], list[Line]]:
+    """Classify unmatched lines whose characters all survive as reflow, not loss.
+
+    Same multiset of characters on both sides means the text is present but
+    grouped into different lines (baseline splits, cell order) — the audit's
+    invoice wrap-flip and budget baseline-split cases. Real loss keeps its
+    asymmetric remainder in missing/extra.
+    """
+    gt_chars = sorted("".join(line.key for line in missing))
+    out_chars = sorted("".join(line.key for line in extra))
+    if gt_chars and gt_chars == out_chars:
+        info = {
+            "gt_lines": len(missing),
+            "out_lines": len(extra),
+            "samples": [line.key[:60] for line in missing[:3]],
+        }
+        return info, [], []
+    return {"gt_lines": 0, "out_lines": 0, "samples": []}, missing, extra
+
+
+def diff_page(
+    gt: PageLayout, out: PageLayout, noise_floor: float = 0.12
+) -> dict:
+    matches, missing, extra = match_lines(gt.lines, out.lines)
+    wraps, missing, extra = take_wrap_differences(missing, extra)
+    reflow, missing, extra = take_reflows(missing, extra)
+
+    dys = [out_line.y - gt_line.y for gt_line, out_line in matches]
+    dx0s = [out_line.x0 - gt_line.x0 for gt_line, out_line in matches]
+    width_pcts = [
+        (out_line.width - gt_line.width) / gt_line.width * 100
+        for gt_line, out_line in matches
+        if gt_line.width > 1.0
+    ]
+
+    pitch_deltas: list[float] = []
+    matched_gt = {id(gt_line) for gt_line, _ in matches}
+    ordered = [pair for pair in matches]
+    ordered.sort(key=lambda pair: pair[0].y)
+    for (gt_a, out_a), (gt_b, out_b) in zip(ordered, ordered[1:]):
+        if id(gt_a) in matched_gt and id(gt_b) in matched_gt:
+            pitch_deltas.append((out_b.y - out_a.y) - (gt_b.y - gt_a.y))
+
+    worst_dy_index = max(range(len(dys)), key=lambda i: abs(dys[i]), default=None)
+
+    rect_pairs = 0
+    rect_center_deltas: list[float] = []
+    unclaimed = list(out.rects)
+    for gt_rect in gt.rects:
+        best = None
+        best_distance = RECT_MATCH_RADIUS_PT
+        for candidate in unclaimed:
+            if candidate.kind != gt_rect.kind:
+                continue
+            distance = max(
+                abs(candidate.center[0] - gt_rect.center[0]),
+                abs(candidate.center[1] - gt_rect.center[1]),
+            )
+            if distance <= best_distance:
+                best, best_distance = candidate, distance
+        if best is not None:
+            unclaimed.remove(best)
+            rect_pairs += 1
+            rect_center_deltas.append(best_distance)
+
+    def stats(values: list[float]) -> dict:
+        if not values:
+            return {"mean_abs": 0.0, "worst": 0.0}
+        return {
+            "mean_abs": sum(abs(v) for v in values) / len(values),
+            "worst": max(values, key=abs),
+        }
+
+    dy_stats = stats(dys)
+    return {
+        "lines": {
+            "gt": len(gt.lines),
+            "out": len(out.lines),
+            "matched": len(matches),
+            "missing": len(missing),
+            "extra": len(extra),
+            "deviant": sum(1 for dy in dys if abs(dy) > noise_floor),
+            "missing_text": [line.key[:60] for line in missing[:5]],
+            "extra_text": [line.key[:60] for line in extra[:5]],
+        },
+        "baseline": {
+            "mean_abs_dy": dy_stats["mean_abs"],
+            "worst_dy": abs(dy_stats["worst"]),
+            "worst_dy_signed": dy_stats["worst"],
+            "worst_line": (
+                matches[worst_dy_index][0].key[:60] if worst_dy_index is not None else ""
+            ),
+        },
+        "dx0": stats(dx0s),
+        "width": {
+            "mean_abs_pct": stats(width_pcts)["mean_abs"],
+            "worst_pct": abs(stats(width_pcts)["worst"]),
+        },
+        "pitch": {"pairs": len(pitch_deltas), "worst_delta": abs(stats(pitch_deltas)["worst"])},
+        "wraps": {"count": len(wraps), "samples": wraps[:5]},
+        "reflow": reflow,
+        "rects": {
+            "gt_count": len(gt.rects),
+            "out_count": len(out.rects),
+            "matched": rect_pairs,
+            "mean_center_delta": stats(rect_center_deltas)["mean_abs"],
+        },
+        "noise_floor": noise_floor,
+    }
+
+
+def render_reading(vectors: list[dict]) -> str:
+    lines = ["## Reading", ""]
+    for index, vector in enumerate(vectors, start=1):
+        page_notes: list[str] = []
+        line_info = vector["lines"]
+        if line_info["missing"] or line_info["extra"]:
+            page_notes.append(
+                f"content differs: {line_info['missing']} GT line(s) unmatched "
+                f"(e.g. {line_info['missing_text'][:1]}), {line_info['extra']} extra"
+            )
+        if vector["wraps"]["count"]:
+            page_notes.append(
+                f"{vector['wraps']['count']} paragraph(s) wrap at a different word "
+                "(text present, break point moved) — check advances, kerning, or spacing"
+            )
+        if vector["reflow"]["gt_lines"]:
+            page_notes.append(
+                f"{vector['reflow']['gt_lines']} GT line(s) re-grouped into "
+                f"{vector['reflow']['out_lines']} output line(s) with no text lost — "
+                "baseline splits or a moved wrap, not missing content"
+            )
+        if line_info["deviant"]:
+            page_notes.append(
+                f"{line_info['deviant']}/{line_info['matched']} matched lines sit past the "
+                f"{vector['noise_floor']}pt floor; worst {vector['baseline']['worst_dy_signed']:+.2f}pt "
+                f"on '{vector['baseline']['worst_line']}'"
+            )
+        if vector["pitch"]["worst_delta"] > vector["noise_floor"]:
+            page_notes.append(
+                f"line pitch drifts up to {vector['pitch']['worst_delta']:.2f}pt — "
+                "line-height model rather than block placement"
+            )
+        if vector["rects"]["gt_count"] != vector["rects"]["out_count"]:
+            page_notes.append(
+                f"rect census differs: GT {vector['rects']['gt_count']} vs "
+                f"output {vector['rects']['out_count']} draw ops — can be op-splitting "
+                "(per-cell border segments vs one merged stroke), so confirm visually "
+                "before reading it as missing ink"
+            )
+        if not page_notes:
+            page_notes.append("no deviation past the noise floor")
+        lines.append(f"- page {index}: " + "; ".join(page_notes))
+    return "\n".join(lines)
+
+
+def run_mutool(pdf: Path) -> str:
+    mutool = shutil.which("mutool")
+    if mutool is None:
+        sys.exit("mutool is required (brew install mupdf-tools)")
+    result = subprocess.run(
+        [mutool, "draw", "-F", "trace", str(pdf)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("gt", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--page", type=int, help="1-based page to compare (default: all)")
+    parser.add_argument(
+        "--noise-floor",
+        type=float,
+        default=0.12,
+        help="pt threshold under which a delta is measurement noise (0.12 Word GT, 0.5 Excel GT)",
+    )
+    parser.add_argument("--json", action="store_true", help="emit the deviation vectors as JSON")
+    args = parser.parse_args()
+
+    gt_pages = parse_trace(run_mutool(args.gt))
+    out_pages = parse_trace(run_mutool(args.output))
+
+    if args.page is not None:
+        gt_pages = gt_pages[args.page - 1 : args.page]
+        out_pages = out_pages[args.page - 1 : args.page]
+
+    count = min(len(gt_pages), len(out_pages))
+    vectors = [
+        diff_page(gt_pages[i], out_pages[i], noise_floor=args.noise_floor) for i in range(count)
+    ]
+
+    if args.json:
+        print(json.dumps({"pages": vectors, "gt_pages": len(gt_pages), "out_pages": len(out_pages)}, indent=1))
+        return 0
+
+    if len(gt_pages) != len(out_pages):
+        print(f"PAGE COUNT MISMATCH: GT {len(gt_pages)} vs output {len(out_pages)}\n")
+    for index, vector in enumerate(vectors, start=1):
+        line_info = vector["lines"]
+        print(
+            f"page {index}: {line_info['matched']} matched "
+            f"({line_info['missing']} missing, {line_info['extra']} extra, "
+            f"{vector['wraps']['count']} re-wrapped) | "
+            f"dy mean {vector['baseline']['mean_abs_dy']:.2f}pt worst "
+            f"{vector['baseline']['worst_dy_signed']:+.2f}pt | "
+            f"pitch worst {vector['pitch']['worst_delta']:.2f}pt | "
+            f"width worst {vector['width']['worst_pct']:.1f}% | "
+            f"rects {vector['rects']['gt_count']}/{vector['rects']['out_count']}"
+        )
+    print()
+    print(render_reading(vectors))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -1,0 +1,220 @@
+"""Unit tests for the trace-based layout differ.
+
+All fixtures are synthetic ``mutool draw -F trace`` fragments that mirror the
+real output format (device transform on each op, glyph coordinates in text
+space, sizes in trm units), so the parser is exercised on the same shapes it
+will meet in production without shelling out to mutool.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import compare_layout
+
+
+def trace_document(*pages: str) -> str:
+    body = "\n".join(
+        f'<page number="{i + 1}" mediabox="0 0 595.2 841.92">\n{content}\n</page>'
+        for i, content in enumerate(pages)
+    )
+    return f'<?xml version="1.0"?>\n<document filename="x.pdf">\n{body}\n</document>'
+
+
+def text_op(
+    words: list[tuple[str, float]],
+    baseline_y: float,
+    size_units: float = 44.0,
+    scale: float = 0.24,
+    color: str = "0 0 0",
+    font: str = "AAAAAA+ArialMT",
+) -> str:
+    """One fill_text whose glyphs sit at ``baseline_y`` (device pt).
+
+    ``words`` is a list of (character, device_x) pairs; coordinates are
+    converted back into text space so the parser has to apply the transform.
+    """
+    offset = 841.92
+    glyph_lines = []
+    for char, device_x in words:
+        text_x = device_x / scale
+        text_y = (offset - baseline_y) / scale
+        glyph_lines.append(
+            f'<g unicode="{char}" glyph="1" x="{text_x:.4f}" y="{text_y:.4f}" adv=".5"/>'
+        )
+    glyphs = "\n".join(glyph_lines)
+    return (
+        f'<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color="{color}" '
+        f'ri="1" bp="1" op="0" opm="0" transform="{scale} 0 0 -{scale} 0 {offset}">\n'
+        f'<span font="{font}" wmode="0" bidi="0" trm="{size_units} 0 0 {size_units}">\n'
+        f"{glyphs}\n</span>\n</fill_text>"
+    )
+
+
+def line_of(text: str, x0: float, baseline_y: float, pitch: float = 6.0) -> str:
+    words = [(char, x0 + i * pitch) for i, char in enumerate(text)]
+    return text_op(words, baseline_y)
+
+
+def rect_op(x0: float, y0: float, x1: float, y1: float, kind: str = "fill_path") -> str:
+    extra = ' winding="nonzero"' if kind == "fill_path" else ' linewidth="1"'
+    return (
+        f'<{kind}{extra} colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".8 .8 .8" '
+        f'ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 841.92">\n'
+        f'<moveto x="{x0}" y="{841.92 - y0}"/>\n'
+        f'<lineto x="{x1}" y="{841.92 - y0}"/>\n'
+        f'<lineto x="{x1}" y="{841.92 - y1}"/>\n'
+        f'<lineto x="{x0}" y="{841.92 - y1}"/>\n'
+        f"<closepath/>\n</{kind}>"
+    )
+
+
+class ParseTraceTest(unittest.TestCase):
+    def test_glyphs_carry_device_coordinates_and_pt_sizes(self) -> None:
+        doc = trace_document(text_op([("A", 72.0), ("B", 78.0)], baseline_y=100.0))
+        pages = compare_layout.parse_trace(doc)
+        self.assertEqual(len(pages), 1)
+        line = pages[0].lines[0]
+        self.assertEqual(line.text, "AB")
+        self.assertAlmostEqual(line.glyphs[0].x, 72.0, places=3)
+        self.assertAlmostEqual(line.glyphs[0].y, 100.0, places=3)
+        # trm 44 under a 0.24 transform is a 10.56pt glyph.
+        self.assertAlmostEqual(line.glyphs[0].size, 10.56, places=3)
+        # adv .5 em at that size is 5.28pt.
+        self.assertAlmostEqual(line.glyphs[0].advance, 5.28, places=3)
+
+    def test_glyphs_on_one_baseline_group_into_one_line_in_x_order(self) -> None:
+        page = "\n".join(
+            [
+                text_op([("B", 80.0)], baseline_y=100.0),
+                text_op([("A", 72.0)], baseline_y=100.2),
+                text_op([("C", 90.0)], baseline_y=300.0),
+            ]
+        )
+        pages = compare_layout.parse_trace(trace_document(page))
+        texts = [line.text for line in pages[0].lines]
+        self.assertEqual(texts, ["AB", "C"])
+
+    def test_rects_capture_device_bbox_and_kind(self) -> None:
+        page = "\n".join(
+            [rect_op(69.36, 792.96, 525.84, 793.44), rect_op(10, 20, 30, 21, "stroke_path")]
+        )
+        pages = compare_layout.parse_trace(trace_document(page))
+        rects = pages[0].rects
+        self.assertEqual(len(rects), 2)
+        fill = next(r for r in rects if r.kind == "fill")
+        self.assertAlmostEqual(fill.x0, 69.36, places=2)
+        self.assertAlmostEqual(fill.y1, 793.44, places=2)
+        self.assertEqual({r.kind for r in rects}, {"fill", "stroke"})
+
+
+class MatchAndDiffTest(unittest.TestCase):
+    def diff(self, gt_page: str, out_page: str, **kwargs) -> dict:
+        gt = compare_layout.parse_trace(trace_document(gt_page))[0]
+        out = compare_layout.parse_trace(trace_document(out_page))[0]
+        return compare_layout.diff_page(gt, out, **kwargs)
+
+    def test_identical_pages_report_no_deviation(self) -> None:
+        page = "\n".join(
+            [line_of("hello", 72, 100), line_of("world", 72, 112), rect_op(70, 90, 300, 91)]
+        )
+        vector = self.diff(page, page)
+        self.assertEqual(vector["lines"]["matched"], 2)
+        self.assertEqual(vector["lines"]["missing"], 0)
+        self.assertEqual(vector["lines"]["extra"], 0)
+        self.assertEqual(vector["lines"]["deviant"], 0)
+        self.assertAlmostEqual(vector["baseline"]["mean_abs_dy"], 0.0, places=6)
+        self.assertEqual(vector["rects"]["gt_count"], vector["rects"]["out_count"])
+
+    def test_shifted_line_reports_dy_and_deviant_count(self) -> None:
+        gt = "\n".join([line_of("hello", 72, 100), line_of("world", 72, 112)])
+        out = "\n".join([line_of("hello", 72, 100), line_of("world", 72, 114)])
+        vector = self.diff(gt, out)
+        self.assertEqual(vector["lines"]["deviant"], 1)
+        self.assertAlmostEqual(vector["baseline"]["worst_dy"], 2.0, places=3)
+        worst = vector["baseline"]["worst_line"]
+        self.assertIn("world", worst)
+
+    def test_sub_noise_floor_shift_is_not_deviant(self) -> None:
+        gt = line_of("hello", 72, 100)
+        out = line_of("hello", 72, 100.08)
+        vector = self.diff(gt, out, noise_floor=0.12)
+        self.assertEqual(vector["lines"]["deviant"], 0)
+        # The raw statistic still carries the measurement.
+        self.assertGreater(vector["baseline"]["worst_dy"], 0.0)
+
+    def test_missing_and_extra_lines_are_counted(self) -> None:
+        gt = "\n".join([line_of("alpha", 72, 100), line_of("beta", 72, 112)])
+        out = line_of("alpha", 72, 100)
+        vector = self.diff(gt, out)
+        self.assertEqual(vector["lines"]["missing"], 1)
+        self.assertEqual(vector["lines"]["extra"], 0)
+        self.assertIn("beta", vector["lines"]["missing_text"][0])
+
+    def test_wrap_difference_is_detected_not_reported_missing(self) -> None:
+        gt = "\n".join([line_of("abcdef", 72, 100), line_of("ghi", 72, 112)])
+        out = "\n".join([line_of("abc", 72, 100), line_of("defghi", 72, 112)])
+        vector = self.diff(gt, out)
+        self.assertEqual(vector["lines"]["missing"], 0)
+        self.assertEqual(vector["lines"]["extra"], 0)
+        self.assertEqual(vector["wraps"]["count"], 1)
+
+    def test_reordered_content_is_classified_reflow_not_loss(self) -> None:
+        # A table row whose cells share one baseline in GT but split across two
+        # baselines in the output: same characters, different line grouping.
+        gt = line_of("labelvalue", 72, 100)
+        out = "\n".join([line_of("value", 120, 99), line_of("label", 72, 103)])
+        vector = self.diff(gt, out)
+        self.assertEqual(vector["lines"]["missing"], 0)
+        self.assertEqual(vector["lines"]["extra"], 0)
+        self.assertEqual(vector["reflow"]["gt_lines"], 1)
+        self.assertEqual(vector["reflow"]["out_lines"], 2)
+
+    def test_real_text_loss_is_still_reported_missing(self) -> None:
+        gt = "\n".join([line_of("kept", 72, 100), line_of("lost", 72, 112)])
+        out = "\n".join([line_of("kept", 72, 100), line_of("other", 72, 112)])
+        vector = self.diff(gt, out)
+        self.assertEqual(vector["lines"]["missing"], 1)
+        self.assertEqual(vector["lines"]["extra"], 1)
+        self.assertEqual(vector["reflow"]["gt_lines"], 0)
+
+    def test_pitch_delta_between_consecutive_matched_lines(self) -> None:
+        gt = "\n".join([line_of("one", 72, 100), line_of("two", 72, 112), line_of("three", 72, 124)])
+        out = "\n".join([line_of("one", 72, 100), line_of("two", 72, 113), line_of("three", 72, 126)])
+        vector = self.diff(gt, out)
+        self.assertAlmostEqual(vector["pitch"]["worst_delta"], 1.0, places=3)
+        self.assertEqual(vector["pitch"]["pairs"], 2)
+
+    def test_width_drift_is_relative(self) -> None:
+        gt = line_of("wide", 72, 100, pitch=6.0)
+        out = line_of("wide", 72, 100, pitch=6.3)
+        vector = self.diff(gt, out)
+        self.assertGreater(vector["width"]["worst_pct"], 3.0)
+
+    def test_rect_census_reports_count_delta(self) -> None:
+        gt = "\n".join([rect_op(70, 90, 300, 91), rect_op(70, 110, 300, 111, "stroke_path")])
+        out = rect_op(70, 90, 300, 91)
+        vector = self.diff(gt, out)
+        self.assertEqual(vector["rects"]["gt_count"], 2)
+        self.assertEqual(vector["rects"]["out_count"], 1)
+
+
+class ReadingTest(unittest.TestCase):
+    def test_reading_mentions_wrap_and_missing_content(self) -> None:
+        gt = compare_layout.parse_trace(
+            trace_document("\n".join([line_of("abcdef", 72, 100), line_of("ghi", 72, 112)]))
+        )[0]
+        out = compare_layout.parse_trace(
+            trace_document("\n".join([line_of("abc", 72, 100), line_of("defghi", 72, 112)]))
+        )[0]
+        vector = compare_layout.diff_page(gt, out)
+        reading = compare_layout.render_reading([vector])
+        self.assertIn("wrap", reading.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `scripts/compare_layout.py`, the quantitative-verification tool proposed in #694: it parses `mutool draw -F trace` for a GT/output pair, matches text lines by content, and emits a typed per-page deviation vector — missing vs re-wrapped vs re-grouped lines classified separately from real text loss, baseline dy statistics, inter-line pitch deltas, line-width drift, and a fill/stroke rect census — with the GT quantisation noise floors built in (`--noise-floor 0.12` for Word GT, `0.5` for Excel GT). `--json` emits the vectors for future baseline storage (#697).

The 2026-07-29 audit showed pixel scalars rank attention poorly and even move the wrong way when output becomes more faithful than an imperfect GT; every finding that stuck was settled by exactly the trace measurements this tool automates (six audit agents each hand-wrote the same parsers).

## Related issue

Related: #694

## Key changes

- `scripts/compare_layout.py` — parser (device-transform aware), line builder, SequenceMatcher line matching, wrap/reflow classifiers, deviation vector, `## Reading` renderer, CLI.
- `scripts/tests/test_compare_layout.py` — 14 unit tests over synthetic trace fragments mirroring real mutool output (transform math, clustering, matching, wrap vs reflow vs loss, pitch/width, noise floor, rect census).
- `.github/workflows/ci.yml` — runs the new test file beside the visual-PR-validator step.
- `CLAUDE.md` — 5-line pointer in the Three-axis comparison section.

## Testing

- `python3 -m unittest discover -s scripts/tests -p 'test_compare_layout.py'` — 14/14 pass.
- Triangulated on two audited pages: reproduces the invoice wrap-flip cascade (worst −11.50pt, classified as reflow with no text lost) and the budget row drift (worst +21.75pt, pitch drift flagged) to the figures measured by hand in the audit; the rect census carries an explicit op-splitting caveat where GT draws per-cell border segments.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: tooling and docs only; the converter is untouched.

## Checklist

- [x] Commits include a `Signed-off-by` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)