### PR TITLE
fix(ci): pin zune-jpeg past the warn! expansion rustc 1.97 rejects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,15 @@ repository = "https://github.com/developer0hye/office2pdf"
 [patch.crates-io]
 umya-spreadsheet = { git = "https://github.com/developer0hye/umya-spreadsheet.git", branch = "fix/panic-safety-v2" }
 docx-rs = { git = "https://github.com/developer0hye/docx-rs.git", branch = "fix/parse-tolerance" }
+# zune-jpeg 0.5.15 on crates.io ends a block with `warn!(…)` and no semicolon,
+# which rustc 1.97 rejects: "macro expansion ends with an incomplete
+# expression". It reaches us through `image`, so every Rust job fails on a cold
+# cache. Upstream fixed it after publishing; the pinned rev is still version
+# 0.5.15, so this satisfies `^0.5` without opting into the 0.5.16-rc1
+# prerelease. Drop this once 0.5.16 is released (issue #816).
+#
+# `zune-core` has to come from the same rev: `zune-jpeg` re-exports its types,
+# and mixing the git copy with the crates.io one leaves two distinct
+# `ZByteReaderTrait`s, so `image` stops satisfying its own bounds.
+zune-jpeg = { git = "https://github.com/etemesi254/zune-image", rev = "0346b875169ed528e206441c97899d99002e17ca" }
+zune-core = { git = "https://github.com/etemesi254/zune-image", rev = "0346b875169ed528e206441c97899d99002e17ca" }


### PR DESCRIPTION
## What was broken

Every Rust job fails once the build cache misses:

```
Checking zune-jpeg v0.5.15
error: macro expansion ends with an incomplete expression: expected expression
   --> zune-jpeg-0.5.15/src/mcu_prog.rs:463:17
463 |     warn!("RST marker was not found, where expected, image may be garbled")
```

`zune-jpeg 0.5.15` as published ends a block with `warn!(…)` and no semicolon,
which **rustc 1.97 rejects**. CI installs stable 1.97.1, and the crate reaches
the build through `image v0.25.10`, which both `docx-rs` and `typst`/`hayro`
depend on.

It looked intermittent because earlier runs reused warm `Swatinem/rust-cache`
artifacts. Re-running a single failed job on #815 took it from **1 failing job
to 12** — a cold rebuild. `main` is latently broken the same way and will show
it on the next cache eviction.

## The fix

Two entries in the existing `[patch.crates-io]`, pinned to the upstream rev
where the semicolon is present. That rev is **still version 0.5.15**, so it
satisfies `^0.5` without opting into the `0.5.16-rc1` prerelease published hours
ago.

`zune-core` has to move with it: `zune-jpeg` re-exports its types, and patching
only `zune-jpeg` leaves `image` looking at the crates.io `zune-core` while
`zune-jpeg` uses the git one — two distinct `ZByteReaderTrait`s, and `image`
stops satisfying its own bounds. I hit exactly that on the first attempt.

## Verification

I could not originally reproduce this: the machine was on rustc 1.93.1, which
compiles the published crate without complaint. So I installed the CI toolchain
rather than guess.

On **rustc 1.97.1**, with `Cargo.lock` deleted first so resolution matches CI:

| | |
| --- | --- |
| `cargo check --all-targets` | clean |
| `cargo test -p office2pdf` | **2327 passed**, 0 failed |
| `cargo clippy --all-targets` | clean |
| `cargo fmt --check` | clean |

Confirmed the fresh resolve picks the git rev for the 0.5 pair while
`zune-jpeg 0.4.21` (via `hayro-syntax`) stays on crates.io and builds fine.

MSRV is unaffected — the pinned crates declare `rust-version` 1.77.1 and 1.75.0,
both under the workspace's 1.89.

## Not addressed here

`Cargo.lock` remains gitignored. That it is unpinned at all is why a published
dependency can break CI without anything in this repo changing, but committing
it changes dependency policy and is the maintainer's call — recorded in #816
rather than decided here.

Upstream needs no PR: they already carry the fix at the pinned rev. Drop this
patch once `0.5.16` is released.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: The change is confined to `[patch.crates-io]` in the workspace root manifest and swaps a JPEG decoder for the same version of the same crate from a source that compiles. No conversion code is touched and the full suite, including the golden-mock and visual tests, passes unchanged.

Closes #816