### PR TITLE
feat(tooling): add a text-layer codepoint census check (issue #696)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
         run: python3 -m unittest discover -s scripts/tests -p 'test_check_visual_pr.py'
       - name: Test layout differ
         run: python3 -m unittest discover -s scripts/tests -p 'test_compare_layout.py'
+      - name: Test text-layer census
+        run: python3 -m unittest discover -s scripts/tests -p 'test_compare_text_layer.py'
       - name: Validate visual PR contract
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,8 @@ within +-2 per channel. The shift compares cumulative distributions, so that
 noise reaches 0.0003 while the half-width borders of #487 reached 0.0016.
 | Pixel difference (`AE`, `RMSE`) | whatever the other two were not watching | see below |
 
+
+
 **Never conclude from the pixel count alone.** Measured on this corpus: two
 shadow variants that look plainly different both scored an identical 173,524
 at `AE -fuzz 5%`; a correct anchor-height fix made the count *rise* because the
@@ -175,6 +177,16 @@ cut the error from 86pt to 4.4pt barely moved it, because re-proportioning
 columns changes where pixels are, not how many differ. Use `RMSE` or
 `AE -fuzz 1%` when magnitude matters, and treat all of them as a regression
 tripwire rather than evidence.
+
+**Text layer (`scripts/compare_text_layer.py`)** is a fourth axis none of the
+three above can see. Some defects change what a reader can select and search
+for while leaving every pixel identical: injected U+2060/U+00A0 (#664), or a
+ligature swallowing letter-spacing so the run extracts as `o ffi c e 2 p d f`
+(#684 — measured 24 occurrences in the pre-fix output, against 0 of the
+`ofce2pdf` that issue's body reports). It reports a codepoint-class census and a normalized-content check
+separately — a class delta with matching content is an encoding difference, a
+content residual is real text loss. Costs milliseconds; run it on any fix that
+touches text.
 
 The tool's `## Reading` section is the part to act on — it routes attention to
 the defect class (pagination, line advance, indent, fill, size) instead of

--- a/scripts/compare_text_layer.py
+++ b/scripts/compare_text_layer.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Text-layer codepoint census: is the extracted text intact, independent of layout?
+
+Some defects are invisible in any raster and in any geometry comparison, because
+they change *what a reader can select and search for* rather than where ink
+lands. Two from the 2026-07-29 audit wave:
+
+- U+2060 WORD JOINER and U+00A0 injected into slide text (issue #664), which
+  render identically but break search and copy;
+- ``ffi`` ligatures swallowing letter-spacing so the run extracted as
+  ``o ffi c e 2 p d f`` instead of ``office2pdf`` (issue #684) — 17 codepoints
+  where the word is 10, matching no search for it.
+
+Measured on the pre-fix output of ``office2pdf_introduction_ko.pptx``:
+``grep -c "o ffi c e 2 p d f"`` returned 24 and ``grep -c "ofce2pdf"``
+returned 0. ``pdftotext`` renders the merged glyph as the three letters
+``ffi``, and the tracking puts a space between every glyph, so characters are
+*gained* rather than lost — which is why this shows up below as a
+``space:SPACE`` delta and not a ``ligature:`` one. (Issue #684's body says the
+text reads ``ofce2pdf``; that string does not occur in the output, and the
+issue carries a correction to that effect.)
+
+Both are one extraction pass from automatic detection, and cost milliseconds.
+
+This tool answers two questions separately:
+
+1. **Census** — how many codepoints of each class does each side carry?
+   Injected joiners, NBSPs, ligature codepoints and control characters show up
+   as a class delta even when the rendered page is pixel-identical.
+2. **Content** — after undoing ligatures and collapsing whitespace, is the text
+   the same? A residual here is real text loss or gain, not a formatting
+   artefact.
+
+Reporting them apart matters: a ligature changes the census without changing the
+content, while a dropped word changes both. Conflating them makes a cosmetic
+difference look like data loss.
+
+Usage:
+    compare_text_layer.py GT.pdf OUTPUT.pdf [--page N] [--json]
+
+Requires ``pdftotext`` (poppler-utils).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import unicodedata
+from collections import Counter
+from pathlib import Path
+
+# Codepoints that a correct converter should never inject into the text layer.
+# Each renders as nothing or as an ordinary space, so a raster comparison cannot
+# see them, but each breaks search and copy.
+INVISIBLE_FORMATTERS: dict[str, str] = {
+    "⁠": "WORD JOINER",
+    "​": "ZERO WIDTH SPACE",
+    "‌": "ZERO WIDTH NON-JOINER",
+    "‍": "ZERO WIDTH JOINER",
+    "﻿": "ZERO WIDTH NO-BREAK SPACE",
+    "­": "SOFT HYPHEN",
+}
+
+# Spaces that are not U+0020. NBSP is the one converters reach for when they
+# want a space that does not collapse, which is exactly what breaks a search.
+NONSTANDARD_SPACES: dict[str, str] = {
+    " ": "NO-BREAK SPACE",
+    " ": "FIGURE SPACE",
+    " ": "THIN SPACE",
+    " ": "NARROW NO-BREAK SPACE",
+    "　": "IDEOGRAPHIC SPACE",
+}
+
+# Precomposed ligatures. A ligature is correct typography but wrong text: the
+# reader searching for "office" finds nothing if the file holds U+FB03.
+LIGATURES: dict[str, str] = {
+    "ﬀ": "ff",
+    "ﬁ": "fi",
+    "ﬂ": "fl",
+    "ﬃ": "ffi",
+    "ﬄ": "ffl",
+    "ﬅ": "st",
+    "ﬆ": "st",
+}
+
+
+def extract_text(pdf: Path, page: int | None) -> str:
+    """The PDF's text layer, as a reader's copy-paste would see it."""
+    command = ["pdftotext"]
+    if page is not None:
+        command += ["-f", str(page), "-l", str(page)]
+    command += [str(pdf), "-"]
+    try:
+        result = subprocess.run(command, capture_output=True, check=True)
+    except FileNotFoundError:
+        sys.exit("pdftotext not found — install poppler-utils.")
+    except subprocess.CalledProcessError as error:
+        sys.exit(f"pdftotext failed on {pdf}: {error}")
+    return result.stdout.decode("utf-8", errors="replace")
+
+
+def census(text: str) -> dict[str, int]:
+    """Counts per codepoint class, not per codepoint.
+
+    Classes are what a reviewer can act on: "3 word joiners appeared" is a
+    finding, "codepoint 8288 appeared 3 times" is a lookup.
+    """
+    counts: Counter[str] = Counter()
+    for char in text:
+        if char in INVISIBLE_FORMATTERS:
+            counts[f"invisible:{INVISIBLE_FORMATTERS[char]}"] += 1
+        elif char in NONSTANDARD_SPACES:
+            counts[f"space:{NONSTANDARD_SPACES[char]}"] += 1
+        elif char in LIGATURES:
+            counts[f"ligature:{LIGATURES[char]}"] += 1
+        elif char == " ":
+            counts["space:SPACE"] += 1
+        elif char in "\n\r\t":
+            continue  # layout, not content
+        elif unicodedata.category(char) == "Cc":
+            counts["control"] += 1
+    return dict(counts)
+
+
+def normalize(text: str) -> str:
+    """Undo ligatures and collapse whitespace, so only real content remains.
+
+    Comparing normalized forms separates "the text is different" from "the text
+    is encoded differently" — a distinction a raw diff cannot make.
+    """
+    for ligature, expansion in LIGATURES.items():
+        text = text.replace(ligature, expansion)
+    for invisible in INVISIBLE_FORMATTERS:
+        text = text.replace(invisible, "")
+    for space in NONSTANDARD_SPACES:
+        text = text.replace(space, " ")
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def compare(gt_text: str, out_text: str) -> dict:
+    """Census deltas and a content residual, reported apart."""
+    gt_census, out_census = census(gt_text), census(out_text)
+    deltas = {
+        key: out_census.get(key, 0) - gt_census.get(key, 0)
+        for key in set(gt_census) | set(out_census)
+        if out_census.get(key, 0) != gt_census.get(key, 0)
+    }
+    gt_norm, out_norm = normalize(gt_text), normalize(out_text)
+    return {
+        "census_gt": gt_census,
+        "census_output": out_census,
+        "census_deltas": deltas,
+        "content_matches": gt_norm == out_norm,
+        "content_length_gt": len(gt_norm),
+        "content_length_output": len(out_norm),
+    }
+
+
+def render_report(result: dict) -> str:
+    """A report that says what to do, not just what differs."""
+    lines: list[str] = ["## Text layer census", ""]
+    deltas = result["census_deltas"]
+    if not deltas:
+        lines.append("No codepoint class differs.")
+    else:
+        lines.append("| class | GT | output | delta |")
+        lines.append("| --- | ---: | ---: | ---: |")
+        for key in sorted(deltas):
+            lines.append(
+                f"| {key} | {result['census_gt'].get(key, 0)} | "
+                f"{result['census_output'].get(key, 0)} | {deltas[key]:+d} |"
+            )
+    lines += ["", "## Content", ""]
+    if result["content_matches"]:
+        lines.append(
+            "Normalized content is identical — any class delta above is an "
+            "encoding difference, not text loss."
+        )
+    else:
+        lines.append(
+            f"Normalized content DIFFERS: {result['content_length_gt']} chars in "
+            f"GT against {result['content_length_output']} in the output. This is "
+            "text gained or lost, not a formatting artefact."
+        )
+
+    lines += ["", "## Reading", ""]
+    injected = {k: v for k, v in deltas.items() if v > 0 and k.startswith("invisible:")}
+    ligatures = {k: v for k, v in deltas.items() if v > 0 and k.startswith("ligature:")}
+    nbsp = {k: v for k, v in deltas.items() if v > 0 and k.startswith("space:") and "SPACE" != k.split(":")[1]}
+    if injected:
+        lines.append(
+            "Invisible formatting characters were injected. They render as "
+            "nothing, so no raster check can see them, but they break search "
+            "and copy (see issue #664)."
+        )
+    if ligatures:
+        lines.append(
+            "The output carries ligature codepoints GT does not. The page may "
+            "look right while the word is unsearchable (see issue #684)."
+        )
+    if nbsp:
+        lines.append(
+            "Non-standard spaces were introduced. A search for the plain-space "
+            "form will not match."
+        )
+    if not (injected or ligatures or nbsp) and result["content_matches"]:
+        lines.append("Text layer is intact.")
+    elif not (injected or ligatures or nbsp):
+        lines.append(
+            "No class was injected, so the residual is genuine text loss or "
+            "gain — compare the extractions directly."
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("gt", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--page", type=int, default=None)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    result = compare(
+        extract_text(args.gt, args.page),
+        extract_text(args.output, args.page),
+    )
+    if args.json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        print(render_report(result))
+    # A census delta alone is not a failure; unexplained content loss is.
+    return 0 if result["content_matches"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_compare_text_layer.py
+++ b/scripts/tests/test_compare_text_layer.py
@@ -1,0 +1,87 @@
+"""Tests for the text-layer codepoint census.
+
+The cases are the two real defects that motivated it (issues #664 and #684),
+plus the negatives that keep the tool from crying wolf.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from compare_text_layer import census, compare, normalize, render_report
+
+
+class CensusTest(unittest.TestCase):
+    def test_counts_injected_word_joiners_as_their_own_class(self):
+        # Issue #664: U+2060 renders as nothing, so no raster check sees it.
+        counts = census("of⁠fice⁠2pdf")
+        self.assertEqual(counts["invisible:WORD JOINER"], 2)
+
+    def test_counts_nbsp_apart_from_ordinary_space(self):
+        counts = census("a b c")
+        self.assertEqual(counts["space:SPACE"], 1)
+        self.assertEqual(counts["space:NO-BREAK SPACE"], 1)
+
+    def test_counts_ligature_codepoints(self):
+        # Issue #684: the ffi ligature makes "office" unsearchable.
+        counts = census("oﬃce2pdf")
+        self.assertEqual(counts["ligature:ffi"], 1)
+
+    def test_ignores_layout_whitespace(self):
+        # Newlines and tabs are layout, and belong to the layout differ.
+        self.assertNotIn("control", census("a\nb\tc\r"))
+
+
+class NormalizeTest(unittest.TestCase):
+    def test_expands_ligatures_to_their_letters(self):
+        self.assertEqual(normalize("oﬃce2pdf"), "office2pdf")
+
+    def test_strips_invisible_formatters(self):
+        self.assertEqual(normalize("of⁠fice"), "office")
+
+    def test_folds_nonstandard_spaces_and_collapses_runs(self):
+        self.assertEqual(normalize("a  b\n\nc"), "a b c")
+
+
+class CompareTest(unittest.TestCase):
+    def test_ligature_is_an_encoding_difference_not_text_loss(self):
+        # The distinction the tool exists to make: the page reads the same, the
+        # text layer does not.
+        result = compare("office2pdf", "oﬃce2pdf")
+        self.assertTrue(result["content_matches"])
+        self.assertEqual(result["census_deltas"]["ligature:ffi"], 1)
+
+    def test_injected_joiners_are_reported_while_content_still_matches(self):
+        result = compare("office2pdf", "of⁠fice2pdf")
+        self.assertTrue(result["content_matches"])
+        self.assertEqual(result["census_deltas"]["invisible:WORD JOINER"], 1)
+
+    def test_dropped_word_is_content_loss(self):
+        result = compare("alpha beta gamma", "alpha gamma")
+        self.assertFalse(result["content_matches"])
+
+    def test_identical_text_reports_no_delta(self):
+        result = compare("office2pdf", "office2pdf")
+        self.assertEqual(result["census_deltas"], {})
+        self.assertTrue(result["content_matches"])
+
+
+class ReportTest(unittest.TestCase):
+    def test_ligature_report_names_the_searchability_consequence(self):
+        report = render_report(compare("office2pdf", "oﬃce2pdf"))
+        self.assertIn("unsearchable", report)
+
+    def test_clean_comparison_says_so_plainly(self):
+        self.assertIn("intact", render_report(compare("abc", "abc")))
+
+    def test_content_loss_is_not_blamed_on_a_class(self):
+        # No class was injected, so the report must point at real loss rather
+        # than leaving the reader hunting for a formatting cause.
+        report = render_report(compare("alpha beta", "alpha"))
+        self.assertIn("genuine text loss", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `scripts/compare_text_layer.py`, a fourth comparison axis: whether the extracted text layer is intact, independent of layout.

Some defects change what a reader can **select and search for** while leaving every pixel identical. Neither the geometry axis, the colour axis, nor the pixel count can see them. Two from the audit wave: invisible formatters injected into slide text (#664), and a ligature swallowing letter-spacing so a word extracts unsearchable (#684).

## Related issue

Related: #696

## Key changes

- `scripts/compare_text_layer.py` — extracts via `pdftotext` and reports **two things apart**:
  - a **codepoint-class census** (invisible formatters, non-standard spaces, ligatures, control chars),
  - a **normalized-content equality check** that expands ligatures and folds whitespace first.

  Reporting them apart is the point: a class delta with matching content is an *encoding* difference; a content residual is *real text loss*. Conflating them makes a cosmetic difference look like data loss. Exit status follows the content check alone, so a benign encoding difference does not fail a build.
- `scripts/tests/test_compare_text_layer.py` — 14 tests, cased on the two real defects plus the negatives that keep it from crying wolf.
- `.github/workflows/ci.yml` — runs the tests beside the existing layout-differ step.
- `CLAUDE.md` — documents it as a fourth axis, placed after the pixel-count warning so that discussion stays contiguous.

## Testing

- `python3 -m unittest discover -s scripts/tests -p 'test_compare_text_layer.py'` — 14 tests, OK.
- `yaml.safe_load` parses the modified `ci.yml`.

**Validated against the real defect, not only synthetic input.** Run on the introduction deck rendered either side of the #684 fix:

```
| class       | GT   | output | delta |
| space:SPACE | 2032 | 2200   | +168  |
Normalized content DIFFERS: 12747 chars in GT against 12915 in the output.
```

That +168 matches the character delta I measured by hand when fixing #684 — so the tool would have caught that defect automatically.

## A correction this surfaced

Issue #684's body reports the extraction as `ofce2pdf`. Measured on the pre-fix output:

```
grep -c "o ffi c e 2 p d f"  -> 24
grep -c "ofce2pdf"           -> 0
```

`pdftotext` renders the merged glyph as the three letters `ffi`, and the tracking puts a space between every glyph, so characters are **gained**, not lost. That is why the census catches it as a `space:SPACE` delta rather than a `ligature:` one. #684 carries a correction, and the docstring states the measurement so the claim does not rest on the issue text.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: This adds a standalone analysis script, its tests, a CI step that runs those tests, and documentation. No crate source is touched, so no conversion path and no rendered output can differ.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
