### PR TITLE
Fix current-stable XLSX formula Clippy failure

### DIFF
--- a/crates/office2pdf/src/parser/xlsx_formula.rs
+++ b/crates/office2pdf/src/parser/xlsx_formula.rs
@@ -209,7 +209,6 @@ fn tokenize(text: &str) -> Option<Vec<Token>> {
                         || *c == '.'
                         || *c == '!'
                         || *c == '\''
-                        || *c == ' ' && false
                 }) {
                     index += 1;
                 }


### PR DESCRIPTION
## Summary

- remove an unreachable `&& false` arm from the XLSX formula lexer
- restore the current-stable `clippy::overly_complex_bool_expr` gate without changing tokenization

Closes #979

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p office2pdf xlsx_formula` (10 passed)
- `cargo clippy --workspace --all-targets -- -D warnings`

## Documentation

- pre-commit freshness audit: PASS; the unreachable condition had no documented behavior, API, command, configuration, or limitation

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Removes a boolean operand that is statically false; the accepted lexer characters and every rendering path are unchanged.
