### PR TITLE
fix(docx): give a framed header page number its own context

### DIFF
--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -1861,18 +1861,22 @@ fn generate_hf_elements(out: &mut String, elements: &[HFInline], ctx: &mut GenCt
             HFInline::Image(image) => generate_image(out, image, ctx),
             // Word applies the containing run's properties to the field
             // result, so the number matches the literals around it.
+            // `context` is explicit because a header or footer paragraph
+            // carrying a frame is emitted as a `#place` at document level,
+            // where the page counter has no context of its own and Typst
+            // refuses it. Inside a real header the value is the same.
             HFInline::PageNumber(style) => {
                 write_hf_field(
                     out,
                     style,
                     &format!(
-                        "#counter(page).display(\"{}\")",
+                        "#context counter(page).display(\"{}\")",
                         ctx.page_number_format.typst_pattern()
                     ),
                 );
             }
             HFInline::TotalPages(style) => {
-                write_hf_field(out, style, "#counter(page).final().first()");
+                write_hf_field(out, style, "#context counter(page).final().first()");
             }
             HFInline::PositionedTab(_) => out.push_str("#h(1em)"),
         }

--- a/crates/office2pdf/src/render/typst_gen_page_misc_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_page_misc_tests.rs
@@ -187,6 +187,62 @@ fn test_generate_page_anchored_footer_frame_in_foreground() {
     assert!(!output.source.contains("footer:"));
 }
 
+/// A page number inside a page-anchored frame has to compile.
+///
+/// The frame is emitted as a `#place` at document level, where the page
+/// counter has no context of its own, so a bare `#counter(page).display()`
+/// makes Typst abort the whole conversion (issue #788).
+#[test]
+fn test_page_anchored_frame_page_number_compiles() {
+    use crate::ir::{
+        FrameAnchor, HFInline, HeaderFooter, HeaderFooterFrame, HeaderFooterParagraph,
+    };
+
+    let doc = make_doc(vec![Page::Flow(FlowPage {
+        size: PageSize::default(),
+        margins: Margins::default(),
+        content: vec![make_paragraph("Body")],
+        header: Some(HeaderFooter {
+            distance_from_edge: None,
+            paragraphs: vec![HeaderFooterParagraph {
+                style: ParagraphStyle::default(),
+                elements: vec![HFInline::PageNumber(TextStyle::default())],
+                border: None,
+                border_space: None,
+                frame: Some(HeaderFooterFrame {
+                    x: Some(50.0),
+                    y: Some(25.0),
+                    width: None,
+                    height: None,
+                    horizontal_anchor: FrameAnchor::Page,
+                    vertical_anchor: FrameAnchor::Page,
+                }),
+            }],
+        }),
+        footer: None,
+        columns: None,
+        line_grid_pitch: None,
+        line_grid_snaps_lines: false,
+        page_numbering: None,
+    })]);
+
+    let output = generate_typst(&doc).unwrap();
+    assert!(
+        output
+            .source
+            .contains("#place(top + left, dx: 50pt, dy: 25pt)"),
+        "the frame is still placed at document level: {}",
+        output.source
+    );
+    assert!(
+        output.source.contains("#context counter(page)"),
+        "the counter needs its own context there: {}",
+        output.source
+    );
+    crate::render::pdf::compile_to_pdf(&output.source, &output.images, None, &[], false, false)
+        .expect("a framed page number must compile");
+}
+
 #[test]
 fn test_generate_flow_page_with_header_and_footer() {
     use crate::ir::{HFInline, HeaderFooter, HeaderFooterParagraph};
@@ -599,8 +655,16 @@ fn test_table_page_with_page_number_footer() {
     let doc = make_doc(vec![page]);
     let output = generate_typst(&doc).unwrap();
     assert!(output.source.contains("footer: context ["));
-    assert!(output.source.contains(r#"#counter(page).display("1")"#));
-    assert!(output.source.contains("#counter(page).final().first()"));
+    assert!(
+        output
+            .source
+            .contains(r#"#context counter(page).display("1")"#)
+    );
+    assert!(
+        output
+            .source
+            .contains("#context counter(page).final().first()")
+    );
 }
 
 #[test]
@@ -1821,7 +1885,7 @@ fn test_page_number_field_uses_its_run_style() {
     let output = generate_typst(&doc).unwrap();
     let counter = output
         .source
-        .find(r#"#counter(page).display("1")"#)
+        .find(r#"#context counter(page).display("1")"#)
         .expect("page counter emitted");
     let prefix = &output.source[..counter];
     let wrapper = prefix
@@ -1866,7 +1930,11 @@ fn test_unstyled_page_number_field_stays_bare() {
     })]);
 
     let output = generate_typst(&doc).unwrap();
-    assert!(output.source.contains(r#"#counter(page).display("1")"#));
+    assert!(
+        output
+            .source
+            .contains(r#"#context counter(page).display("1")"#)
+    );
     assert!(
         !output.source.contains("#text()[#counter"),
         "no empty text wrapper"
@@ -1904,7 +1972,9 @@ fn test_section_page_numbering_updates_the_counter_and_its_numerals() {
         output.source
     );
     assert!(
-        output.source.contains(r#"#counter(page).display("i")"#),
+        output
+            .source
+            .contains(r#"#context counter(page).display("i")"#),
         "the PAGE field renders the section's numerals: {}",
         output.source
     );


### PR DESCRIPTION
## Summary

A header or footer paragraph carrying `w:framePr` is emitted by
`generate_page_anchored_hf_frames` as a `#place` at document level.
`#counter(page).display()` has no context there, so Typst refuses it and aborts
the whole conversion.

## Reproduction

A one-paragraph framed header with the ordinary `w:fldSimple` page field — the
encoding that already resolves to `HFInline::PageNumber`, so nothing exotic is
needed to reach this:

```xml
<w:p><w:pPr>
  <w:framePr w:w="1000" w:h="400" w:hRule="exact" w:wrap="around"
             w:vAnchor="page" w:hAnchor="page" w:x="1000" w:y="500"/>
</w:pPr>
<w:r><w:t xml:space="preserve">P </w:t></w:r>
<w:fldSimple w:instr=" PAGE "><w:r><w:t>1</w:t></w:r></w:fldSimple>
</w:p>
```

| | result |
| --- | --- |
| before | `render error: Typst compilation failed: can only be used when context is known` |
| after | converts; page 2's framed header extracts as `P2` |

## Change

`generate_hf_elements` emits `#context counter(page)…` for both `PageNumber` and
`TotalPages`. It is the idiom the TOC generator in the same file already uses.

`#counter(page).update(…)` at the section-numbering site is deliberately left
alone: `.update()` schedules a mutation and never reads the counter, so it does
not need a context.

## Measured

Of the 58 DOCX fixtures under `tests/fixtures/docx` and
`tests/golden_mocks/*/sources/docx` that convert on `main`, all 58 produce
byte-identical PDFs with this change. The only behavioural difference is that a
document which previously aborted now converts.

(`IllustrativeCases.docx` fails on both sides with a different, pre-existing
Typst error and is untouched by this.)

## Tests

`test_page_anchored_frame_page_number_compiles` builds a framed header holding a
`PageNumber` and runs the result through `compile_to_pdf`, so it asserts the
document actually compiles rather than just inspecting markup. Reverting
`typst_gen.rs` makes it fail with the exact error above.

The existing assertions on the emitted field markup were updated to the new
literal; they still match the full string rather than being loosened.

## How this was found

The bulk third-party gate on #738 flagged `docx/libreoffice/tdf112443.docx` and
`docx/libreoffice/tdf112446_frameStyle.docx` going from success to this error.
Both have a framed footer holding a **split** `w:fldChar` PAGE field: that
encoding used to degrade to static text, so the counter was never emitted there
and this bug stayed hidden. It is a separate root cause from #738 and is fixed
on its own here, ahead of it.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added

- Reason: every document that renders today renders byte-identically — 58 of 58
  DOCX fixtures verified above. This fix only turns an aborted conversion into a
  successful one, and a document that produced no PDF has no before image to
  compare against, so there is no honest GT/Before/After triple to attach. The
  new test compiles the previously-failing case end to end instead, and the
  extracted header text is quoted in the table above.

Related: #788
