### PR TITLE
fix(harness): export each Excel GT sheet as its own PDF

### DIFF
--- a/scripts/macos/export_excel_pdfs.applescript
+++ b/scripts/macos/export_excel_pdfs.applescript
@@ -26,8 +26,13 @@ on run argv
                             set visibleSheetCount to visibleSheetCount + 1
                             set outputPath to outputDirectory & "/" & outputId & "-sheet-" & my paddedIndex(sheetIndex) & ".pdf"
                             set outputFile to my createEmptyFile(outputPath)
+                            -- Excel's PDF save as always exports every visible sheet of the
+                            -- workbook, so hiding the others is the only way to scope the
+                            -- export to just this worksheet.
+                            set hiddenSheetNames to my hideOtherVisibleSheets(openedWorkbook, name of currentSheet)
                             save as currentSheet filename outputFile file format PDF file format
                             my waitForNonEmptyFile(outputPath)
+                            my restoreSheetVisibility(openedWorkbook, hiddenSheetNames)
                         end if
                     end repeat
 
@@ -48,6 +53,35 @@ on run argv
 
     if (count failures) > 0 then error my joinLines(failures)
 end run
+
+on hideOtherVisibleSheets(openedWorkbook, currentSheetName)
+    set hiddenSheetNames to {}
+    tell application "Microsoft Excel"
+        -- Iterate every sheet (not just worksheets) so chart sheets are hidden
+        -- too; match by name because object-specifier equality is unreliable.
+        -- The explicit `get` materializes the list before iterating: a bare
+        -- `repeat with x in (every sheet of wb)` re-resolves `item N of
+        -- (every sheet ...)` per iteration, which Excel rejects with
+        -- parameter error -50 even though `get every sheet` succeeds.
+        repeat with candidateSheet in (get every sheet of openedWorkbook)
+            if (name of candidateSheet) is not currentSheetName then
+                if visible of candidateSheet is sheet visible then
+                    set visible of candidateSheet to sheet hidden
+                    set end of hiddenSheetNames to (name of candidateSheet)
+                end if
+            end if
+        end repeat
+    end tell
+    return hiddenSheetNames
+end hideOtherVisibleSheets
+
+on restoreSheetVisibility(openedWorkbook, hiddenSheetNames)
+    tell application "Microsoft Excel"
+        repeat with hiddenSheetName in hiddenSheetNames
+            set visible of sheet (hiddenSheetName as text) of openedWorkbook to sheet visible
+        end repeat
+    end tell
+end restoreSheetVisibility
 
 on removePreviousSheetPdfs(outputDirectory, outputId)
     set filePattern to outputId & "-sheet-*.pdf"


### PR DESCRIPTION
## What changed

`scripts/macos/export_excel_pdfs.applescript` now hides every other visible sheet (chart sheets included) around each per-sheet `save as`, then restores exactly the sheets it hid, so each `<id>-sheet-NNNN.pdf` contains exactly one worksheet.

## Why

Excel's AppleScript `save as` is a workbook-level command — applied to a worksheet it still delegates to the workbook's SaveAs, and a PDF SaveAs always exports **every visible sheet**. The per-sheet loop therefore wrote N whole-workbook copies, and `public_visual_audit.rs` concatenated them with `pdfunite`: every multi-sheet GT page count and text-length baseline was inflated by the sheet count (a 10-sheet workbook exported 230 GT pages for a real 23).

## Key changes

- `hideOtherVisibleSheets`: walks `every sheet` of the workbook, matches by name (object-specifier equality is unreliable), hides only currently-visible sheets, returns their names. Hidden/very-hidden sheets are never touched; the current sheet stays visible, so the at-least-one-visible-sheet rule can't trip.
- `restoreSheetVisibility`: restores exactly the recorded sheets before the next iteration's visibility check.
- Both handlers wrap Excel terminology in their own `tell application` block (they sit outside the main tell).
- Convention decided per the issue's open question: **all visible sheets, one PDF per sheet**, matching what the converter renders and the existing pdfunite combine step in `public_visual_audit.rs` (unchanged).

## Verification

Ran the fixed exporter through real Excel on the 10-sheet `tests/fixtures/xlsx/office2pdf_repository_workbook.xlsx`:
- 10 per-sheet PDFs, page counts **1, 5, 3, 1, 1, 6, 1, 2, 1, 2 — sum exactly 23** (before: every PDF was the whole 23-page workbook)
- each PDF samples to its own sheet's text; all file sizes distinct
- `osacompile` clean; Excel quit cleanly

Known trade-off: structure-protected workbooks now fail loudly at the first hide instead of silently producing duplicated GT — preferable for a ground-truth exporter.

No Rust code touched; the default `cargo test` suite is unaffected (harness-only change consumed by the `#[ignore]`d visual audit on macOS).

Related: #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)