### PR TITLE
fix(pptx): stop injecting joiners into the no-wrap text layer

### DIFF
--- a/crates/office2pdf/src/render/typst_gen_fixed_page_textbox_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_fixed_page_textbox_tests.rs
@@ -972,7 +972,110 @@ fn test_fixed_page_text_box_no_wrap_centered_text_uses_inline_box() {
 }
 
 #[test]
-fn test_fixed_page_text_box_no_wrap_inserts_word_joiners_for_cjk_titles() {
+fn test_fixed_page_text_box_no_wrap_keeps_mixed_latin_cjk_searchable() {
+    // The heading issue #664 measured: `panic 안전성` came out with a joiner
+    // between every character and its space swapped for U+00A0, so searching
+    // the PDF for the heading found nothing.
+    let doc = make_doc(vec![make_fixed_page(
+        960.0,
+        540.0,
+        vec![FixedElement {
+            x: 100.0,
+            y: 120.0,
+            width: 180.0,
+            height: 40.0,
+            kind: FixedElementKind::TextBox(crate::ir::TextBoxData {
+                content: vec![Block::Paragraph(Paragraph {
+                    style: ParagraphStyle {
+                        alignment: Some(Alignment::Center),
+                        ..ParagraphStyle::default()
+                    },
+                    runs: vec![Run {
+                        text: "panic 안전성".to_string(),
+                        style: TextStyle {
+                            font_size: Some(28.0),
+                            ..TextStyle::default()
+                        },
+                        href: None,
+                        footnote: None,
+                    }],
+                })],
+                padding: Insets::default(),
+                vertical_align: crate::ir::TextBoxVerticalAlign::Top,
+                fill: None,
+                opacity: None,
+                stroke: None,
+                shape_kind: None,
+                no_wrap: true,
+                auto_fit: false,
+                text_rotation_deg: None,
+            }),
+        }],
+    )]);
+    let output = generate_typst(&doc).unwrap();
+    assert!(
+        output.source.contains("panic 안전성"),
+        "Expected the heading with an ordinary space, got:\n{}",
+        output.source,
+    );
+}
+
+#[test]
+fn test_fixed_page_text_box_no_wrap_still_strips_the_kinsoku_marker() {
+    // Triangulation: the zero-width kinsoku marker must keep being dropped. A
+    // no-wrap box never takes that break, and letting U+200B through would
+    // trade one invisible text-layer character for another.
+    let doc = make_doc(vec![make_fixed_page(
+        960.0,
+        540.0,
+        vec![FixedElement {
+            x: 100.0,
+            y: 120.0,
+            width: 180.0,
+            height: 40.0,
+            kind: FixedElementKind::TextBox(crate::ir::TextBoxData {
+                content: vec![Block::Paragraph(Paragraph {
+                    style: ParagraphStyle {
+                        alignment: Some(Alignment::Center),
+                        ..ParagraphStyle::default()
+                    },
+                    runs: vec![Run {
+                        text: "\u{200B}제안\u{200B}개요".to_string(),
+                        style: TextStyle {
+                            font_size: Some(28.0),
+                            ..TextStyle::default()
+                        },
+                        href: None,
+                        footnote: None,
+                    }],
+                })],
+                padding: Insets::default(),
+                vertical_align: crate::ir::TextBoxVerticalAlign::Top,
+                fill: None,
+                opacity: None,
+                stroke: None,
+                shape_kind: None,
+                no_wrap: true,
+                auto_fit: false,
+                text_rotation_deg: None,
+            }),
+        }],
+    )]);
+    let output = generate_typst(&doc).unwrap();
+    assert!(
+        output.source.contains("제안개요"),
+        "Expected the marker stripped, got:\n{}",
+        output.source,
+    );
+    assert!(
+        !output.source.contains('\u{200B}'),
+        "No U+200B may reach the text layer, got:\n{}",
+        output.source,
+    );
+}
+
+#[test]
+fn test_fixed_page_text_box_no_wrap_keeps_cjk_title_extractable() {
     let doc = make_doc(vec![make_fixed_page(
         960.0,
         540.0,
@@ -1010,9 +1113,27 @@ fn test_fixed_page_text_box_no_wrap_inserts_word_joiners_for_cjk_titles() {
         }],
     )]);
     let output = generate_typst(&doc).unwrap();
+    // The enclosing `#box[` already forbids every break inside the paragraph,
+    // so no joiner is needed — and one here would reach the PDF text layer and
+    // make the title unsearchable (issue #664).
     assert!(
-        output.source.contains("제\u{2060}안\u{2060}개\u{2060}요"),
-        "Expected no-wrap word joiners in output, got:\n{}",
+        output.source.contains("제안개요"),
+        "Expected the title verbatim in output, got:\n{}",
+        output.source,
+    );
+    assert!(
+        !output.source.contains('\u{2060}'),
+        "No U+2060 WORD JOINER may reach the text layer, got:\n{}",
+        output.source,
+    );
+    assert!(
+        !output.source.contains('\u{00A0}'),
+        "No U+00A0 NO-BREAK SPACE may reach the text layer, got:\n{}",
+        output.source,
+    );
+    assert!(
+        output.source.contains("#box["),
+        "The no-wrap box is what suppresses the breaks, got:\n{}",
         output.source,
     );
 }
@@ -1107,12 +1228,21 @@ fn test_fixed_page_text_box_no_wrap_keeps_mixed_script_titles_unbroken() {
         }],
     )]);
     let output = generate_typst(&doc).unwrap();
+    // The heading must stay unbreakable *and* readable: the enclosing `#box[`
+    // supplies the first, so the text itself is emitted verbatim (issue #664).
     assert!(
-        output.source.contains("I\u{2060}I\u{2060}I\u{2060}.")
-            && output
-                .source
-                .contains("\u{00A0}\u{2060}기\u{2060}술\u{2060}부\u{2060}문"),
-        "Expected mixed-script no-wrap title to keep the full heading unbreakable, got:\n{}",
+        output.source.contains("III. 기술부문"),
+        "Expected the mixed-script heading verbatim, got:\n{}",
+        output.source,
+    );
+    assert!(
+        output.source.contains("#box["),
+        "The no-wrap box is what keeps the heading unbroken, got:\n{}",
+        output.source,
+    );
+    assert!(
+        !output.source.contains('\u{2060}') && !output.source.contains('\u{00A0}'),
+        "No invisible joiner may reach the text layer, got:\n{}",
         output.source,
     );
 }
@@ -1167,12 +1297,17 @@ fn test_fixed_page_text_box_no_wrap_preserves_mixed_script_titles_across_runs() 
         }],
     )]);
     let output = generate_typst(&doc).unwrap();
+    // Split across runs, the heading still has to come out as one readable
+    // string rather than a joiner-separated one (issue #664).
     assert!(
-        output.source.contains("I\u{2060}I\u{2060}I\u{2060}.")
-            && output
-                .source
-                .contains("\u{00A0}\u{2060}기\u{2060}술\u{2060}부\u{2060}문"),
-        "Expected mixed-script no-wrap title to stay unbroken across runs, got:\n{}",
+        output.source.contains("III.") && output.source.contains(" 기술부문"),
+        "Expected both runs of the heading verbatim, the second keeping its
+         ordinary leading space, got:\n{}",
+        output.source,
+    );
+    assert!(
+        !output.source.contains('\u{2060}') && !output.source.contains('\u{00A0}'),
+        "No invisible joiner may reach the text layer, got:\n{}",
         output.source,
     );
 }

--- a/crates/office2pdf/src/render/typst_gen_text.rs
+++ b/crates/office2pdf/src/render/typst_gen_text.rs
@@ -933,23 +933,12 @@ pub(super) fn generate_runs_with_tabs_no_wrap(
     tab_stops: Option<&[TabStop]>,
     default_tab_width_pt: f64,
 ) {
-    let preserve_cjk_no_wrap: bool = runs
-        .iter()
-        .filter(|run| run.footnote.is_none())
-        .any(|run| run.text.chars().any(is_cjk_like));
-    let mut no_wrap_state: NoWrapState = NoWrapState::default();
     let transformed_runs: Vec<Run> = runs
         .iter()
         .map(|run| {
             let mut transformed_run: Run = run.clone();
             if transformed_run.footnote.is_none() {
-                transformed_run.text = no_wrap_text(
-                    &transformed_run.text,
-                    preserve_cjk_no_wrap,
-                    &mut no_wrap_state,
-                );
-            } else {
-                no_wrap_state = NoWrapState::default();
+                transformed_run.text = no_wrap_text(&transformed_run.text);
             }
             transformed_run
         })
@@ -964,12 +953,6 @@ pub(super) fn generate_runs_with_tabs_no_wrap(
         default_tab_width_pt,
         EojeolWrap::Syllable,
     );
-}
-
-#[derive(Clone, Copy, Default)]
-struct NoWrapState {
-    previous_visible_char: Option<char>,
-    previous_non_breaking_space: bool,
 }
 
 /// Emits Typst variable bindings for a non-first tab segment: measurement,
@@ -1050,11 +1033,15 @@ pub(super) enum EojeolWrap {
     /// contingent break for PowerPoint kinsoku (issue #438).
     ///
     /// A no-break marker between the syllables — U+2060 WORD JOINER, the
-    /// obvious alternative and the shape the auto-space and kinsoku markers
-    /// in this file already use — does suppress the breaks, but it lands in
-    /// the PDF text layer and makes the text unsearchable. That is issue
-    /// #664, reproduced from first principles on a probe before this
-    /// mechanism was chosen; a frame leaves the text layer untouched.
+    /// obvious alternative — does suppress the breaks, but it lands in the PDF
+    /// text layer and makes the text unsearchable. The no-wrap path emitted
+    /// exactly that until issue #664; the marker turned out to be redundant
+    /// there, because the paragraph was already inside a box. A frame leaves
+    /// the text layer untouched, so it is the mechanism here too.
+    ///
+    /// The other two markers this file uses are stripped before emission and
+    /// never reach the text layer: U+E001 for auto-space and U+200B for the
+    /// kinsoku break.
     ///
     /// `line_box_em` is the paragraph's fixed `(top-edge, bottom-edge)` when
     /// it declares them, so the frame can restore them; see
@@ -1459,50 +1446,21 @@ fn write_eojeol_frame_close(out: &mut String, line_box_em: Option<(f64, f64)>) {
     out.push_str(if line_box_em.is_some() { "]]" } else { "]" });
 }
 
-fn no_wrap_text(text: &str, preserve_cjk_no_wrap: bool, state: &mut NoWrapState) -> String {
-    if !preserve_cjk_no_wrap {
-        return text.to_string();
-    }
-
-    let mut out: String = String::new();
-
-    for ch in text.chars() {
-        if matches!(ch, '\t' | PPTX_SOFT_LINE_BREAK_CHAR) {
-            out.push(ch);
-            *state = NoWrapState::default();
-            continue;
-        }
-
-        // A no-wrap box never takes the kinsoku break, so drop its marker
-        // instead of letting the zero-width space reach the text layer.
-        if ch == HANGUL_KINSOKU_BREAK_CHAR {
-            continue;
-        }
-
-        if ch == ' ' {
-            out.push('\u{00A0}');
-            state.previous_visible_char = None;
-            state.previous_non_breaking_space = true;
-            continue;
-        }
-
-        if state.previous_non_breaking_space
-            || state
-                .previous_visible_char
-                .is_some_and(|prev| needs_no_wrap_joiner(prev, ch))
-        {
-            out.push('\u{2060}');
-        }
-        out.push(ch);
-        state.previous_visible_char = Some(ch);
-        state.previous_non_breaking_space = false;
-    }
-
-    out
-}
-
-fn needs_no_wrap_joiner(previous: char, current: char) -> bool {
-    !previous.is_whitespace() && !current.is_whitespace()
+/// Strip the kinsoku break markers from a run bound for a no-wrap box.
+///
+/// The paragraph is already emitted inside a `#box[...]`, and a box is a
+/// single object to UAX #14, so no break opportunity survives inside it. This
+/// therefore has nothing to add to break suppression and only has to keep the
+/// zero-width kinsoku marker out of the text layer.
+///
+/// It used to also replace every space with U+00A0 and insert a U+2060 WORD
+/// JOINER between adjacent characters. Those were redundant with the enclosing
+/// box, and they reached the PDF text layer: slide text came out as
+/// `p<WJ>a<WJ>n<WJ>i<WJ>c`, which no search for `panic` can match (issue #664).
+fn no_wrap_text(text: &str) -> String {
+    text.chars()
+        .filter(|ch| *ch != HANGUL_KINSOKU_BREAK_CHAR)
+        .collect()
 }
 
 pub(crate) fn is_cjk_like(ch: char) -> bool {


### PR DESCRIPTION
## Summary

The PPTX no-wrap path inserted a U+2060 WORD JOINER between adjacent characters and
replaced every interior space with U+00A0. Neither codepoint is in the source or in
PowerPoint's export. Glyph positions were unaffected, but the PDF text layer read
`p<WJ>a<WJ>n<WJ>i<WJ>c<NBSP><WJ>안<WJ>전<WJ>성`, so a search for `panic 안전성` found
nothing and copy-paste carried invisible joiners.

## Root cause

The markers were redundant from the start. `generate_paragraph` already wraps a no-wrap
paragraph in `#box[...]`:

```rust
if no_wrap {
    out.push_str("#box[");
    generate_runs_with_tabs_no_wrap(/* … */);
```

A box is a single object to UAX #14, so no break opportunity survives inside it — the
joiners were suppressing breaks that the box had already removed. This file's own
`EojeolWrap::Eojeol` doc comment records that same finding, citing this issue, and uses a
frame for exactly this reason.

`no_wrap_text` now strips only the U+200B kinsoku marker, which a no-wrap box never takes.

## Measured

`tests/fixtures/pptx/office2pdf_introduction_ko.pptx`, all 30 pages:

| | before | after |
| --- | ---: | ---: |
| U+2060 WORD JOINER | 15 | **0** |
| U+00A0 NO-BREAK SPACE | 5 | **0** |
| U+200B, U+E001 | 0 | 0 |

`panic 안전성` is now found by a text search of the output. The before figures match this
issue's own count (4 on slide 5 + 11 on slide 11, and 5 spaces).

**That the box alone suppresses the breaks is verified, not assumed.** Every one of the 30
pages was rendered before and after at 100 DPI and compared with
`compare -metric AE -fuzz 2%`: **zero differing pixels on every page**. Nothing re-wrapped,
and no glyph moved.

## Tests

Four existing tests asserted the joiner output literally — one of them the exact
`I<WJ>I<WJ>I<WJ>.` string this issue reports as the defect. They now assert what the fix is
for: the heading emitted verbatim, no invisible codepoint in the text layer, and the
`#box[` that does the real work. Two tests are added, covering the mixed Latin/CJK heading
the issue measured and the kinsoku marker that must still be stripped.

## Incidental correction

The `EojeolWrap::Eojeol` doc comment claimed U+2060 was "the shape the auto-space and
kinsoku markers in this file already use". Those markers are U+E001 and U+200B. Corrected
while the surrounding text was being touched, and both are confirmed absent from the
output.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: the change removes invisible codepoints from the PDF text layer only. All 30
  pages of the audited deck were rendered before and after and compared page by page at
  100 DPI, giving zero differing pixels — there is no rendered difference to show.

Related: #664
