### PR TITLE
fix(render): satisfy clippy::nonminimal_bool on Rust 1.93

### DIFF
--- a/crates/office2pdf/src/render/typst_gen_tables.rs
+++ b/crates/office2pdf/src/render/typst_gen_tables.rs
@@ -1177,17 +1177,20 @@ fn resolve_boundary_painted_borders(
         // stack). The data area starts at row/column 1, so its seeding is
         // untouched.
         let heading_exterior_is_excluded: bool = table.prints_headings;
+        // Stated as "no disqualifier applies" rather than as a chain of ANDed
+        // negations: the two are equivalent by De Morgan, but only this form
+        // satisfies clippy::nonminimal_bool.
         let horizontal_boundary_is_free = |boundary: usize, col: usize| -> bool {
-            !(heading_exterior_is_excluded && boundary == 0)
-                && !top_sides.contains_key(&(boundary, col))
-                && !bottom_sides.contains_key(&(boundary, col))
-                && !fill_suppressed_horizontal.contains(&(boundary, col))
+            !((heading_exterior_is_excluded && boundary == 0)
+                || top_sides.contains_key(&(boundary, col))
+                || bottom_sides.contains_key(&(boundary, col))
+                || fill_suppressed_horizontal.contains(&(boundary, col)))
         };
         let vertical_boundary_is_free = |boundary: usize, row: usize| -> bool {
-            !(heading_exterior_is_excluded && boundary == 0)
-                && !left_sides.contains_key(&(boundary, row))
-                && !right_sides.contains_key(&(boundary, row))
-                && !fill_suppressed_vertical.contains(&(boundary, row))
+            !((heading_exterior_is_excluded && boundary == 0)
+                || left_sides.contains_key(&(boundary, row))
+                || right_sides.contains_key(&(boundary, row))
+                || fill_suppressed_vertical.contains(&(boundary, row)))
         };
         for placement in &placements {
             let column_tracks = placement.first_col..placement.first_col + placement.col_span;


### PR DESCRIPTION
## Summary

Rust 1.93's clippy rejects the ANDed-negation form of the two `*_boundary_is_free` closures in `typst_gen_tables.rs` under `clippy::nonminimal_bool` — six errors — which fails the workspace `cargo clippy --workspace --all-targets -- -D warnings` gate on **every** pull request.

`typst_gen_tables.rs` has not changed since it last passed CI (main was green on `c528eef`), so this is the newer stable toolchain reaching existing code, not a regression introduced by a PR. It currently blocks all work.

Rewritten by De Morgan into "no disqualifier applies", which is what the predicate already meant: a boundary is free when it is not the excluded heading exterior, carries no declared side on either neighbour, and is not fill-suppressed. Same operands, same short-circuit order, no behaviour change.

## Related issue

None — CI infrastructure repair.

## Testing

- `cargo clippy --workspace --all-targets -- -D warnings` → exit 0 (was exit 101 with 6 errors)
- `cargo test -p office2pdf` → all targets pass
- `cargo fmt` clean

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: A boolean predicate rewritten by De Morgan's law into an equivalent form. The operands, their short-circuit order, and the returned value are identical for every input, so no rendered pixel can differ. The full `cargo test -p office2pdf` suite — which includes the golden-mock and visual-audit contracts — passes unchanged.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)