### PR TITLE
fix(tooling): parse mutool pages that carry no number attribute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
         run: python3 -m unittest discover -s scripts/tests -p 'test_check_visual_pr.py'
       - name: Test layout differ
         run: python3 -m unittest discover -s scripts/tests -p 'test_compare_layout.py'
+      - name: Test render comparison
+        run: python3 -m unittest discover -s scripts/tests -p 'test_compare_render.py'
       - name: Test text-layer census
         run: python3 -m unittest discover -s scripts/tests -p 'test_compare_text_layer.py'
       - name: Test GT integrity gate

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -38,7 +38,10 @@ from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from pathlib import Path
 
-PAGE_RE = re.compile(r'<page number="\d+"[^>]*>(.*?)</page>', re.S)
+# mutool 1.23.x opens a page as `<page mediabox="...">` with no `number`
+# attribute; later builds add one. Requiring it parses zero pages and reports
+# that as "no differences found" instead of as a failure.
+PAGE_RE = re.compile(r"<page\b[^>]*>(.*?)</page>", re.S)
 FILL_TEXT_RE = re.compile(r"<fill_text\b([^>]*)>(.*?)</fill_text>", re.S)
 SPAN_RE = re.compile(r"<span\b([^>]*)>(.*?)</span>", re.S)
 GLYPH_RE = re.compile(
@@ -418,6 +421,13 @@ def main() -> int:
 
     gt_pages = parse_trace(run_mutool(args.gt))
     out_pages = parse_trace(run_mutool(args.output))
+
+    # A trace that yields no pages means the parser did not understand mutool's
+    # output, not that the two files agree. Reporting an empty diff here would
+    # be indistinguishable from a clean comparison.
+    for label, path, pages in (("GT", args.gt, gt_pages), ("output", args.output, out_pages)):
+        if not pages:
+            sys.exit(f"no pages parsed from the {label} trace ({path}) — cannot compare")
 
     if args.page is not None:
         gt_pages = gt_pages[args.page - 1 : args.page]

--- a/scripts/compare_render.py
+++ b/scripts/compare_render.py
@@ -46,7 +46,10 @@ FILL_TEXT_RE = re.compile(
     r'([-0-9.]+) ([-0-9.]+)"[^>]*>(.*?)</fill_text>',
     re.S,
 )
-TRACE_PAGE_RE = re.compile(r'<page number="\d+')
+# mutool 1.23.x opens a page as `<page mediabox="...">`; later builds add a
+# `number` attribute. Splitting on the numbered form alone yields zero pages and
+# silently drops the geometry axis.
+TRACE_PAGE_RE = re.compile(r"<page\b")
 GLYPH_RE = re.compile(r'<g unicode="([^"]*)" glyph="[^"]*" x="([-0-9.]+)" y="([-0-9.]+)"')
 HISTOGRAM_BINS = 32
 

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -1,9 +1,10 @@
 """Unit tests for the trace-based layout differ.
 
 All fixtures are synthetic ``mutool draw -F trace`` fragments that mirror the
-real output format (device transform on each op, glyph coordinates in text
-space, sizes in trm units), so the parser is exercised on the same shapes it
-will meet in production without shelling out to mutool.
+real output format (numberless ``<page>`` opening tag, device transform on each
+op, glyph coordinates in text space, sizes in trm units), so the parser is
+exercised on the same shapes it will meet in production without shelling out to
+mutool.
 """
 
 from __future__ import annotations
@@ -17,9 +18,17 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import compare_layout
 
 
-def trace_document(*pages: str) -> str:
+def trace_document(*pages: str, numbered: bool = False) -> str:
+    """Wrap page bodies in a trace document.
+
+    Defaults to the numberless `<page mediabox="...">` mutool 1.23.x emits, so
+    the shared fixtures exercise the shape the parser actually meets. Pass
+    ``numbered=True`` for the attribute later builds add.
+    """
     body = "\n".join(
-        f'<page number="{i + 1}" mediabox="0 0 595.2 841.92">\n{content}\n</page>'
+        "<page {}mediabox=\"0 0 595.2 841.92\">\n{}\n</page>".format(
+            f'number="{i + 1}" ' if numbered else "", content
+        )
         for i, content in enumerate(pages)
     )
     return f'<?xml version="1.0"?>\n<document filename="x.pdf">\n{body}\n</document>'
@@ -71,6 +80,38 @@ def rect_op(x0: float, y0: float, x1: float, y1: float, kind: str = "fill_path")
         f'<lineto x="{x0}" y="{841.92 - y1}"/>\n'
         f"<closepath/>\n</{kind}>"
     )
+
+
+class PageElementTest(unittest.TestCase):
+    """The ``<page>`` opening tag differs across mutool releases.
+
+    1.23.x emits ``<page mediabox="...">`` with no ``number`` attribute, so a
+    parser that requires one measures nothing at all — and reports that as
+    "no differences" rather than as a failure.
+    """
+
+    def test_page_without_number_attribute_is_parsed(self) -> None:
+        pages = compare_layout.parse_trace(
+            trace_document(text_op([("A", 72.0)], baseline_y=100.0))
+        )
+        self.assertEqual(len(pages), 1)
+        self.assertEqual(pages[0].lines[0].text, "A")
+
+    def test_pages_without_number_keep_document_order(self) -> None:
+        pages = compare_layout.parse_trace(
+            trace_document(
+                text_op([("A", 72.0)], baseline_y=100.0),
+                text_op([("B", 72.0)], baseline_y=100.0),
+            )
+        )
+        self.assertEqual([p.lines[0].text for p in pages], ["A", "B"])
+
+    def test_page_with_number_attribute_still_parses(self) -> None:
+        pages = compare_layout.parse_trace(
+            trace_document(text_op([("A", 72.0)], baseline_y=100.0), numbered=True)
+        )
+        self.assertEqual(len(pages), 1)
+        self.assertEqual(pages[0].lines[0].text, "A")
 
 
 class ParseTraceTest(unittest.TestCase):

--- a/scripts/tests/test_compare_render.py
+++ b/scripts/tests/test_compare_render.py
@@ -1,0 +1,61 @@
+"""Unit tests for the three-axis render comparison.
+
+Covers the trace page split, which decides whether the geometry axis sees any
+pages at all. mutool's `<page>` opening tag has varied across releases, and a
+split that misses it drops every line silently rather than failing.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import compare_render
+
+
+def trace_page(body: str, numbered: bool) -> str:
+    attrs = 'number="1" mediabox="0 0 595.2 841.92"' if numbered else 'mediabox="0 0 595.2 841.92"'
+    return f"<page {attrs}>\n{body}\n</page>"
+
+
+def text_op(char: str, x: float, baseline_y: float) -> str:
+    """One fill_text whose glyph sits at ``baseline_y`` in device points.
+
+    Mirrors the scaled text space Office exports on macOS use, so the glyph
+    coordinates have to be run back through the transform to be read.
+    """
+    scale = 0.24
+    gx = x / scale
+    gy = (baseline_y - 841.92) / -scale
+    return (
+        f'<fill_text transform="{scale} 0 0 -{scale} 0 841.92">\n'
+        f'<span font="AAAAAA+ArialMT" wmode="0" trm="44 0 0 44">\n'
+        f'<g unicode="{char}" glyph="2" x="{gx:.4f}" y="{gy:.4f}" adv=".5"/>\n'
+        f"</span>\n</fill_text>"
+    )
+
+
+class TracePageSplitTest(unittest.TestCase):
+    def test_splits_page_without_number_attribute(self) -> None:
+        doc = trace_page(text_op("A", 72.0, 100.0), numbered=False)
+        self.assertEqual(len(compare_render.TRACE_PAGE_RE.split(doc)[1:]), 1)
+
+    def test_splits_page_with_number_attribute(self) -> None:
+        doc = trace_page(text_op("A", 72.0, 100.0), numbered=True)
+        self.assertEqual(len(compare_render.TRACE_PAGE_RE.split(doc)[1:]), 1)
+
+    def test_counts_every_page_in_a_mixed_document(self) -> None:
+        doc = "\n".join(
+            [
+                trace_page(text_op("A", 72.0, 100.0), numbered=False),
+                trace_page(text_op("B", 72.0, 100.0), numbered=True),
+            ]
+        )
+        self.assertEqual(len(compare_render.TRACE_PAGE_RE.split(doc)[1:]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

`scripts/compare_layout.py` and `scripts/compare_render.py` both matched
mutool's page element as `<page number="...">`. mutool 1.23.x opens a page as
`<page mediabox="...">` with no `number` attribute, so both parsed **zero
pages** on any host running that version.

## Why it matters

The failure was silent. Comparing a ground-truth PDF against **itself** printed
an empty report rather than a perfect match:

```sh
$ python3 scripts/compare_layout.py <GT>.pdf <GT>.pdf

## Reading
```

CLAUDE.md instructs running `compare_layout.py` **first** for layout defects and
states that "Its numbers are assertable; pixel counts are only a tripwire". On
mutool 1.23.x that guidance yielded no measurement at all, and an empty result
is indistinguishable from "no differences found".

After the fix, the same self-comparison reports what it should:

```
page 1: 21 matched (0 missing, 0 extra, 0 re-wrapped) | dy mean 0.00pt worst
+0.00pt | pitch worst 0.00pt | width worst 0.0% | rects 34/34
```

`compare_render.py`'s geometry axis was dead the same way — its
`TRACE_PAGE_RE.split(...)[1:]` found no delimiter — and now matches 21 of 21
lines.

## Key changes

- `compare_layout.py` — `PAGE_RE` relaxed to `<page\b[^>]*>`; `main()` now exits
  non-zero when a trace yields no pages, so a comparison that measured nothing
  can never be presented as a comparison that found nothing.
- `compare_render.py` — `TRACE_PAGE_RE` relaxed to `<page\b`.
- `scripts/tests/test_compare_layout.py` — new `PageElementTest` covering the
  numberless form, the multi-page ordering case, and the numbered form. The
  shared `trace_document()` helper hardcoded `number="{i+1}"`, which is exactly
  why the suite passed while real traces failed; it now emits the numberless
  shape mutool actually produces, with a `numbered=True` override retaining
  coverage of the attribute later builds add.
- `scripts/tests/test_compare_render.py` — new file; this script had no tests.
- `.github/workflows/ci.yml` — wires the new test file in, since CI names each
  test file explicitly.

## Verification

`python3 -m unittest discover -s scripts/tests -p 'test_*.py'` → 73 tests, OK.
Verified against real `mutool 1.23.10` output on a committed GT export, not only
against synthetic fixtures.

## Scope

Found while investigating #630; the measurement tool needed for that issue was
reporting nothing. Two further root causes were found in the same area and filed
separately rather than bundled here:

- #809 — `compare_render.py` hardcodes ImageMagick 7's `magick`, so the colour
  and pixel axes crash on ImageMagick 6. This PR does not address it; the
  geometry axis is what was silently empty.

Closes #808
Related: #809

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Changes are confined to `scripts/compare_layout.py`, `scripts/compare_render.py`, their unit tests, and the CI wiring for those tests. No crate under `crates/` is touched, so no conversion output changes. The scripts are measurement tools run by hand against already-rendered PDFs; they never participate in producing one.
