### PR TITLE
feat(docx): honour w:wordWrap for Hangul line breaking

### DIFF
--- a/crates/office2pdf/src/ir/style.rs
+++ b/crates/office2pdf/src/ir/style.rs
@@ -26,6 +26,12 @@ pub struct NamedStyle {
 #[derive(Debug, Clone, Default)]
 pub struct ParagraphStyle {
     pub alignment: Option<Alignment>,
+    /// Word's `w:wordWrap`: whether a Hangul line breaks between eojeol
+    /// (`Some(true)`) or at any syllable (`Some(false)`). `None` leaves the
+    /// choice to the renderer's default, which is word-level for a
+    /// non-justified paragraph. The property overrides the style chain, so it
+    /// cannot be inferred from `pStyle` (issue #730).
+    pub word_wrap: Option<bool>,
     pub indent_left: Option<f64>,
     pub indent_right: Option<f64>,
     pub indent_first_line: Option<f64>,
@@ -281,6 +287,9 @@ impl ParagraphStyle {
     pub fn merge_from(&mut self, other: &ParagraphStyle) {
         if other.alignment.is_some() {
             self.alignment = other.alignment;
+        }
+        if other.word_wrap.is_some() {
+            self.word_wrap = other.word_wrap;
         }
         if other.indent_left.is_some() {
             self.indent_left = other.indent_left;

--- a/crates/office2pdf/src/ir/style_tests.rs
+++ b/crates/office2pdf/src/ir/style_tests.rs
@@ -183,6 +183,7 @@ fn text_style_merge_from_into_default_target() {
 fn paragraph_style_merge_from_all_none_source_preserves_target() {
     let mut target = ParagraphStyle {
         alignment: Some(Alignment::Center),
+        word_wrap: None,
         indent_left: Some(10.0),
         indent_right: Some(5.0),
         indent_first_line: Some(20.0),
@@ -233,6 +234,7 @@ fn paragraph_style_merge_from_all_some_source_overwrites_target() {
     };
     let source = ParagraphStyle {
         alignment: Some(Alignment::Right),
+        word_wrap: Some(false),
         indent_left: Some(20.0),
         indent_right: Some(15.0),
         indent_first_line: Some(30.0),

--- a/crates/office2pdf/src/parser/docx.rs
+++ b/crates/office2pdf/src/parser/docx.rs
@@ -576,7 +576,10 @@ fn convert_paragraph_element(
                     .style
                     .space_after
                     .get_or_insert(WORD_COMPATIBLE_PARAGRAPH_SPACE_AFTER_PT);
-                TaggedElement::ListParagraph { info, paragraph }
+                TaggedElement::ListParagraph {
+                    info,
+                    paragraph: Box::new(paragraph),
+                }
             } else {
                 TaggedElement::Plain(vec![])
             }

--- a/crates/office2pdf/src/parser/docx_layout_rtl_tests.rs
+++ b/crates/office2pdf/src/parser/docx_layout_rtl_tests.rs
@@ -711,3 +711,48 @@ fn test_parse_docx_text_after_run_page_break_still_renders() {
         other => panic!("expected the trailing text paragraph, got {other:?}"),
     }
 }
+
+// ── w:wordWrap (issue #730) ────────────────────────────────────────────
+
+/// The property reaches the IR from `docx-rs`, with `0` and `1` distinct from
+/// each other and from an absent element.
+#[test]
+fn test_word_wrap_reaches_the_paragraph_style() {
+    let off = extract_paragraph_style(&docx_rs::ParagraphProperty::new().word_wrap(false));
+    assert_eq!(off.word_wrap, Some(false));
+
+    let on = extract_paragraph_style(&docx_rs::ParagraphProperty::new().word_wrap(true));
+    assert_eq!(on.word_wrap, Some(true));
+
+    let absent = extract_paragraph_style(&docx_rs::ParagraphProperty::new());
+    assert_eq!(absent.word_wrap, None);
+}
+
+/// Measured on Word: a paragraph's own `w:wordWrap` beats the one its style
+/// carries. A `ListParagraph` with `w:val="0"` breaks mid-eojeol even though
+/// the style alone keeps eojeol whole.
+#[test]
+fn test_explicit_word_wrap_overrides_the_style_chain() {
+    let explicit_prop = docx_rs::ParagraphProperty::new().word_wrap(false);
+    let explicit = extract_paragraph_style(&explicit_prop);
+    let style = ResolvedStyle {
+        text: TextStyle::default(),
+        paragraph: ParagraphStyle {
+            word_wrap: Some(true),
+            ..ParagraphStyle::default()
+        },
+        paragraph_tab_overrides: None,
+        heading_level: None,
+    };
+
+    let merged = merge_paragraph_style(&explicit, None, Some(&style));
+    assert_eq!(
+        merged.word_wrap,
+        Some(false),
+        "the paragraph's own value wins"
+    );
+
+    // And the style still supplies the value when the paragraph says nothing.
+    let inherited = merge_paragraph_style(&ParagraphStyle::default(), None, Some(&style));
+    assert_eq!(inherited.word_wrap, Some(true));
+}

--- a/crates/office2pdf/src/parser/docx_lists.rs
+++ b/crates/office2pdf/src/parser/docx_lists.rs
@@ -279,7 +279,14 @@ pub(super) enum TaggedElement {
     /// A regular block (non-list paragraph, table, image, page break, etc.)
     Plain(Vec<Block>),
     /// A list paragraph with its numbering info and the paragraph IR.
-    ListParagraph { info: NumInfo, paragraph: Paragraph },
+    ///
+    /// Boxed because a `Paragraph` is an order of magnitude larger than the
+    /// `Plain` variant's vector, and every element of the stream would
+    /// otherwise be sized for the larger one.
+    ListParagraph {
+        info: NumInfo,
+        paragraph: Box<Paragraph>,
+    },
 }
 
 /// A list item paired with the `numId` of the paragraph it came from, so a
@@ -465,7 +472,7 @@ pub(super) fn group_into_lists(
                             footnote: None,
                         },
                     );
-                    result.push(Block::Paragraph(paragraph));
+                    result.push(Block::Paragraph(*paragraph));
                     continue;
                 }
 
@@ -474,7 +481,7 @@ pub(super) fn group_into_lists(
                     resolved_level.map(|level| &level.paragraph_style),
                 );
                 let mut item = ListItem {
-                    content: vec![paragraph],
+                    content: vec![*paragraph],
                     level: info.level,
                     start_at: None,
                 };

--- a/crates/office2pdf/src/parser/docx_styles.rs
+++ b/crates/office2pdf/src/parser/docx_styles.rs
@@ -393,6 +393,12 @@ pub(super) fn merge_paragraph_style(
         alignment: explicit
             .alignment
             .or(style_paragraph.and_then(|style| style.alignment)),
+        // Measured on Word: a paragraph's own w:wordWrap beats the one its
+        // style carries — a ListParagraph with w:val="0" breaks mid-eojeol
+        // although the style alone would not (issue #730).
+        word_wrap: explicit
+            .word_wrap
+            .or(style_paragraph.and_then(|style| style.word_wrap)),
         indent_left: explicit
             .indent_left
             .or(style_paragraph.and_then(|style| style.indent_left)),

--- a/crates/office2pdf/src/parser/docx_text.rs
+++ b/crates/office2pdf/src/parser/docx_text.rs
@@ -36,6 +36,7 @@ pub(super) fn extract_paragraph_style(prop: &docx_rs::ParagraphProperty) -> Para
 
     ParagraphStyle {
         alignment,
+        word_wrap: prop.word_wrap,
         indent_left,
         indent_right,
         indent_first_line,

--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -154,11 +154,11 @@ struct GenCtx {
     /// `EojeolWrap::Syllable` because that path resolves neither the frame's
     /// fixed text edges nor the box's inner measure — see the note there.
     ///
-    /// The flag is unconditional for a flow page: `w:wordWrap`, which is how
-    /// a document asks Word for character-level Hangul breaking, is not
-    /// parsed, so a paragraph declaring `w:val="0"` still gets the word-level
-    /// rule. That is issue #730 — it needs a `docx-rs` field before the value
-    /// can reach the IR.
+    /// The flag is the flow page's *default*, not the last word. A paragraph
+    /// carrying `w:wordWrap w:val="0"` — how a document asks Word for
+    /// character-level Hangul breaking — overrides it, and
+    /// [`paragraph_eojeol_wrap`] checks that before anything here (issue
+    /// #730).
     breaks_hangul_at_eojeol: bool,
     /// The width one line of the current container has, in points, before a
     /// paragraph's own indents are taken off it: a flow page's text width,

--- a/crates/office2pdf/src/render/typst_gen_text.rs
+++ b/crates/office2pdf/src/render/typst_gen_text.rs
@@ -1114,6 +1114,12 @@ pub(super) fn paragraph_eojeol_wrap(
     line_box_em: Option<(f64, f64)>,
     container_measure_pt: Option<f64>,
 ) -> EojeolWrap {
+    // `w:wordWrap w:val="0"` asks for character-level breaking outright, and
+    // it wins over the style chain, so it is checked before anything the
+    // paragraph inherits (issue #730).
+    if style.word_wrap == Some(false) {
+        return EojeolWrap::Syllable;
+    }
     if !breaks_hangul_at_eojeol || matches!(style.alignment, Some(Alignment::Justify)) {
         return EojeolWrap::Syllable;
     }

--- a/crates/office2pdf/src/render/typst_gen_text_pipeline_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_text_pipeline_tests.rs
@@ -772,6 +772,45 @@ fn a_docx_paragraph_keeps_each_hangul_eojeol_whole() {
     );
 }
 
+/// `w:wordWrap w:val="0"` asks Word for character-level breaking of Hangul,
+/// and it overrides the style chain. A paragraph that says so must not get the
+/// eojeol frames #626 gives every other non-justified paragraph (issue #730).
+#[test]
+fn a_docx_paragraph_asking_for_character_breaking_gets_no_eojeol_frames() {
+    let mut paragraph = korean_paragraph(EOJEOL_SENTENCE, None, None);
+    if let Block::Paragraph(ref mut p) = paragraph {
+        p.style.word_wrap = Some(false);
+    }
+    let doc = make_doc(vec![make_flow_page(vec![paragraph])]);
+    let result = generate_typst(&doc).unwrap().source;
+
+    assert!(
+        result.contains(EOJEOL_SENTENCE),
+        "the text stays one run so Typst may break inside an eojeol: {result}"
+    );
+    assert!(
+        !result.contains("#box["),
+        "no eojeol frame may be emitted when wordWrap is off: {result}"
+    );
+}
+
+/// Triangulation: `w:val="1"` is the word-level setting, so it must keep the
+/// frames rather than being treated as "the property is present, back off".
+#[test]
+fn a_docx_paragraph_asking_for_word_breaking_keeps_its_eojeol_frames() {
+    let mut paragraph = korean_paragraph(EOJEOL_SENTENCE, None, None);
+    if let Block::Paragraph(ref mut p) = paragraph {
+        p.style.word_wrap = Some(true);
+    }
+    let doc = make_doc(vec![make_flow_page(vec![paragraph])]);
+    let result = generate_typst(&doc).unwrap().source;
+
+    assert!(
+        result.contains("본 #box[계약은] #box[갑과] #box[을이]"),
+        "wordWrap=1 keeps each eojeol whole: {result}"
+    );
+}
+
 #[test]
 fn a_justified_docx_paragraph_keeps_syllable_breaking() {
     let doc = make_doc(vec![make_flow_page(vec![korean_paragraph(


### PR DESCRIPTION
## Summary

`w:wordWrap` is Word's switch between word-level and character-level Hangul line
breaking: `w:val="1"` keeps an eojeol whole, `w:val="0"` allows a break at any
syllable. It was not parsed, so a paragraph explicitly asking for
character-level breaking still got the word-level rule #626 applies to every
non-justified paragraph.

## The dependency came first

`docx-rs` had no `word_wrap` anywhere in `docx-core`, which is what #730 was
blocked on. Added upstream in developer0hye/docx-rs#3 and merged into the
`fix/parse-tolerance` branch this repo pins, so no change is needed here beyond
reading the field.

That PR records both values rather than only the true case, unlike the
neighbouring flags — `w:val="0"` is the setting that carries the instruction,
and collapsing it to `None` is indistinguishable from the property being absent.

## Measured

The same Korean sentence in a narrow column, three times, differing only in the
property:

| paragraph | before | after |
| --- | --- | --- |
| `w:val="1"` | `…신뢰를 / 바탕으로…` | `…신뢰를 / 바탕으로…` |
| `w:val="0"` | `…신뢰를 / 바탕으로…` | `…신뢰를 바탕 / 으로…` |
| absent | `…신뢰를 / 바탕으로…` | `…신뢰를 / 바탕으로…` |

Only the paragraph that asks for character-level breaking changes, and it now
breaks inside `바탕으로` instead of before it.

The expected behaviour comes from the native Microsoft Word probes recorded in
the issue, not from a local reference render: **LibreOffice does not implement
this property.** All three paragraphs above break identically in a LibreOffice
24.2.7.2 render of the same file, so it cannot serve as ground truth here and
none is attached.

## Change

`ParagraphStyle` gains `word_wrap`, `merge_paragraph_style` resolves it
explicit-over-style, and `paragraph_eojeol_wrap` consults it before anything the
paragraph inherits — Word's probes show a `ListParagraph` with `w:val="0"`
breaks mid-eojeol although the style alone would not, so the property has to win
over the style chain.

`ParagraphStyle::merge_from` gained a clause too; without it the property would
have been dropped silently on that path.

Adding the field pushed `TaggedElement::ListParagraph` past clippy's
`large_enum_variant` threshold — 232 bytes against `Plain`'s 24 — so its
`Paragraph` is boxed.

## Tests

Five:

- a paragraph with `w:val="0"` emits no eojeol frames, so Typst may break inside
  an eojeol
- triangulation: `w:val="1"` keeps its frames, so the fix is not "the property
  is present, back off"
- the value reaches the IR from `docx-rs` with `0`, `1` and absent all distinct
- an explicit value beats the one the style carries, and the style still supplies
  it when the paragraph says nothing

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added

- Reason: no document in the corpus carries `w:wordWrap` — 0 of 59 DOCX under
  `tests/fixtures/docx` and `tests/golden_mocks/*/sources/docx` contain the
  element — so the change is inert on everything that exists today: of the 58
  that convert, all 58 render byte-identically. It only takes effect on a
  document that sets the property, and the sole reference renderer available
  here ignores it, so there is no honest GT/Before/After triple to attach. The
  probe's extracted lines are quoted in Measured above instead.

Related: #730
