### PR TITLE
fix(pptx): read a:spAutoFit as shape autofit, not shrink-to-fit

### DIFF
--- a/crates/office2pdf/src/ir/elements.rs
+++ b/crates/office2pdf/src/ir/elements.rs
@@ -604,7 +604,10 @@ pub struct TextBoxData {
     /// When true, text should not wrap — the content width is unconstrained.
     /// Corresponds to `<a:bodyPr wrap="none"/>` in OOXML.
     pub no_wrap: bool,
-    /// Whether the source requested PowerPoint autofit behavior for this box.
+    /// Whether the source asked for the text to shrink to the box —
+    /// `<a:normAutofit/>` alone. `<a:spAutoFit/>` grows the shape to the
+    /// text instead and leaves the declared size alone, so it does not set
+    /// this (issue #898).
     pub auto_fit: bool,
     /// Clockwise text rotation from `<a:bodyPr vert>` ("vert" = 90°,
     /// "vert270" = 270°); the box geometry itself stays unrotated.

--- a/crates/office2pdf/src/parser/pptx_slides.rs
+++ b/crates/office2pdf/src/parser/pptx_slides.rs
@@ -1851,7 +1851,10 @@ impl<'a> SlideXmlParser<'a> {
             b"bodyPr" if self.in_shape && self.in_txbody => {
                 extract_pptx_text_box_body_props(e, &mut self.text_box);
             }
-            b"spAutoFit" | b"normAutofit" if self.in_shape && self.in_txbody => {
+            // Only `<a:normAutofit/>` shrinks text. `<a:spAutoFit/>` grows the
+            // shape to the text and leaves the run's declared size alone
+            // (ECMA-376 §21.1.2.1.2 / §21.1.2.1.3, issue #898).
+            b"normAutofit" if self.in_shape && self.in_txbody => {
                 self.text_box.auto_fit = true;
             }
             b"lstStyle" if self.in_shape && self.in_txbody => {
@@ -2251,7 +2254,10 @@ impl<'a> SlideXmlParser<'a> {
             b"bodyPr" if self.in_shape && self.in_txbody => {
                 extract_pptx_text_box_body_props(e, &mut self.text_box);
             }
-            b"spAutoFit" | b"normAutofit" if self.in_shape && self.in_txbody => {
+            // Only `<a:normAutofit/>` shrinks text. `<a:spAutoFit/>` grows the
+            // shape to the text and leaves the run's declared size alone
+            // (ECMA-376 §21.1.2.1.2 / §21.1.2.1.3, issue #898).
+            b"normAutofit" if self.in_shape && self.in_txbody => {
                 self.text_box.auto_fit = true;
             }
             b"prstGeom" if self.in_pic && self.pic.in_sp_pr => {

--- a/crates/office2pdf/src/parser/pptx_text_box_semantic_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_text_box_semantic_tests.rs
@@ -304,10 +304,11 @@ fn test_text_box_body_pr_defaults_and_center_anchor_extracted() {
         text_box.vertical_align,
         crate::ir::TextBoxVerticalAlign::Center
     );
-    assert!(
-        text_box.auto_fit,
-        "spAutoFit text boxes should preserve the autofit hint in the IR"
-    );
+    // `auto_fit` drives text scaling, and `<a:spAutoFit/>` does not ask for
+    // any: it resizes the shape to the text and leaves the run's declared
+    // size alone (ECMA-376 §21.1.2.1.2). This assertion used to require the
+    // opposite, which is what shrank an 8pt label to 4.9pt in issue #898.
+    assert!(!text_box.auto_fit);
     assert!(!text_box.no_wrap);
 }
 

--- a/crates/office2pdf/src/parser/pptx_text_box_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_text_box_tests.rs
@@ -682,3 +682,38 @@ fn test_a_run_without_cap_leaves_casing_unset() {
     assert_eq!(style.all_caps, None);
     assert_eq!(style.small_caps, None);
 }
+
+/// `<a:spAutoFit/>` and `<a:normAutofit/>` are different requests
+/// (ECMA-376 §21.1.2.1.2 / §21.1.2.1.3) and only the second one shrinks text
+/// (issue #898).
+///
+/// - *shape autofit* grows the **shape** to the text; the run keeps its
+///   declared size, and PowerPoint saves the grown box.
+/// - *normal autofit* shrinks the **text** on overflow, by the `fontScale`
+///   and `lnSpcReduction` it states.
+///
+/// The deck in #841 puts `<a:spAutoFit/>` on a 9.6pt-tall box holding 8pt
+/// text, and we scaled the run to 4.9pt to make it fit one line.
+#[test]
+fn sp_auto_fit_does_not_shrink_text_but_norm_autofit_does() {
+    for (autofit, expected_scaling) in [("<a:spAutoFit/>", false), ("<a:normAutofit/>", true)] {
+        let shape = format!(
+            r#"<p:sp><p:nvSpPr><p:cNvPr id="2" name="T"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr><p:spPr><a:xfrm><a:off x="63500" y="6672580"/><a:ext cx="855663" cy="121920"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr><p:txBody><a:bodyPr horzOverflow="overflow" lIns="0" tIns="0" rIns="0" bIns="0">{autofit}</a:bodyPr><a:lstStyle/><a:p><a:r><a:rPr lang="en-US" sz="800"/><a:t>Sensitivity: Internal</a:t></a:r></a:p></p:txBody></p:sp>"#
+        );
+        let slide = make_slide_xml(&[shape]);
+        let data = build_test_pptx(SLIDE_CX, SLIDE_CY, &[slide]);
+        let parser = PptxParser;
+        let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
+
+        let page = first_fixed_page(&doc);
+        let FixedElementKind::TextBox(ref text_box) = page.elements[0].kind else {
+            panic!("expected a text box");
+        };
+        assert_eq!(
+            text_box.auto_fit,
+            expected_scaling,
+            "{autofit} must {} request text scaling",
+            if expected_scaling { "" } else { "not" }
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`<a:spAutoFit/>` and `<a:normAutofit/>` were read into the same `auto_fit`
flag, and that flag is one of the two things that trigger
`single_line_fit_paragraph`'s scale-to-fit. They are different requests
(ECMA-376 §21.1.2.1.2 / §21.1.2.1.3):

- `<a:normAutofit/>` — *normal autofit* — shrinks the **text** on overflow, by
  the `fontScale`/`lnSpcReduction` it states.
- `<a:spAutoFit/>` — *shape autofit* — grows the **shape** to the text. The run
  keeps its declared size; PowerPoint saves the grown box.

So a `spAutoFit` box whose text would overflow was silently rescaled.

`test_text_box_body_pr_defaults_and_center_anchor_extracted` required the old
behaviour, with the message "spAutoFit text boxes should preserve the autofit
hint in the IR". That pinned the defect rather than any measured Office
behaviour, so it is flipped with the spec reference spelled out.

**This does not fix #898**, and the issue has been corrected to say so.
Separating the two leaves that measurement exactly where it was: the label
there sits in a box barely one line tall, so the other operand of

```rust
text_box.auto_fit || inner_height_pt <= estimated_line_height_pt * 1.2
```

fires on its own — `9.6 <= 11.52` for a 9.6pt box holding 8pt text. #898 now
records that clause as its root cause.

## Related issue

Related: #903, #898

## Testing

- `cargo test --workspace` — 2516 passed, 0 failures
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --check` — clean
- new: `sp_auto_fit_does_not_shrink_text_but_norm_autofit_does`, written first
  and confirmed red (`left: true, right: false`) before the change

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: All 64 pptx fixtures under `tests/fixtures/pptx/` and `tests/golden_mocks/business/sources/pptx/` were rendered with a binary built from this branch with the one-line change reverted, and their `pdftotext -bbox` text layers diffed against this branch's output. None differ. The corpus holds 209 `<a:spAutoFit/>` shapes, 46 of them in the band where `auto_fit` is the sole trigger of the scale — taller than 1.2x their line height so the short-box clause misses, within 2.0x so `is_short_box` still holds — but none of those overflows its box, and scaling by 1.0 agrees with not scaling. The behaviour that changes is an overflowing `spAutoFit` box, which no fixture exercises and which the new unit test covers.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
