### PR TITLE
fix: make visual audits catch repeated labels

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,7 @@
 - Renderer and DPI: <!-- e.g. pdftoppm, 150 DPI -->
 - Evidence mode: `fix` <!-- `fix` requires gt/before/after; `defect` requires compare -->
 - New follow-up issues found in this audit: <!-- #N, #N or None; create issues before completing the audit -->
+- Model vision findings: <!-- Describe what Codex/Claude saw in the full pages, diff, and crops. Numeric output is insufficient. -->
 - GT: `assets/bugfixes/issue-<!-- N -->/gt.jpg`
 - Before: `assets/bugfixes/issue-<!-- N -->/before.jpg`
 - After: `assets/bugfixes/issue-<!-- N -->/after.jpg`
@@ -51,7 +52,9 @@
 
 - [ ] Rendered all evidence at 150 DPI or higher
 - [ ] Stored progressive JPEG quality 86 assets with metadata stripped
+- [ ] Used Codex/Claude vision to inspect the full GT/output pages, diff, and matched crops
 - [ ] Inspected matched region crops at full resolution
+- [ ] Ran compare_layout.py --audit and dispositioned every large text-instance shift
 - [ ] Ran the 5% fuzz pixel-difference sweep
 - [ ] Inventoried hairlines and border dash styles
 - [ ] Inventoried font weight, italic, and underline emphasis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,15 @@ just the pages a screenshot shows.
 2. **Run all four axes**, not one: `compare_layout.py` (geometry, per page),
    `compare_text_layer.py` (what a reader can select), `compare_render.py`
    (colour and pixels), and a page-by-page visual at >=150 DPI.
+   Run the geometry axis with `--audit`; every large text-instance shift it
+   names must be fixed or recorded as a remaining deviation with an open issue.
+   Do not classify the pixel diff as antialiasing while this audit is failing.
+   Source/XML inspection and numeric reports only route attention; they never
+   constitute a visual pass. The acting Codex or Claude agent must use its image
+   vision to open and inspect the full GT/output pages, the pixel diff, and all
+   matched region crops before completing the audit. Record the concrete visual
+   observations in `Model vision findings`; numeric output or `None` does not
+   satisfy the PR contract.
 3. **Read the source XML before attributing a deviation.** Name the element and
    attribute that produced it; a measurement without one is a guess.
 4. **A token the reference has and we lack is not automatically our defect.**
@@ -162,12 +171,24 @@ produces no new finding.
 Run `python3 scripts/compare_render.py <GT.pdf> <output.pdf> [--page N]` before
 judging a rendered difference. It reports geometry, colour histogram, and pixel
 difference together, then states what the combination means.
+For a visual audit, also pass `--artifacts-dir <directory>`: for the page chosen
+by `--page`, it preserves the full GT/output pages, their side-by-side image,
+the 5% pixel diff, and a matched GT/output crop for every large text-instance
+shift on that page. Run it once for every compared page, using a distinct
+directory per page. It fails if ImageMagick is unavailable rather than silently
+omitting evidence. Open every emitted path with Codex/Claude image vision;
+producing the files is not itself inspection.
 
-For layout defects, run `python3 scripts/compare_layout.py <GT.pdf> <output.pdf>`
+For layout defects, run `python3 scripts/compare_layout.py <GT.pdf> <output.pdf> --audit`
 first: it matches text lines from `mutool` traces and reports missing/extra/
 re-wrapped lines, baseline dy, pitch and width drift, and a rect census, with
 GT noise floors built in (`--noise-floor 0.12` Word, `0.5` Excel). Its numbers
-are assertable; pixel counts are only a tripwire.
+are assertable; pixel counts are only a tripwire. Repeated strings are matched
+as separate spatial instances: a chart title and legend both named `Sales`
+appear as `Sales [1/2]` and `Sales [2/2]`, with their own `dx`/`dy`. The audit
+exits nonzero when any instance moves more than 5pt (override with
+`--large-shift PT` for a justified fixture-specific threshold); inspect and
+track every named instance before marking alignment as matching.
 
 **Its width column measures origin-to-origin and so counts invisible trailing
 glyphs.** Word emits a trailing space after a paragraph's last character where

--- a/scripts/check_visual_pr.py
+++ b/scripts/check_visual_pr.py
@@ -42,7 +42,9 @@ AUDIT_ROWS = (
 INSPECTION_ITEMS = (
     "Rendered all evidence at 150 DPI or higher",
     "Stored progressive JPEG quality 86 assets with metadata stripped",
+    "Used Codex/Claude vision to inspect the full GT/output pages, diff, and matched crops",
     "Inspected matched region crops at full resolution",
+    "Ran compare_layout.py --audit and dispositioned every large text-instance shift",
     "Ran the 5% fuzz pixel-difference sweep",
     "Inventoried hairlines and border dash styles",
     "Inventoried font weight, italic, and underline emphasis",
@@ -50,6 +52,11 @@ INSPECTION_ITEMS = (
 FIX_PREVIEW_LABELS = ("GT", "Before", "After")
 DEFECT_PREVIEW_LABELS = ("Compare",)
 ALLOWED_RESULTS = ("Matches GT", "Fixed", "No deviation observed")
+VISION_WORDS = re.compile(
+    r"(?i)\b(?:page|diff|crop|text|title|label|line|shape|image|chart|table|"
+    r"position|align(?:ment|ed)?|offset|colour|color|fill|stroke|border|font|"
+    r"spacing|clip(?:ping|ped)?|overflow|rotation|size|weight)\b"
+)
 
 
 @dataclass(frozen=True)
@@ -202,6 +209,19 @@ def validate_pr_body(body: str, changed_paths: list[str]) -> list[str]:
                 errors.append(
                     f"New follow-up issues must also classify a Remaining deviation: {references}."
                 )
+
+    vision_findings = field(audit, "Model vision findings")
+    descriptive_words = re.findall(r"[A-Za-z]{3,}", vision_findings or "")
+    if (
+        not vision_findings
+        or len(vision_findings) < 20
+        or len(descriptive_words) < 4
+        or not VISION_WORDS.search(vision_findings)
+    ):
+        errors.append(
+            "Visual audit > Model vision findings must record a substantive direct "
+            "inspection of the full pages, diff, and crops; numeric metrics alone do not count."
+        )
 
     for item in INSPECTION_ITEMS:
         if not checked(audit, item):

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -22,7 +22,7 @@ position, size, pitch, wrap, and element presence, which is what actually
 changes when a layout defect is fixed.
 
 Usage:
-    compare_layout.py GT.pdf OUTPUT.pdf [--page N] [--noise-floor PT] [--json]
+    compare_layout.py GT.pdf OUTPUT.pdf [--page N] [--noise-floor PT] [--audit]
 """
 
 from __future__ import annotations
@@ -35,8 +35,9 @@ import statistics
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from difflib import SequenceMatcher
 from pathlib import Path
+
+from spatial_match import minimum_cost_pairs
 
 # mutool 1.23.x opens a page as `<page mediabox="...">` with no `number`
 # attribute; later builds add one. Requiring it parses zero pages and reports
@@ -197,18 +198,39 @@ def build_lines(glyphs: list[Glyph], y_tolerance: float = LINE_Y_TOLERANCE_PT) -
 def match_lines(
     gt_lines: list[Line], out_lines: list[Line]
 ) -> tuple[list[tuple[Line, Line]], list[Line], list[Line]]:
-    matcher = SequenceMatcher(
-        a=[line.key for line in gt_lines], b=[line.key for line in out_lines], autojunk=False
-    )
+    """Pair every exact-text line by minimum spatial distance.
+
+    A sequence matcher can align repeated labels to the wrong occurrence, and
+    the older render harness discarded repeats entirely. Grouping by text and
+    assigning in x/y space preserves every chart title, legend, tick, and table
+    value as an independently auditable instance.
+    """
+    gt_groups: dict[str, list[Line]] = {}
+    out_groups: dict[str, list[Line]] = {}
+    for line in gt_lines:
+        gt_groups.setdefault(line.key, []).append(line)
+    for line in out_lines:
+        out_groups.setdefault(line.key, []).append(line)
+
     matches: list[tuple[Line, Line]] = []
-    missing: list[Line] = []
-    extra: list[Line] = []
-    for tag, a0, a1, b0, b1 in matcher.get_opcodes():
-        if tag == "equal":
-            matches.extend(zip(gt_lines[a0:a1], out_lines[b0:b1]))
-        else:
-            missing.extend(gt_lines[a0:a1])
-            extra.extend(out_lines[b0:b1])
+    matched_gt: set[int] = set()
+    matched_out: set[int] = set()
+    for key, references in gt_groups.items():
+        candidates = out_groups.get(key, [])
+        references = sorted(references, key=lambda line: (line.y, line.x0))
+        candidates = sorted(candidates, key=lambda line: (line.y, line.x0))
+        for reference_index, candidate_index in minimum_cost_pairs(
+            [(line.x0, line.y) for line in references],
+            [(line.x0, line.y) for line in candidates],
+        ):
+            reference = references[reference_index]
+            candidate = candidates[candidate_index]
+            matches.append((reference, candidate))
+            matched_gt.add(id(reference))
+            matched_out.add(id(candidate))
+    matches.sort(key=lambda pair: (pair[0].y, pair[0].x0))
+    missing = [line for line in gt_lines if id(line) not in matched_gt]
+    extra = [line for line in out_lines if id(line) not in matched_out]
     return matches, missing, extra
 
 
@@ -220,7 +242,7 @@ def take_wrap_differences(
     A wrap difference is text that exists on both sides but breaks at a
     different point, so joined runs of unmatched lines carry the same
     characters. Greedy prefix consumption keeps it linear and is sufficient
-    for the contiguous runs SequenceMatcher produces.
+    for the unmatched lines left after exact-text spatial pairing.
     """
     wraps: list[str] = []
     remaining_missing = list(missing)
@@ -257,7 +279,10 @@ def take_reflows(missing: list[Line], extra: list[Line]) -> tuple[dict, list[Lin
 
 
 def diff_page(
-    gt: PageLayout, out: PageLayout, noise_floor: float = 0.12
+    gt: PageLayout,
+    out: PageLayout,
+    noise_floor: float = 0.12,
+    large_shift: float = 5.0,
 ) -> dict:
     matches, missing, extra = match_lines(gt.lines, out.lines)
     wraps, missing, extra = take_wrap_differences(missing, extra)
@@ -269,6 +294,44 @@ def diff_page(
         (out_line.width - gt_line.width) / gt_line.width * 100
         for gt_line, out_line in matches
         if gt_line.width > 1.0
+    ]
+
+    gt_occurrences: dict[str, list[Line]] = {}
+    for line in gt.lines:
+        gt_occurrences.setdefault(line.key, []).append(line)
+    occurrence_by_id: dict[int, tuple[int, int]] = {}
+    for repeated in gt_occurrences.values():
+        ordered_occurrences = sorted(repeated, key=lambda line: (line.y, line.x0))
+        for index, line in enumerate(ordered_occurrences, start=1):
+            occurrence_by_id[id(line)] = (index, len(ordered_occurrences))
+
+    instances: list[dict] = []
+    for gt_line, out_line in matches:
+        occurrence, occurrence_count = occurrence_by_id[id(gt_line)]
+        label = gt_line.key[:60]
+        if occurrence_count > 1:
+            label = f"{label} [{occurrence}/{occurrence_count}]"
+        width_pct = (
+            (out_line.width - gt_line.width) / gt_line.width * 100
+            if gt_line.width > 1.0
+            else 0.0
+        )
+        instances.append(
+            {
+                "label": label,
+                "gt_x": gt_line.x0,
+                "gt_y": gt_line.y,
+                "out_x": out_line.x0,
+                "out_y": out_line.y,
+                "dx": out_line.x0 - gt_line.x0,
+                "dy": out_line.y - gt_line.y,
+                "width_pct": width_pct,
+            }
+        )
+    large_shifts = [
+        instance
+        for instance in instances
+        if abs(instance["dx"]) > large_shift or abs(instance["dy"]) > large_shift
     ]
 
     pitch_deltas: list[float] = []
@@ -334,6 +397,11 @@ def diff_page(
             "mean_abs_pct": stats(width_pcts)["mean_abs"],
             "worst_pct": abs(stats(width_pcts)["worst"]),
         },
+        "instances": {
+            "large_shift_threshold": large_shift,
+            "large_shift_count": len(large_shifts),
+            "large_shifts": large_shifts,
+        },
         "pitch": {"pairs": len(pitch_deltas), "worst_delta": abs(stats(pitch_deltas)["worst"])},
         "wraps": {"count": len(wraps), "samples": wraps[:5]},
         "reflow": reflow,
@@ -374,6 +442,20 @@ def render_reading(vectors: list[dict]) -> str:
                 f"{vector['noise_floor']}pt floor; worst {vector['baseline']['worst_dy_signed']:+.2f}pt "
                 f"on '{vector['baseline']['worst_line']}'"
             )
+        if vector["instances"]["large_shift_count"]:
+            examples = "; ".join(
+                f"'{item['label']}' dx {item['dx']:+.2f}pt, dy {item['dy']:+.2f}pt"
+                for item in sorted(
+                    vector["instances"]["large_shifts"],
+                    key=lambda value: max(abs(value["dx"]), abs(value["dy"])),
+                    reverse=True,
+                )
+            )
+            page_notes.append(
+                f"{vector['instances']['large_shift_count']} matched text instance(s) move "
+                f"past {vector['instances']['large_shift_threshold']:.2f}pt: {examples}. "
+                "These are layout differences, not antialiasing; inspect and track each one"
+            )
         if vector["pitch"]["worst_delta"] > vector["noise_floor"]:
             page_notes.append(
                 f"line pitch drifts up to {vector['pitch']['worst_delta']:.2f}pt — "
@@ -390,6 +472,16 @@ def render_reading(vectors: list[dict]) -> str:
             page_notes.append("no deviation past the noise floor")
         lines.append(f"- page {index}: " + "; ".join(page_notes))
     return "\n".join(lines)
+
+
+def audit_failures(vectors: list[dict]) -> int:
+    """Count material text findings that require visual disposition."""
+    return sum(
+        vector["instances"]["large_shift_count"]
+        + vector["lines"]["missing"]
+        + vector["lines"]["extra"]
+        for vector in vectors
+    )
 
 
 def run_mutool(pdf: Path) -> str:
@@ -416,6 +508,18 @@ def main() -> int:
         default=0.12,
         help="pt threshold under which a delta is measurement noise (0.12 Word GT, 0.5 Excel GT)",
     )
+    parser.add_argument(
+        "--large-shift",
+        type=float,
+        default=5.0,
+        metavar="PT",
+        help="flag any matched text instance whose x or y moves by more than this (default: 5pt)",
+    )
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="exit nonzero on missing/extra text, a large instance shift, or a page-count mismatch",
+    )
     parser.add_argument("--json", action="store_true", help="emit the deviation vectors as JSON")
     args = parser.parse_args()
 
@@ -435,11 +539,19 @@ def main() -> int:
 
     count = min(len(gt_pages), len(out_pages))
     vectors = [
-        diff_page(gt_pages[i], out_pages[i], noise_floor=args.noise_floor) for i in range(count)
+        diff_page(
+            gt_pages[i],
+            out_pages[i],
+            noise_floor=args.noise_floor,
+            large_shift=args.large_shift,
+        )
+        for i in range(count)
     ]
 
     if args.json:
         print(json.dumps({"pages": vectors, "gt_pages": len(gt_pages), "out_pages": len(out_pages)}, indent=1))
+        if args.audit and (audit_failures(vectors) or len(gt_pages) != len(out_pages)):
+            return 1
         return 0
 
     if len(gt_pages) != len(out_pages):
@@ -454,10 +566,19 @@ def main() -> int:
             f"{vector['baseline']['worst_dy_signed']:+.2f}pt | "
             f"pitch worst {vector['pitch']['worst_delta']:.2f}pt | "
             f"width worst {vector['width']['worst_pct']:.1f}% | "
+            f"large shifts {vector['instances']['large_shift_count']} | "
             f"rects {vector['rects']['gt_count']}/{vector['rects']['out_count']}"
         )
     print()
     print(render_reading(vectors))
+    failures = audit_failures(vectors)
+    if args.audit and (failures or len(gt_pages) != len(out_pages)):
+        print()
+        print(
+            f"AUDIT FAILED: {failures} unresolved text-layout finding(s) require visual "
+            "inspection and an issue reference before the audit can be marked as matching."
+        )
+        return 1
     return 0
 
 

--- a/scripts/compare_render.py
+++ b/scripts/compare_render.py
@@ -22,7 +22,7 @@ histogram flat has moved something without changing what is drawn, which is
 usually exactly what a positioning fix should do.
 
 Usage:
-    compare_render.py GT.pdf OUTPUT.pdf [--page N] [--dpi 150]
+    compare_render.py GT.pdf OUTPUT.pdf [--page N] [--dpi 150] [--audit]
 """
 
 from __future__ import annotations
@@ -33,8 +33,11 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
+
+from spatial_match import minimum_cost_pairs
 
 PAGE_RE = re.compile(r'<page width="[\d.]+" height="[\d.]+">(.*?)</page>', re.S)
 WORD_RE = re.compile(
@@ -63,6 +66,28 @@ class TextLine:
     x_min: float
     y_min: float
     text: str
+
+
+@dataclass(frozen=True)
+class TextLineMatch:
+    reference: TextLine
+    candidate: TextLine
+    occurrence: int
+    occurrences: int
+
+    @property
+    def label(self) -> str:
+        if self.occurrences == 1:
+            return self.reference.text
+        return f"{self.reference.text} [{self.occurrence}/{self.occurrences}]"
+
+    @property
+    def dx(self) -> float:
+        return self.candidate.x_min - self.reference.x_min
+
+    @property
+    def dy(self) -> float:
+        return self.candidate.y_min - self.reference.y_min
 
 
 def render_page(pdf: Path, page: int, dpi: int, out_dir: Path, role: str) -> Path:
@@ -112,6 +137,15 @@ def imagemagick_command(tool: str) -> list[str] | None:
 def has_imagemagick() -> bool:
     """Whether every tool the colour and pixel axes need can be invoked."""
     return all(imagemagick_command(tool) is not None for tool in IMAGEMAGICK_TOOLS)
+
+
+def require_vision_artifact_dependencies(artifacts_dir: Path | None) -> None:
+    """Fail rather than silently omit requested model-vision evidence."""
+    if artifacts_dir is not None and not has_imagemagick():
+        raise SystemExit(
+            "--artifacts-dir requires ImageMagick to preserve full pages, the "
+            "pixel diff, and matched crops; install imagemagick and rerun"
+        )
 
 
 def baseline_lines(pdf: Path) -> list[TextLine]:
@@ -207,34 +241,62 @@ def text_lines(pdf: Path) -> list[TextLine]:
     return descriptor_box_lines(pdf)
 
 
-def unique_lines(lines: list[TextLine]) -> dict[str, TextLine]:
-    """Lines keyed by their text, keeping only texts that occur exactly once.
+def match_text_line_instances(
+    gt_lines: list[TextLine], other_lines: list[TextLine]
+) -> list[TextLineMatch]:
+    """Match equal text per page, including every repeated occurrence."""
+    gt_groups: dict[tuple[int, str], list[TextLine]] = defaultdict(list)
+    other_groups: dict[tuple[int, str], list[TextLine]] = defaultdict(list)
+    for line in gt_lines:
+        gt_groups[(line.page, line.text)].append(line)
+    for line in other_lines:
+        other_groups[(line.page, line.text)].append(line)
 
-    A repeated string cannot be paired between two renderings without guessing
-    which occurrence is which, so repeats are dropped rather than mismatched.
-    """
-    seen: dict[str, list[TextLine]] = {}
-    for line in lines:
-        seen.setdefault(line.text, []).append(line)
-    return {text: found[0] for text, found in seen.items() if len(found) == 1}
+    matches: list[TextLineMatch] = []
+    for key, references in gt_groups.items():
+        candidates = other_groups.get(key, [])
+        references = sorted(references, key=lambda line: (line.y_min, line.x_min))
+        candidates = sorted(candidates, key=lambda line: (line.y_min, line.x_min))
+        for reference_index, candidate_index in minimum_cost_pairs(
+            [(line.x_min, line.y_min) for line in references],
+            [(line.x_min, line.y_min) for line in candidates],
+        ):
+            matches.append(
+                TextLineMatch(
+                    reference=references[reference_index],
+                    candidate=candidates[candidate_index],
+                    occurrence=reference_index + 1,
+                    occurrences=len(references),
+                )
+            )
+    return sorted(
+        matches,
+        key=lambda match: (
+            match.reference.page,
+            match.reference.y_min,
+            match.reference.x_min,
+        ),
+    )
 
 
-def report_geometry(gt: Path, other: Path) -> dict[str, float]:
-    """Vertical and horizontal drift of every line matched by unique text."""
-    gt_lines = unique_lines(text_lines(gt))
-    other_lines = unique_lines(text_lines(other))
-    dy: list[float] = []
-    dx: list[float] = []
-    page_mismatch = 0
-    for text, reference in gt_lines.items():
-        candidate = other_lines.get(text)
-        if candidate is None:
-            continue
-        if candidate.page != reference.page:
-            page_mismatch += 1
-            continue
-        dy.append(candidate.y_min - reference.y_min)
-        dx.append(candidate.x_min - reference.x_min)
+def report_geometry(gt: Path, other: Path, large_shift: float = 5.0) -> dict[str, float]:
+    """Vertical and horizontal drift of spatially matched text instances."""
+    gt_text_lines = text_lines(gt)
+    other_text_lines = text_lines(other)
+    matches = match_text_line_instances(gt_text_lines, other_text_lines)
+    dy = [match.dy for match in matches]
+    dx = [match.dx for match in matches]
+    other_text_pages: dict[str, set[int]] = defaultdict(set)
+    for line in other_text_lines:
+        other_text_pages[line.text].add(line.page)
+    matched_reference_ids = {id(match.reference) for match in matches}
+    page_mismatch = sum(
+        1
+        for line in gt_text_lines
+        if id(line) not in matched_reference_ids
+        and line.text in other_text_pages
+        and line.page not in other_text_pages[line.text]
+    )
 
     print("## Geometry — position, size, pitch")
     if not has_mutool():
@@ -242,15 +304,34 @@ def report_geometry(gt: Path, other: Path) -> dict[str, float]:
         print("  boxes rather than baselines. The error scales with font size and can")
         print("  invert the sign. Install mupdf-tools before trusting these numbers.")
     if not dy:
-        print("  no lines matched by unique text; compare pages manually")
+        print("  no text instances matched; compare pages manually")
         return {}
     mad_y = sum(abs(value) for value in dy) / len(dy)
     mad_x = sum(abs(value) for value in dx) / len(dx)
-    coverage = len(dy) / len(gt_lines) if gt_lines else 0.0
-    print(f"  matched lines      {len(dy)} of {len(gt_lines)} "
-          f"({coverage * 100:.0f}% of the GT's unique lines)")
-    print(f"  vertical   MAD {mad_y:7.2f}pt   worst {max(dy, key=abs):+8.2f}pt")
-    print(f"  horizontal MAD {mad_x:7.2f}pt   worst {max(dx, key=abs):+8.2f}pt")
+    coverage = len(dy) / len(gt_text_lines) if gt_text_lines else 0.0
+    worst_dy = max(matches, key=lambda match: abs(match.dy))
+    worst_dx = max(matches, key=lambda match: abs(match.dx))
+    large_matches = [
+        match for match in matches if abs(match.dx) > large_shift or abs(match.dy) > large_shift
+    ]
+    print(f"  matched instances  {len(dy)} of {len(gt_text_lines)} "
+          f"({coverage * 100:.0f}% of the GT's text lines)")
+    print(
+        f"  vertical   MAD {mad_y:7.2f}pt   worst {worst_dy.dy:+8.2f}pt  "
+        f"{worst_dy.label[:60]}"
+    )
+    print(
+        f"  horizontal MAD {mad_x:7.2f}pt   worst {worst_dx.dx:+8.2f}pt  "
+        f"{worst_dx.label[:60]}"
+    )
+    print(f"  large instance shifts (>{large_shift:.2f}pt): {len(large_matches)}")
+    for match in sorted(
+        large_matches, key=lambda item: max(abs(item.dx), abs(item.dy)), reverse=True
+    ):
+        print(
+            f"    page {match.reference.page + 1}: {match.label[:52]}  "
+            f"dx {match.dx:+.2f}pt  dy {match.dy:+.2f}pt"
+        )
     if page_mismatch:
         print(f"  on a different page: {page_mismatch} line(s) — pagination differs")
     return {
@@ -259,6 +340,10 @@ def report_geometry(gt: Path, other: Path) -> dict[str, float]:
         "page_mismatch": float(page_mismatch),
         "matched": float(len(dy)),
         "coverage": coverage,
+        "worst_dx": worst_dx.dx,
+        "worst_dy": worst_dy.dy,
+        "large_shift_count": float(len(large_matches)),
+        "large_shift_threshold": large_shift,
     }
 
 
@@ -380,6 +465,138 @@ def report_pixels(gt_png: Path, other_png: Path, out_dir: Path) -> None:
         print(f"  {label}      {result.stderr.strip()}")
 
 
+def shift_crop_box(
+    match: TextLineMatch, dpi: int, image_width: int, image_height: int
+) -> tuple[int, int, int, int]:
+    """Matched page-space crop containing both locations of one shifted line."""
+    scale = dpi / 72.0
+    text_extent_pt = max(72.0, min(240.0, len(match.reference.text) * 8.0))
+    left = max(0, round((min(match.reference.x_min, match.candidate.x_min) - 24.0) * scale))
+    right = min(
+        image_width,
+        round(
+            (max(match.reference.x_min, match.candidate.x_min) + text_extent_pt + 24.0)
+            * scale
+        ),
+    )
+    top = max(0, round((min(match.reference.y_min, match.candidate.y_min) - 32.0) * scale))
+    bottom = min(
+        image_height,
+        round((max(match.reference.y_min, match.candidate.y_min) + 24.0) * scale),
+    )
+    return left, top, max(1, right - left), max(1, bottom - top)
+
+
+def preserve_vision_artifacts(
+    gt_png: Path,
+    other_png: Path,
+    artifacts_dir: Path,
+    page: int,
+    dpi: int,
+    large_matches: list[TextLineMatch],
+) -> list[Path]:
+    """Persist full pages, a pixel diff, and matched crops for model vision."""
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    gt_artifact = artifacts_dir / f"page-{page}-gt.png"
+    output_artifact = artifacts_dir / f"page-{page}-output.png"
+    side_by_side = artifacts_dir / f"page-{page}-side-by-side.png"
+    diff_artifact = artifacts_dir / f"page-{page}-diff-5pct.png"
+
+    size = subprocess.run(
+        [*(imagemagick_command("identify") or []), "-format", "%wx%h", str(other_png)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    width, height = (int(value) for value in size.split("x", maxsplit=1))
+    subprocess.run(
+        [
+            *(imagemagick_command("convert") or []),
+            str(gt_png),
+            "-background",
+            "white",
+            "-extent",
+            size,
+            str(gt_artifact),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    shutil.copy2(other_png, output_artifact)
+    subprocess.run(
+        [
+            *(imagemagick_command("convert") or []),
+            str(gt_artifact),
+            str(output_artifact),
+            "+append",
+            str(side_by_side),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    diff = subprocess.run(
+        [
+            *(imagemagick_command("compare") or []),
+            "-metric",
+            "AE",
+            "-fuzz",
+            "5%",
+            str(gt_artifact),
+            str(output_artifact),
+            str(diff_artifact),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if diff.returncode not in (0, 1):
+        raise SystemExit(f"ImageMagick failed to create {diff_artifact}: {diff.stderr.strip()}")
+
+    paths = [gt_artifact, output_artifact, side_by_side, diff_artifact]
+    for index, match in enumerate(large_matches, start=1):
+        slug = re.sub(r"[^a-z0-9]+", "-", match.label.lower()).strip("-") or "text"
+        crop_path = artifacts_dir / f"page-{page}-shift-{index:02d}-{slug[:48]}.png"
+        left, top, crop_width, crop_height = shift_crop_box(match, dpi, width, height)
+        crop = f"{crop_width}x{crop_height}+{left}+{top}"
+        gt_crop = artifacts_dir / f".gt-crop-{index:02d}.png"
+        output_crop = artifacts_dir / f".output-crop-{index:02d}.png"
+        for source, destination in (
+            (gt_artifact, gt_crop),
+            (output_artifact, output_crop),
+        ):
+            subprocess.run(
+                [
+                    *(imagemagick_command("convert") or []),
+                    str(source),
+                    "-crop",
+                    crop,
+                    "+repage",
+                    str(destination),
+                ],
+                check=True,
+                capture_output=True,
+            )
+        subprocess.run(
+            [
+                *(imagemagick_command("convert") or []),
+                str(gt_crop),
+                str(output_crop),
+                "+append",
+                str(crop_path),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        gt_crop.unlink()
+        output_crop.unlink()
+        paths.append(crop_path)
+
+    print("## Vision artifacts — open every image with Codex/Claude vision")
+    print("  Numeric output does not complete the visual audit.")
+    for path in paths:
+        print(f"  {path}")
+    return paths
+
+
 def diagnose(
     geometry: dict[str, float], histogram_result: dict[str, float] | None
 ) -> None:
@@ -423,6 +640,8 @@ def diagnose(
     pages_differ: bool = geometry["page_mismatch"] > 0
     intersection: float = histogram_result.get("intersection", 1.0)
     ink_delta: float = histogram_result.get("ink_delta", 0.0)
+    large_shift_count = int(geometry.get("large_shift_count", 0.0))
+    large_shift_threshold = geometry.get("large_shift_threshold", 5.0)
 
     # Thresholds are deliberately loose: they route attention, they do not
     # decide correctness. A point of drift is invisible; ten is not.
@@ -437,6 +656,13 @@ def diagnose(
     ink_differs: bool = colour_measured and abs(ink_delta) > 0.2
 
     findings: list[str] = []
+    if large_shift_count:
+        findings.append(
+            f"{large_shift_count} matched text instance(s) move more than "
+            f"{large_shift_threshold:.2f}pt. These named element-level differences "
+            "remain valid even when the page has too few lines for aggregate MAD "
+            "to be representative; inspect and track each one above."
+        )
     if not colour_measured:
         findings.append(
             "The colour and pixel axes did not run — ImageMagick is absent, so "
@@ -499,36 +725,29 @@ def diagnose(
 
 
 def report_matched_lines(gt: Path, other: Path) -> None:
-    """Per-line baselines for every line matched by unique text.
+    """Per-instance positions for every text line matched spatially.
 
     Aggregate drift says a page is wrong; this says which line. Pairing the two
     PDFs by hand — taking the topmost line, or grepping for a prefix — silently
     matches the wrong line and produces impossible numbers, so the pairing here
-    is the same unique-text match the geometry axis already trusts.
+    is the same duplicate-safe spatial match the geometry axis already trusts.
     """
-    gt_lines = unique_lines(text_lines(gt))
-    other_lines = unique_lines(text_lines(other))
-    rows: list[tuple[TextLine, TextLine]] = [
-        (reference, other_lines[text])
-        for text, reference in gt_lines.items()
-        if text in other_lines and other_lines[text].page == reference.page
-    ]
-    rows.sort(key=lambda pair: (pair[0].page, pair[0].y_min))
+    rows = match_text_line_instances(text_lines(gt), text_lines(other))
 
-    print("## Matched lines — baseline of each, and the pitch between them")
+    print("## Matched lines — x/y position of each spatial text instance")
     if not rows:
-        print("  none matched by unique text")
+        print("  no text instances matched")
         return
-    print(f"  {'page':>4} {'GT':>9} {'output':>9} {'delta':>8} "
-          f"{'GT pitch':>9} {'out pitch':>9}  text")
-    previous: tuple[float, float] | None = None
-    for reference, candidate in rows:
-        gt_pitch = "" if previous is None else f"{reference.y_min - previous[0]:9.2f}"
-        out_pitch = "" if previous is None else f"{candidate.y_min - previous[1]:9.2f}"
-        print(f"  {reference.page + 1:>4} {reference.y_min:9.2f} {candidate.y_min:9.2f} "
-              f"{candidate.y_min - reference.y_min:+8.2f} {gt_pitch:>9} {out_pitch:>9}  "
-              f"{reference.text[:44]}")
-        previous = (reference.y_min, candidate.y_min)
+    print(f"  {'page':>4} {'GT x':>8} {'out x':>8} {'dx':>8} "
+          f"{'GT y':>8} {'out y':>8} {'dy':>8}  text instance")
+    for match in rows:
+        reference = match.reference
+        candidate = match.candidate
+        print(
+            f"  {reference.page + 1:>4} {reference.x_min:8.2f} {candidate.x_min:8.2f} "
+            f"{match.dx:+8.2f} {reference.y_min:8.2f} {candidate.y_min:8.2f} "
+            f"{match.dy:+8.2f}  {match.label[:52]}"
+        )
 
 
 def main() -> None:
@@ -538,21 +757,39 @@ def main() -> None:
     parser.add_argument("--page", type=int, default=1)
     parser.add_argument("--dpi", type=int, default=150, help="at least 150")
     parser.add_argument(
+        "--large-shift",
+        type=float,
+        default=5.0,
+        metavar="PT",
+        help="flag any matched text instance whose x or y moves by more than this (default: 5pt)",
+    )
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="exit nonzero when a large per-instance text shift is found",
+    )
+    parser.add_argument(
+        "--artifacts-dir",
+        type=Path,
+        help="preserve full GT/output pages, 5%% diff, and large-shift crops for model vision",
+    )
+    parser.add_argument(
         "--lines",
         action="store_true",
-        help="list every matched line's baselines, so a single paragraph can be "
-        "inspected without hand-pairing text between the two PDFs",
+        help="list every matched text instance's x/y position without hand-pairing "
+        "repeated labels between the two PDFs",
     )
     args = parser.parse_args()
 
     if args.dpi < 150:
         raise SystemExit("--dpi must be at least 150; hairlines vanish below that")
+    require_vision_artifact_dependencies(args.artifacts_dir)
 
     print(f"GT     {args.gt}")
     print(f"output {args.output}")
     print(f"page {args.page} at {args.dpi} DPI\n")
 
-    geometry = report_geometry(args.gt, args.output)
+    geometry = report_geometry(args.gt, args.output, large_shift=args.large_shift)
     print()
     if args.lines:
         report_matched_lines(args.gt, args.output)
@@ -566,6 +803,26 @@ def main() -> None:
             histogram_result = report_histogram(gt_png, other_png)
             print()
             report_pixels(gt_png, other_png, out_dir)
+            if args.artifacts_dir is not None:
+                matches = match_text_line_instances(text_lines(args.gt), text_lines(args.output))
+                page_matches = [
+                    match
+                    for match in matches
+                    if match.reference.page == args.page - 1
+                    and (
+                        abs(match.dx) > args.large_shift
+                        or abs(match.dy) > args.large_shift
+                    )
+                ]
+                print()
+                preserve_vision_artifacts(
+                    gt_png,
+                    other_png,
+                    args.artifacts_dir,
+                    args.page,
+                    args.dpi,
+                    page_matches,
+                )
     else:
         print("## Histogram and pixel difference — SKIPPED")
         print("  ImageMagick is absent: neither `magick` (7.x) nor all of "
@@ -573,6 +830,13 @@ def main() -> None:
         print("  is on PATH. Install `imagemagick` to measure colour and ink.")
     print()
     diagnose(geometry, histogram_result)
+    if args.audit and geometry.get("large_shift_count", 0.0):
+        print()
+        print(
+            "AUDIT FAILED: large text-instance shifts are layout differences, not "
+            "antialiasing; inspect and track every line above."
+        )
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/spatial_match.py
+++ b/scripts/spatial_match.py
@@ -1,0 +1,92 @@
+"""Minimum-cost pairing for repeated visual elements.
+
+Text alone is not an identity: charts, legends, tables, and axes routinely
+repeat the same label.  Pair repeated instances by their two-dimensional
+positions so one displaced instance cannot disappear from a geometry report.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+
+Point = tuple[float, float]
+
+
+def minimum_cost_pairs(
+    references: Sequence[Point], candidates: Sequence[Point]
+) -> list[tuple[int, int]]:
+    """Return a minimum-total-distance one-to-one assignment.
+
+    The Hungarian algorithm handles rectangular groups and remains cheap for
+    pages containing many identical table values. Returned indexes always
+    address ``references`` first and ``candidates`` second.
+    """
+    if not references or not candidates:
+        return []
+
+    swapped = len(references) > len(candidates)
+    rows = candidates if swapped else references
+    columns = references if swapped else candidates
+    costs = [
+        [math.hypot(row[0] - column[0], row[1] - column[1]) for column in columns]
+        for row in rows
+    ]
+
+    # Rectangular Hungarian algorithm, with rows <= columns.
+    row_count = len(rows)
+    column_count = len(columns)
+    u = [0.0] * (row_count + 1)
+    v = [0.0] * (column_count + 1)
+    column_to_row = [0] * (column_count + 1)
+    previous_column = [0] * (column_count + 1)
+
+    for row_index in range(1, row_count + 1):
+        column_to_row[0] = row_index
+        current_column = 0
+        minimum = [math.inf] * (column_count + 1)
+        used = [False] * (column_count + 1)
+        while True:
+            used[current_column] = True
+            current_row = column_to_row[current_column]
+            delta = math.inf
+            next_column = 0
+            for column_index in range(1, column_count + 1):
+                if used[column_index]:
+                    continue
+                reduced = (
+                    costs[current_row - 1][column_index - 1]
+                    - u[current_row]
+                    - v[column_index]
+                )
+                if reduced < minimum[column_index]:
+                    minimum[column_index] = reduced
+                    previous_column[column_index] = current_column
+                if minimum[column_index] < delta:
+                    delta = minimum[column_index]
+                    next_column = column_index
+            for column_index in range(column_count + 1):
+                if used[column_index]:
+                    u[column_to_row[column_index]] += delta
+                    v[column_index] -= delta
+                else:
+                    minimum[column_index] -= delta
+            current_column = next_column
+            if column_to_row[current_column] == 0:
+                break
+        while True:
+            next_column = previous_column[current_column]
+            column_to_row[current_column] = column_to_row[next_column]
+            current_column = next_column
+            if current_column == 0:
+                break
+
+    pairs = [
+        (row_index - 1, column_index - 1)
+        for column_index, row_index in enumerate(column_to_row[1:], start=1)
+        if row_index
+    ]
+    if swapped:
+        pairs = [(column_index, row_index) for row_index, column_index in pairs]
+    return sorted(pairs)

--- a/scripts/tests/test_check_visual_pr.py
+++ b/scripts/tests/test_check_visual_pr.py
@@ -51,6 +51,7 @@ def visual_body(result_overrides=None, include_previews=True):
 - Renderer and DPI: pdftoppm, 150 DPI
 - Evidence mode: `fix`
 - New follow-up issues found in this audit: {follow_up_value}
+- Model vision findings: Full pages, pixel diff, and matched crops were opened; no untracked visual deviation remains.
 - GT: `assets/bugfixes/issue-186/gt.jpg`
 - Before: `assets/bugfixes/issue-186/before.jpg`
 - After: `assets/bugfixes/issue-186/after.jpg`
@@ -112,6 +113,46 @@ class PullRequestBodyTests(unittest.TestCase):
             ["assets/bugfixes/issue-186/after.jpg"],
         )
         self.assertTrue(any("rendered preview" in error for error in errors))
+
+    def test_visual_audit_requires_large_instance_shift_audit(self):
+        required = (
+            "- [x] Ran compare_layout.py --audit and dispositioned every "
+            "large text-instance shift"
+        )
+        errors = validate_pr_body(
+            visual_body().replace(required, required.replace("[x]", "[ ]")),
+            ["assets/bugfixes/issue-186/after.jpg"],
+        )
+        self.assertTrue(any("large text-instance shift" in error for error in errors))
+
+    def test_visual_audit_requires_model_vision_inspection(self):
+        required = (
+            "- [x] Used Codex/Claude vision to inspect the full GT/output pages, "
+            "diff, and matched crops"
+        )
+        errors = validate_pr_body(
+            visual_body().replace(required, required.replace("[x]", "[ ]")),
+            ["assets/bugfixes/issue-186/after.jpg"],
+        )
+        self.assertTrue(any("Codex/Claude vision" in error for error in errors))
+
+    def test_visual_audit_requires_substantive_model_vision_findings(self):
+        body = visual_body().replace(
+            "Model vision findings: Full pages, pixel diff, and matched crops were opened; "
+            "no untracked visual deviation remains.",
+            "Model vision findings: None",
+        )
+        errors = validate_pr_body(body, ["assets/bugfixes/issue-186/after.jpg"])
+        self.assertTrue(any("substantive direct inspection" in error for error in errors))
+
+    def test_visual_audit_rejects_numeric_only_model_vision_findings(self):
+        body = visual_body().replace(
+            "Model vision findings: Full pages, pixel diff, and matched crops were opened; "
+            "no untracked visual deviation remains.",
+            "Model vision findings: 123456789012345678901234567890",
+        )
+        errors = validate_pr_body(body, ["assets/bugfixes/issue-186/after.jpg"])
+        self.assertTrue(any("numeric metrics alone" in error for error in errors))
 
     def test_visual_audit_requires_distinct_preview_urls(self):
         body = visual_body().replace(

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -195,6 +195,7 @@ class MatchAndDiffTest(unittest.TestCase):
         self.assertEqual(vector["lines"]["missing"], 1)
         self.assertEqual(vector["lines"]["extra"], 0)
         self.assertIn("beta", vector["lines"]["missing_text"][0])
+        self.assertEqual(compare_layout.audit_failures([vector]), 1)
 
     def test_wrap_difference_is_detected_not_reported_missing(self) -> None:
         gt = "\n".join([line_of("abcdef", 72, 100), line_of("ghi", 72, 112)])
@@ -243,6 +244,28 @@ class MatchAndDiffTest(unittest.TestCase):
         self.assertEqual(vector["rects"]["gt_count"], 2)
         self.assertEqual(vector["rects"]["out_count"], 1)
 
+    def test_repeated_labels_are_spatially_matched_and_large_shifts_are_named(self) -> None:
+        gt = "\n".join(
+            [line_of("Sales", 337, 133), line_of("Sales", 553, 286)]
+        )
+        out = "\n".join(
+            [line_of("Sales", 457, 134), line_of("Sales", 526, 286)]
+        )
+
+        vector = self.diff(gt, out, large_shift=5.0)
+
+        self.assertEqual(vector["lines"]["matched"], 2)
+        self.assertEqual(vector["instances"]["large_shift_count"], 2)
+        self.assertEqual(
+            [item["label"] for item in vector["instances"]["large_shifts"]],
+            ["Sales [1/2]", "Sales [2/2]"],
+        )
+        self.assertEqual(
+            [round(item["dx"]) for item in vector["instances"]["large_shifts"]],
+            [120, -27],
+        )
+        self.assertEqual(compare_layout.audit_failures([vector]), 2)
+
 
 class ReadingTest(unittest.TestCase):
     def test_reading_mentions_wrap_and_missing_content(self) -> None:
@@ -255,6 +278,21 @@ class ReadingTest(unittest.TestCase):
         vector = compare_layout.diff_page(gt, out)
         reading = compare_layout.render_reading([vector])
         self.assertIn("wrap", reading.lower())
+
+    def test_reading_names_a_large_repeated_label_shift(self) -> None:
+        gt = compare_layout.parse_trace(
+            trace_document("\n".join([line_of("Sales", 337, 133), line_of("Sales", 553, 286)]))
+        )[0]
+        out = compare_layout.parse_trace(
+            trace_document("\n".join([line_of("Sales", 457, 134), line_of("Sales", 526, 286)]))
+        )[0]
+
+        reading = compare_layout.render_reading(
+            [compare_layout.diff_page(gt, out, large_shift=5.0)]
+        )
+
+        self.assertIn("Sales [1/2]", reading)
+        self.assertIn("+120.00pt", reading)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_compare_render.py
+++ b/scripts/tests/test_compare_render.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import sys
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from pathlib import Path
 from unittest import mock
 
@@ -110,6 +112,15 @@ class ImageMagickEntryPointTest(unittest.TestCase):
         with only_on_path("pdftoppm"):
             self.assertFalse(compare_render.has_imagemagick())
 
+    def test_requested_vision_artifacts_fail_if_imagemagick_is_absent(self) -> None:
+        with only_on_path("pdftoppm"):
+            with self.assertRaisesRegex(SystemExit, "--artifacts-dir requires ImageMagick"):
+                compare_render.require_vision_artifact_dependencies(Path("artifacts"))
+
+    def test_no_artifact_request_does_not_require_imagemagick(self) -> None:
+        with only_on_path("pdftoppm"):
+            compare_render.require_vision_artifact_dependencies(None)
+
 
 class DiagnoseWithoutColourTest(unittest.TestCase):
     """With no ImageMagick, two of three axes are missing, not agreeing."""
@@ -140,6 +151,69 @@ class DiagnoseWithoutColourTest(unittest.TestCase):
     def test_still_claims_agreement_when_every_axis_ran(self) -> None:
         report = self.render({"intersection": 1.0, "shift": 0.0, "ink_delta": 0.0})
         self.assertIn("No axis shows a material difference", report)
+
+    def test_element_shift_prevents_false_antialiasing_verdict(self) -> None:
+        self.geometry.update(
+            {
+                "large_shift_count": 1.0,
+                "large_shift_threshold": 5.0,
+                "worst_dx": 120.0,
+            }
+        )
+
+        report = self.render({"intersection": 1.0, "shift": 0.0, "ink_delta": 0.0})
+
+        self.assertIn("matched text instance", report)
+        self.assertNotIn("No axis shows a material difference", report)
+
+
+class RepeatedTextGeometryTest(unittest.TestCase):
+    """Repeated labels must be paired as spatial instances, never discarded."""
+
+    def setUp(self) -> None:
+        self.gt_lines = [
+            compare_render.TextLine(0, 337.0, 133.0, "Sales"),
+            compare_render.TextLine(0, 553.0, 286.0, "Sales"),
+        ]
+        self.output_lines = [
+            compare_render.TextLine(0, 457.0, 134.0, "Sales"),
+            compare_render.TextLine(0, 526.0, 286.0, "Sales"),
+        ]
+
+    def test_repeated_labels_are_matched_by_spatial_instance(self) -> None:
+        matches = compare_render.match_text_line_instances(self.gt_lines, self.output_lines)
+
+        self.assertEqual(len(matches), 2)
+        self.assertEqual([match.label for match in matches], ["Sales [1/2]", "Sales [2/2]"])
+        self.assertEqual([round(match.dx) for match in matches], [120, -27])
+
+    def test_report_names_the_displaced_repeated_instance(self) -> None:
+        with mock.patch.object(
+            compare_render, "text_lines", side_effect=[self.gt_lines, self.output_lines]
+        ):
+            output = StringIO()
+            with redirect_stdout(output):
+                result = compare_render.report_geometry(
+                    Path("gt.pdf"), Path("output.pdf"), large_shift=5.0
+                )
+
+        self.assertEqual(result["matched"], 2.0)
+        self.assertEqual(result["large_shift_count"], 2.0)
+        self.assertAlmostEqual(result["worst_dx"], 120.0)
+        self.assertIn("Sales [1/2]", output.getvalue())
+        self.assertIn("+120.00pt", output.getvalue())
+
+    def test_shift_crop_contains_both_repeated_label_locations(self) -> None:
+        match = compare_render.match_text_line_instances(self.gt_lines, self.output_lines)[0]
+
+        left, top, width, height = compare_render.shift_crop_box(
+            match, dpi=144, image_width=1440, image_height=1080
+        )
+
+        self.assertLessEqual(left, round(match.reference.x_min * 2))
+        self.assertGreaterEqual(left + width, round(match.candidate.x_min * 2))
+        self.assertLessEqual(top, round(match.reference.y_min * 2))
+        self.assertGreaterEqual(top + height, round(match.candidate.y_min * 2))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_spatial_match.py
+++ b/scripts/tests/test_spatial_match.py
@@ -1,0 +1,35 @@
+"""Tests for duplicate-instance minimum-cost spatial pairing."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from spatial_match import minimum_cost_pairs
+
+
+class MinimumCostPairsTest(unittest.TestCase):
+    def test_finds_global_assignment_instead_of_greedy_nearest(self) -> None:
+        # Greedy picks reference 0 -> candidate 0 (distance 4), stranding the
+        # second reference 11.18pt away. The global optimum crosses the pairs.
+        references = [(0.0, 0.0), (10.0, 0.0)]
+        candidates = [(4.0, 0.0), (0.0, 5.0)]
+
+        self.assertEqual(minimum_cost_pairs(references, candidates), [(0, 1), (1, 0)])
+
+    def test_rectangular_assignment_preserves_reference_indexes(self) -> None:
+        references = [(0.0, 0.0), (10.0, 0.0), (20.0, 0.0)]
+        candidates = [(1.0, 0.0), (19.0, 0.0)]
+
+        self.assertEqual(minimum_cost_pairs(references, candidates), [(0, 0), (2, 1)])
+
+    def test_empty_side_has_no_pairs(self) -> None:
+        self.assertEqual(minimum_cost_pairs([], [(1.0, 1.0)]), [])
+        self.assertEqual(minimum_cost_pairs([(1.0, 1.0)], []), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- match repeated text labels as separate spatial instances instead of discarding or sequence-pairing them
- report every large per-instance dx/dy and make --audit fail on unresolved text-layout findings
- preserve full pages, the 5% pixel diff, and matched crops for Codex/Claude vision inspection
- require visual PRs to record substantive model-vision findings, not numeric metrics alone

Replaying the PR #990 evidence now reports Sales [1/2] at dx +120.00pt and exits 1. The prior harness reported only six unique lines and silently excluded both Sales instances.

## Testing

- python3 -m unittest discover -s scripts/tests -p test_*.py: 94 passed
- cargo fmt --all -- --check: passed
- cargo test --workspace --all-targets: functional suites passed; six pre-existing 30s performance-ceiling tests exceeded the ceiling while the full suite ran concurrently, with measured totals 60.20s to 69.74s
- randomized the spatial matcher against brute-force optimal assignments for 5,000 groups
- replayed the PR #990 GT/output PDFs at 150 DPI; compare_layout.py --audit and compare_render.py --audit both exit 1 and name the +120.00pt title shift
- opened the generated full-page side-by-side, 5% diff, title crop, and all flagged crops with model vision

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Analysis harness, tests, documentation, and PR contract only; converter output is unchanged.