### PR TITLE
fix(wasm): build the browser cdylib package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,10 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
+      # `cargo check` and `wasm-pack test` do not link the browser package
+      # documented in README.md, so keep that artifact buildable too.
+      - name: Build browser package
+        run: wasm-pack build crates/office2pdf --target web --features wasm
       # Runs the wasm integration tests in src/wasm.rs under Node, exercising
       # the wasm32 time paths (Instant/SystemTime) end-to-end so the issue #178
       # class of runtime panic cannot regress unnoticed.

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -10,6 +10,9 @@ readme = "../../README.md"
 keywords = ["pdf", "docx", "xlsx", "pptx", "converter"]
 categories = ["text-processing"]
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [features]
 wasm = ["wasm-bindgen"]
 pdf-ops = ["lopdf"]


### PR DESCRIPTION
## Summary

- Declare `cdylib` and `rlib` outputs for the library crate.
- Build the exact browser package documented in README.md in the WASM CI job.

## Why

`wasm-pack build crates/office2pdf --target web --features wasm` failed before compilation because the crate exposed only Cargo’s default `rlib`. `cargo check` and `wasm-pack test` did not catch that artifact-linking failure.

## Related issue

Related: #942

## Testing

- Reproduced the pre-fix `crate-type must be cdylib` failure with the documented command.
- `wasm-pack build crates/office2pdf --target web --features wasm` — passed; generated `office2pdf_bg.wasm`, JavaScript glue, and TypeScript declarations.
- `wasm-pack test --node --features wasm` — 6 passed.
- `cargo check --target wasm32-unknown-unknown -p office2pdf` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.
- `cargo test --workspace` — 2,056 library tests, 182 DOCX integration tests, and 7 PDF validation tests passed; the run then stopped at six 30-second performance-ceiling failures. The same six failures reproduce unchanged on `main` under default parallelism (31–36s), while the unchanged-main suite passes 11/11 with `--test-threads=1`.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: The change only declares build artifact types and adds an artifact-link CI gate.

## Checklist

- [x] Commit includes a `Signed-off-by` line.
- [x] PR scope contains one root cause.
- [x] Documentation freshness audit returned `PASS:`.