### PR TITLE
fix(pptx): compose a group's rotation into a child picture

### DIFF
--- a/crates/office2pdf/src/ir/elements.rs
+++ b/crates/office2pdf/src/ir/elements.rs
@@ -609,8 +609,9 @@ pub struct TextBoxData {
     /// Clockwise text rotation from `<a:bodyPr vert>` ("vert" = 90°,
     /// "vert270" = 270°); the box geometry itself stays unrotated.
     pub text_rotation_deg: Option<f64>,
-    /// Clockwise rotation of the whole box from `<a:xfrm rot>`, about its
-    /// centre. Unlike `text_rotation_deg` the content lays out in the
+    /// Clockwise rotation of the whole box about its centre: the shape's own
+    /// `<a:xfrm rot>` composed with the angle of any rotated ancestor
+    /// `<p:grpSp>`. Unlike `text_rotation_deg` the content lays out in the
     /// unrotated width x height box and the result is turned as a unit.
     pub shape_rotation_deg: Option<f64>,
 }
@@ -897,8 +898,9 @@ impl ImageCrop {
 #[derive(Debug, Clone)]
 pub struct ImageData {
     pub data: Vec<u8>,
-    /// Clockwise rotation in degrees from `a:xfrm/@rot`, about the image's
-    /// centre. `None` means upright (issue #682).
+    /// Clockwise rotation in degrees about the image's centre: the picture's
+    /// own `a:xfrm/@rot` composed with the angle of any rotated ancestor
+    /// `<p:grpSp>`. `None` means upright (issues #682, #895).
     pub rotation_deg: Option<f64>,
     pub format: ImageFormat,
     pub width: Option<f64>,

--- a/crates/office2pdf/src/parser/pptx_image_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_image_tests.rs
@@ -1069,3 +1069,85 @@ fn test_picture_outer_shadow_parsed() {
     assert!((shadow.opacity - 0.22).abs() < 0.01);
     assert!((shadow.distance - 3.0).abs() < 0.1, "38100 EMU = 3pt");
 }
+
+/// A picture inside a rotated `<p:grpSp>` takes the group's angle, the way a
+/// shape and a text box already do (issue #895).
+///
+/// `GroupTransform::apply` orbits every child around the group centre but only
+/// composed the angle into a `Shape` and, since #894, a `TextBox`. A picture
+/// was moved into place and then drawn upright: measured against a LibreOffice
+/// 24.2 export of a 90°-rotated group holding a 4x2 bitmap, the reference drew
+/// it 47.2 x 125.9pt where we drew it 126.0 x 47.2pt.
+#[test]
+fn a_picture_in_a_rotated_group_takes_the_groups_angle() {
+    let bmp_data = make_test_bmp();
+    let pic = make_pic_xml(0, 0, 1_600_000, 600_000, "rId3");
+    let group = format!(
+        r#"<p:grpSp><p:nvGrpSpPr><p:cNvPr id="10" name="G"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm rot="5400000"><a:off x="4000000" y="2000000"/><a:ext cx="1600000" cy="600000"/><a:chOff x="0" y="0"/><a:chExt cx="1600000" cy="600000"/></a:xfrm></p:grpSpPr>{pic}</p:grpSp>"#
+    );
+    let slide_xml = make_slide_xml(&[group]);
+    let slide_images = vec![TestSlideImage {
+        rid: "rId3".to_string(),
+        path: "../media/image1.bmp".to_string(),
+        data: bmp_data,
+        relationship_type: None,
+    }];
+    let data = build_test_pptx_with_images(SLIDE_CX, SLIDE_CY, &[(slide_xml, slide_images)]);
+    let parser = PptxParser;
+    let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
+
+    let page = first_fixed_page(&doc);
+    let image = get_image(&page.elements[0]);
+    let rotation = image
+        .rotation_deg
+        .expect("a picture in a rotated group must carry the group's angle");
+    assert!(
+        (rotation - 90.0).abs() < 0.01,
+        "expected 90 degrees, got {rotation}"
+    );
+}
+
+/// Triangulation: the group's angle adds to the picture's own, and an
+/// unrotated group leaves a picture unrotated.
+#[test]
+fn a_group_angle_adds_to_a_pictures_own_rotation() {
+    for (group_rot, pic_rot, expected) in [
+        (Some(5_400_000_i64), Some(1_800_000_i64), Some(120.0_f64)),
+        (None, None, None),
+    ] {
+        let pic_xfrm = match pic_rot {
+            Some(rot) => format!(r#"<a:xfrm rot="{rot}">"#),
+            None => "<a:xfrm>".to_string(),
+        };
+        let pic = format!(
+            r#"<p:pic><p:nvPicPr><p:cNvPr id="5" name="Picture"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId3"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr>{pic_xfrm}<a:off x="0" y="0"/><a:ext cx="1600000" cy="600000"/></a:xfrm></p:spPr></p:pic>"#
+        );
+        let group_xfrm = match group_rot {
+            Some(rot) => format!(r#"<a:xfrm rot="{rot}">"#),
+            None => "<a:xfrm>".to_string(),
+        };
+        let group = format!(
+            r#"<p:grpSp><p:nvGrpSpPr><p:cNvPr id="10" name="G"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr>{group_xfrm}<a:off x="4000000" y="2000000"/><a:ext cx="1600000" cy="600000"/><a:chOff x="0" y="0"/><a:chExt cx="1600000" cy="600000"/></a:xfrm></p:grpSpPr>{pic}</p:grpSp>"#
+        );
+        let slide_xml = make_slide_xml(&[group]);
+        let slide_images = vec![TestSlideImage {
+            rid: "rId3".to_string(),
+            path: "../media/image1.bmp".to_string(),
+            data: make_test_bmp(),
+            relationship_type: None,
+        }];
+        let data = build_test_pptx_with_images(SLIDE_CX, SLIDE_CY, &[(slide_xml, slide_images)]);
+        let parser = PptxParser;
+        let (doc, _warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
+
+        let page = first_fixed_page(&doc);
+        match (get_image(&page.elements[0]).rotation_deg, expected) {
+            (None, None) => {}
+            (Some(actual), Some(want)) => assert!(
+                (actual - want).abs() < 0.01,
+                "expected {want} degrees, got {actual}"
+            ),
+            (actual, want) => panic!("expected {want:?}, got {actual:?}"),
+        }
+    }
+}

--- a/crates/office2pdf/src/parser/pptx_shapes.rs
+++ b/crates/office2pdf/src/parser/pptx_shapes.rs
@@ -127,11 +127,9 @@ impl GroupTransform {
                     text_box.shape_rotation_deg =
                         Some(text_box.shape_rotation_deg.unwrap_or(0.0) + self.rot_deg);
                 }
-                // TODO(#895): `ImageData` has a `rotation_deg` of its own but
-                // does not take the group's, so a picture inside a rotated
-                // group is orbited into place and then drawn upright. Left
-                // out here to keep this change to one root cause; #895
-                // carries the measurement.
+                FixedElementKind::Image(ref mut image) => {
+                    image.rotation_deg = Some(image.rotation_deg.unwrap_or(0.0) + self.rot_deg);
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
## Summary

`GroupTransform::apply` orbits every child of a rotated `<p:grpSp>` around the
group centre, but composed the group's angle only into a `Shape` and, since
#894, a `TextBox`. `ImageData` has a `rotation_deg` of its own and was left
out, so a picture was moved into place and then drawn upright.

The rule the function already applies to its other children is that a group
turns what is inside it, not just where it sits. This extends it to the one
kind that was missing, and removes the `TODO(#895)` #896 left behind.

Measured with a minimal probe — a 4x2 PNG in a `<p:grpSp>` whose
`<a:xfrm rot="5400000">` turns the group 90° clockwise, the child `<p:pic>`
stating no rotation of its own. `mutool draw -F trace`, the `fill_image`
transform:

| | transform | drawn box |
| --- | --- | ---: |
| LibreOffice 24.2 | `47.225 0 0 125.943 354.359 118.092` | 47.23 x 125.94pt |
| before | `125.98 0 0 47.24 314.96 157.48` | 126.0 x 47.2pt (upright) |
| after | `~0 125.984 -47.244 ~0 401.575 118.110` | **47.24 x 125.98pt** |

The after matrix reaches the same region as the reference — the negative `c`
coefficient puts the origin at the opposite corner, so both cover
x 354.3..401.6 and y 118.1..244.1 — and its extent agrees to within 0.05pt.

## Related issue

Related: #895, #894

## Testing

- `cargo test --workspace` — 0 failures
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --check` — clean
- new: `a_picture_in_a_rotated_group_takes_the_groups_angle`,
  `a_group_angle_adds_to_a_pictures_own_rotation`. Both written first and
  confirmed red before the change.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: No committed fixture contains the construct. Scanning every `<p:grpSp>` in `tests/fixtures/pptx/` and `tests/golden_mocks/business/sources/pptx/` finds **0** rotated groups holding a `<p:pic>` across all 64 files, so the code path this changes is never entered by the corpus and no fixture's output can differ. The behaviour that changes is a picture inside a rotated group, covered by the two new unit tests and by the probe measured above.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
