### PR TITLE
fix(tooling): resolve the ImageMagick entry point instead of assuming IM7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,5 @@ Whole-page thumbnails at 80 DPI hide hairlines, dash patterns, font weight, and 
 3. **Pixel-difference sweep.** Run `magick compare -metric AE -fuzz 5% gt.png out.png diff.png` on size-normalized pages; view `diff.png` and inspect every highlighted cluster. A checklist pass is complete only when each cluster is either explained by an accepted rendering difference (fonts/antialiasing) or captured as an issue.
 4. **Hairline inventory.** Explicitly enumerate elements ≤1pt (rules, underlines, dashed/dotted lines, borders, tick marks) found in GT and confirm each exists in the output at matching position, width, and dash pattern.
 5. **Weight/emphasis inventory.** Enumerate bold/italic/underlined runs visible in GT (including CJK) and confirm the same emphasis in the output — weight differences must be checked on the high-DPI crops, not thumbnails.
+
+`magick` is ImageMagick 7 only. On ImageMagick 6 drop it: `convert input.png -crop ...`, `compare -metric AE ...`. `scripts/compare_render.py` resolves this itself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,8 @@ Whole-page thumbnails at 80 DPI hide hairlines, dash patterns, font weight, and 
 4. **Hairline inventory.** Explicitly enumerate elements ≤1pt (rules, underlines, dashed/dotted lines, borders, tick marks) found in GT and confirm each exists in the output at matching position, width, and dash pattern.
 5. **Weight/emphasis inventory.** Enumerate bold/italic/underlined runs visible in GT (including CJK) and confirm the same emphasis in the output — weight differences must be checked on the high-DPI crops, not thumbnails.
 
+`magick` is ImageMagick 7 only. On ImageMagick 6 drop it: `convert input.png -crop ...`, `compare -metric AE ...`. `scripts/compare_render.py` resolves this itself.
+
 **A GT primitive is not always the quantity you want.** Native exports draw
 things we draw differently, and comparing the wrong quantity has produced fixes
 that were exactly backwards:

--- a/scripts/compare_render.py
+++ b/scripts/compare_render.py
@@ -52,6 +52,9 @@ FILL_TEXT_RE = re.compile(
 TRACE_PAGE_RE = re.compile(r"<page\b")
 GLYPH_RE = re.compile(r'<g unicode="([^"]*)" glyph="[^"]*" x="([-0-9.]+)" y="([-0-9.]+)"')
 HISTOGRAM_BINS = 32
+# Every ImageMagick tool the colour and pixel axes reach for. Named here so the
+# availability check and the call sites cannot drift apart.
+IMAGEMAGICK_TOOLS = ("convert", "identify", "compare")
 
 
 @dataclass(frozen=True)
@@ -86,6 +89,29 @@ def render_page(pdf: Path, page: int, dpi: int, out_dir: Path, role: str) -> Pat
 def has_mutool() -> bool:
     """Whether `mutool` is on PATH (it ships in `mupdf-tools`)."""
     return shutil.which("mutool") is not None
+
+
+def imagemagick_command(tool: str) -> list[str] | None:
+    """Argv prefix invoking an ImageMagick tool, or None if it is unavailable.
+
+    ImageMagick 7 dispatches every tool through a single `magick` binary;
+    ImageMagick 6 installs them under their own names and has no `magick` at
+    all. Hardcoding the IM7 spelling left the colour and pixel axes dying with
+    FileNotFoundError on an IM6 host, after the geometry axis had already
+    printed a report that looked whole.
+    """
+    if shutil.which("magick") is not None:
+        # `magick convert` is deprecated in 7.1 and warns; plain conversion is
+        # the bare dispatcher, so only the named subtools take an argument.
+        return ["magick"] if tool == "convert" else ["magick", tool]
+    if shutil.which(tool) is not None:
+        return [tool]
+    return None
+
+
+def has_imagemagick() -> bool:
+    """Whether every tool the colour and pixel axes need can be invoked."""
+    return all(imagemagick_command(tool) is not None for tool in IMAGEMAGICK_TOOLS)
 
 
 def baseline_lines(pdf: Path) -> list[TextLine]:
@@ -239,7 +265,7 @@ def report_geometry(gt: Path, other: Path) -> dict[str, float]:
 def histogram(png: Path) -> tuple[list[int], int]:
     """Per-channel binned colour counts, flattened R|G|B, and the pixel total."""
     txt = subprocess.run(
-        ["magick", str(png), "-depth", "8", "txt:-"],
+        [*(imagemagick_command("convert") or []), str(png), "-depth", "8", "txt:-"],
         capture_output=True,
         text=True,
         check=True,
@@ -329,13 +355,14 @@ def report_pixels(gt_png: Path, other_png: Path, out_dir: Path) -> None:
     """Whole-page difference, as a coarse catch-all."""
     normalised = out_dir / "gt-normalised.png"
     size = subprocess.run(
-        ["magick", "identify", "-format", "%wx%h", str(other_png)],
+        [*(imagemagick_command("identify") or []), "-format", "%wx%h", str(other_png)],
         capture_output=True, text=True, check=True,
     ).stdout.strip()
     # pdftoppm can differ by a pixel between two PDFs of the same paper size,
     # which would otherwise make every comparison fail outright.
     subprocess.run(
-        ["magick", str(gt_png), "-background", "white", "-extent", size, str(normalised)],
+        [*(imagemagick_command("convert") or []), str(gt_png),
+         "-background", "white", "-extent", size, str(normalised)],
         check=True, capture_output=True,
     )
 
@@ -346,13 +373,16 @@ def report_pixels(gt_png: Path, other_png: Path, out_dir: Path) -> None:
         ("RMSE       ", ["-metric", "RMSE"]),
     ):
         result = subprocess.run(
-            ["magick", "compare", *args, str(normalised), str(other_png), "null:"],
+            [*(imagemagick_command("compare") or []), *args,
+             str(normalised), str(other_png), "null:"],
             capture_output=True, text=True,
         )
         print(f"  {label}      {result.stderr.strip()}")
 
 
-def diagnose(geometry: dict[str, float], histogram_result: dict[str, float]) -> None:
+def diagnose(
+    geometry: dict[str, float], histogram_result: dict[str, float] | None
+) -> None:
     """Say what the combination of axes means, and what to look at next.
 
     This is the point of running all three: a single number invites the
@@ -360,7 +390,13 @@ def diagnose(geometry: dict[str, float], histogram_result: dict[str, float]) -> 
     and one that does not move at all can hide a large geometric
     improvement. The pattern across axes is what identifies the defect
     class.
+
+    `histogram_result` is None when ImageMagick is absent. An axis that did not
+    run must never read as an axis that agreed, so silence there is reported
+    rather than folded into the verdict.
     """
+    colour_measured: bool = histogram_result is not None
+    histogram_result = histogram_result or {}
     print("## Reading")
     if not geometry:
         print("  Geometry could not be measured, so the other axes stand alone.")
@@ -397,10 +433,17 @@ def diagnose(geometry: dict[str, float], histogram_result: dict[str, float]) -> 
     # Measured separation on this corpus: renderer dithering across a smooth
     # gradient reaches 0.0003, and the half-width cell borders of #487
     # reached 0.0016 before the fix and 0.0004 after it.
-    colour_differs: bool = histogram_result.get("shift", 0.0) > 0.001
-    ink_differs: bool = abs(ink_delta) > 0.2
+    colour_differs: bool = colour_measured and histogram_result.get("shift", 0.0) > 0.001
+    ink_differs: bool = colour_measured and abs(ink_delta) > 0.2
 
     findings: list[str] = []
+    if not colour_measured:
+        findings.append(
+            "The colour and pixel axes did not run — ImageMagick is absent, so "
+            "a wrong fill, a recolour, or a missing element cannot be seen "
+            "here at all. Geometry below stands alone; compare the pages by "
+            "eye before concluding they agree."
+        )
     if pages_differ:
         findings.append(
             "Pagination differs — content sits on the wrong page. Fix this "
@@ -442,7 +485,12 @@ def diagnose(geometry: dict[str, float], histogram_result: dict[str, float]) -> 
     for index, finding in enumerate(findings, start=1):
         print(f"  {index}. {finding}")
 
-    if not colour_differs and not ink_differs and (drifts_vertically or drifts_horizontally):
+    if (
+        colour_measured
+        and not colour_differs
+        and not ink_differs
+        and (drifts_vertically or drifts_horizontally)
+    ):
         print()
         print("  Colour and ink are unchanged while geometry moves: this is a")
         print("  pure layout difference. A pixel count may rise even as the")
@@ -509,13 +557,20 @@ def main() -> None:
     if args.lines:
         report_matched_lines(args.gt, args.output)
         print()
-    with tempfile.TemporaryDirectory() as raw_dir:
-        out_dir = Path(raw_dir)
-        gt_png = render_page(args.gt, args.page, args.dpi, out_dir, "gt")
-        other_png = render_page(args.output, args.page, args.dpi, out_dir, "candidate")
-        histogram_result = report_histogram(gt_png, other_png)
-        print()
-        report_pixels(gt_png, other_png, out_dir)
+    histogram_result: dict[str, float] | None = None
+    if has_imagemagick():
+        with tempfile.TemporaryDirectory() as raw_dir:
+            out_dir = Path(raw_dir)
+            gt_png = render_page(args.gt, args.page, args.dpi, out_dir, "gt")
+            other_png = render_page(args.output, args.page, args.dpi, out_dir, "candidate")
+            histogram_result = report_histogram(gt_png, other_png)
+            print()
+            report_pixels(gt_png, other_png, out_dir)
+    else:
+        print("## Histogram and pixel difference — SKIPPED")
+        print("  ImageMagick is absent: neither `magick` (7.x) nor all of "
+              f"{', '.join(f'`{tool}`' for tool in IMAGEMAGICK_TOOLS)} (6.x)")
+        print("  is on PATH. Install `imagemagick` to measure colour and ink.")
     print()
     diagnose(geometry, histogram_result)
 

--- a/scripts/tests/test_compare_render.py
+++ b/scripts/tests/test_compare_render.py
@@ -3,6 +3,10 @@
 Covers the trace page split, which decides whether the geometry axis sees any
 pages at all. mutool's `<page>` opening tag has varied across releases, and a
 split that misses it drops every line silently rather than failing.
+
+Also covers the ImageMagick entry point, which decides whether the colour and
+pixel axes run at all: IM7 ships one `magick` dispatcher, IM6 ships the tools
+under their own names, and a host may have neither.
 """
 
 from __future__ import annotations
@@ -10,6 +14,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -55,6 +60,86 @@ class TracePageSplitTest(unittest.TestCase):
             ]
         )
         self.assertEqual(len(compare_render.TRACE_PAGE_RE.split(doc)[1:]), 2)
+
+
+def only_on_path(*names: str):
+    """Patch `shutil.which` so exactly `names` resolve, mimicking a real host."""
+    available = set(names)
+    return mock.patch.object(
+        compare_render.shutil,
+        "which",
+        side_effect=lambda name: f"/usr/bin/{name}" if name in available else None,
+    )
+
+
+class ImageMagickEntryPointTest(unittest.TestCase):
+    """An IM6 host names the tools `convert`, `identify` and `compare`.
+
+    Hardcoding IM7's `magick` aborted the run with FileNotFoundError after the
+    geometry axis had already printed, so a partial report looked complete.
+    """
+
+    def test_prefers_the_im7_dispatcher_when_present(self) -> None:
+        with only_on_path("magick", "convert", "identify", "compare"):
+            self.assertEqual(compare_render.imagemagick_command("convert"), ["magick"])
+            self.assertEqual(
+                compare_render.imagemagick_command("identify"), ["magick", "identify"]
+            )
+            self.assertEqual(
+                compare_render.imagemagick_command("compare"), ["magick", "compare"]
+            )
+
+    def test_falls_back_to_the_im6_tool_names(self) -> None:
+        with only_on_path("convert", "identify", "compare"):
+            self.assertEqual(compare_render.imagemagick_command("convert"), ["convert"])
+            self.assertEqual(compare_render.imagemagick_command("identify"), ["identify"])
+            self.assertEqual(compare_render.imagemagick_command("compare"), ["compare"])
+
+    def test_reports_absence_instead_of_guessing(self) -> None:
+        with only_on_path("pdftoppm"):
+            for tool in compare_render.IMAGEMAGICK_TOOLS:
+                self.assertIsNone(compare_render.imagemagick_command(tool))
+
+    def test_availability_follows_the_whole_tool_set(self) -> None:
+        with only_on_path("magick"):
+            self.assertTrue(compare_render.has_imagemagick())
+        with only_on_path("convert", "identify", "compare"):
+            self.assertTrue(compare_render.has_imagemagick())
+        with only_on_path("convert", "identify"):
+            self.assertFalse(compare_render.has_imagemagick())
+        with only_on_path("pdftoppm"):
+            self.assertFalse(compare_render.has_imagemagick())
+
+
+class DiagnoseWithoutColourTest(unittest.TestCase):
+    """With no ImageMagick, two of three axes are missing, not agreeing."""
+
+    def setUp(self) -> None:
+        self.geometry = {
+            "mad_y": 0.1,
+            "mad_x": 0.1,
+            "page_mismatch": 0.0,
+            "matched": 40.0,
+            "coverage": 0.9,
+        }
+
+    def render(self, histogram_result: dict[str, float] | None) -> str:
+        from io import StringIO
+        from contextlib import redirect_stdout
+
+        buffer = StringIO()
+        with redirect_stdout(buffer):
+            compare_render.diagnose(self.geometry, histogram_result)
+        return buffer.getvalue()
+
+    def test_says_the_colour_axis_did_not_run(self) -> None:
+        report = self.render(None)
+        self.assertIn("colour", report.lower())
+        self.assertNotIn("No axis shows a material difference", report)
+
+    def test_still_claims_agreement_when_every_axis_ran(self) -> None:
+        report = self.render({"intersection": 1.0, "shift": 0.0, "ink_delta": 0.0})
+        self.assertIn("No axis shows a material difference", report)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`scripts/compare_render.py` shelled out to `magick`, the ImageMagick 7
dispatcher. ImageMagick 6 has no such binary — it installs the tools under
their own names — so on an IM6 host the geometry axis printed normally and the
run then aborted with an unhandled `FileNotFoundError`, emitting a partial
report with no indication that the colour and pixel axes never ran.

Unlike the `mutool` fallback, which is detected by `has_mutool()` and degrades
to `pdftotext -bbox` under an APPROXIMATE label, there was no availability
check for ImageMagick at all. A report that stops two thirds of the way through
but still looks whole is worse than one that fails: its geometry numbers get
quoted into an issue while the colour and ink figures that would have
contradicted them were never measured.

Key changes:

- `imagemagick_command(tool)` resolves each tool's argv prefix, preferring
  IM7's `magick` dispatcher and falling back to the IM6 names. Plain conversion
  runs as bare `magick` rather than the 7.1-deprecated `magick convert`.
- `has_imagemagick()` gates the colour and pixel axes. A host with neither
  ImageMagick gets a `SKIPPED` section naming what is missing and how to fix
  it, instead of a traceback.
- `diagnose()` accepts `None` for an unmeasured histogram and reports the
  absence as its first finding, so an axis that did not run can never be read
  as an axis that agreed.
- All four former `["magick", ...]` call sites route through the resolver; the
  literal now appears only inside it.
- CLAUDE.md and AGENTS.md note the IM6 spellings for the `magick` commands in
  the fine-detail checklist that are still typed by hand.

## Related issue

Fixes #809

## Testing

Measured on a host with ImageMagick 6.9.12-98 and no `magick` binary:

- `python3 scripts/compare_render.py tests/golden_mocks/business/expected/docx/02_contract_ko.pdf tests/golden_mocks/business/expected/docx/02_contract_ko.pdf --page 1`
  — before this change, the issue's exact reproduction ends in
  `FileNotFoundError: [Errno 2] No such file or directory: 'magick'` after the
  geometry axis has printed. After it, all three axes complete and report.
- The same command with ImageMagick removed from `PATH` exits 0, prints the
  `## Histogram and pixel difference — SKIPPED` section, and leads the
  `## Reading` verdict with the "colour and pixel axes did not run" finding.
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 79 tests, all
  passing. 6 are new: 4 covering the IM7, IM6, absent and partial-install cases
  of the resolver, and 2 covering the `diagnose()` branch that must not report
  agreement for an axis that never ran.

The IM7 path is covered by unit test rather than by execution, since no IM7
host was available.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: the change is confined to `scripts/compare_render.py`, its unit
  tests, and two documentation notes. No crate source is touched, so no
  conversion path and no rendered PDF can differ.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
