### PR TITLE
fix(tooling): scope render geometry by page

### DIFF
--- a/scripts/compare_render.py
+++ b/scripts/compare_render.py
@@ -279,10 +279,17 @@ def match_text_line_instances(
     )
 
 
-def report_geometry(gt: Path, other: Path, large_shift: float = 5.0) -> dict[str, float]:
+def page_text_lines(pdf: Path, page: int) -> list[TextLine]:
+    """Return only the requested 1-based page's text instances."""
+    return [line for line in text_lines(pdf) if line.page == page - 1]
+
+
+def report_geometry(
+    gt: Path, other: Path, page: int = 1, large_shift: float = 5.0
+) -> dict[str, float]:
     """Vertical and horizontal drift of spatially matched text instances."""
-    gt_text_lines = text_lines(gt)
-    other_text_lines = text_lines(other)
+    gt_text_lines = page_text_lines(gt, page)
+    other_text_lines = page_text_lines(other, page)
     matches = match_text_line_instances(gt_text_lines, other_text_lines)
     dy = [match.dy for match in matches]
     dx = [match.dx for match in matches]
@@ -724,7 +731,7 @@ def diagnose(
         print("  toward its true size overlaps GT less, not more.")
 
 
-def report_matched_lines(gt: Path, other: Path) -> None:
+def report_matched_lines(gt: Path, other: Path, page: int = 1) -> None:
     """Per-instance positions for every text line matched spatially.
 
     Aggregate drift says a page is wrong; this says which line. Pairing the two
@@ -732,7 +739,7 @@ def report_matched_lines(gt: Path, other: Path) -> None:
     matches the wrong line and produces impossible numbers, so the pairing here
     is the same duplicate-safe spatial match the geometry axis already trusts.
     """
-    rows = match_text_line_instances(text_lines(gt), text_lines(other))
+    rows = match_text_line_instances(page_text_lines(gt, page), page_text_lines(other, page))
 
     print("## Matched lines — x/y position of each spatial text instance")
     if not rows:
@@ -789,10 +796,12 @@ def main() -> None:
     print(f"output {args.output}")
     print(f"page {args.page} at {args.dpi} DPI\n")
 
-    geometry = report_geometry(args.gt, args.output, large_shift=args.large_shift)
+    geometry = report_geometry(
+        args.gt, args.output, page=args.page, large_shift=args.large_shift
+    )
     print()
     if args.lines:
-        report_matched_lines(args.gt, args.output)
+        report_matched_lines(args.gt, args.output, page=args.page)
         print()
     histogram_result: dict[str, float] | None = None
     if has_imagemagick():
@@ -804,15 +813,15 @@ def main() -> None:
             print()
             report_pixels(gt_png, other_png, out_dir)
             if args.artifacts_dir is not None:
-                matches = match_text_line_instances(text_lines(args.gt), text_lines(args.output))
+                matches = match_text_line_instances(
+                    page_text_lines(args.gt, args.page),
+                    page_text_lines(args.output, args.page),
+                )
                 page_matches = [
                     match
                     for match in matches
-                    if match.reference.page == args.page - 1
-                    and (
-                        abs(match.dx) > args.large_shift
-                        or abs(match.dy) > args.large_shift
-                    )
+                    if abs(match.dx) > args.large_shift
+                    or abs(match.dy) > args.large_shift
                 ]
                 print()
                 preserve_vision_artifacts(

--- a/scripts/tests/test_compare_render.py
+++ b/scripts/tests/test_compare_render.py
@@ -203,6 +203,28 @@ class RepeatedTextGeometryTest(unittest.TestCase):
         self.assertIn("Sales [1/2]", output.getvalue())
         self.assertIn("+120.00pt", output.getvalue())
 
+    def test_report_scopes_geometry_to_the_requested_page(self) -> None:
+        gt_lines = [
+            compare_render.TextLine(0, 10.0, 20.0, "First page"),
+            compare_render.TextLine(1, 30.0, 40.0, "Second page"),
+        ]
+        output_lines = [
+            compare_render.TextLine(0, 110.0, 120.0, "First page"),
+            compare_render.TextLine(1, 31.0, 42.0, "Second page"),
+        ]
+
+        with mock.patch.object(
+            compare_render, "text_lines", side_effect=[gt_lines, output_lines]
+        ):
+            result = compare_render.report_geometry(
+                Path("gt.pdf"), Path("output.pdf"), page=2, large_shift=5.0
+            )
+
+        self.assertEqual(result["matched"], 1.0)
+        self.assertEqual(result["large_shift_count"], 0.0)
+        self.assertAlmostEqual(result["worst_dx"], 1.0)
+        self.assertAlmostEqual(result["worst_dy"], 2.0)
+
     def test_shift_crop_contains_both_repeated_label_locations(self) -> None:
         match = compare_render.match_text_line_instances(self.gt_lines, self.output_lines)[0]
 


### PR DESCRIPTION
## Summary

- scope `compare_render.py` text geometry to the same 1-based `--page` used for raster/diff evidence
- scope the optional matched-line listing and large-shift crops through the same helper
- add a two-page regression proving a page-1 displacement cannot contaminate a page-2 audit

Closes #1007
Related to #841

## Root cause

The render and pixel axes consumed `args.page`, but `report_geometry` and `report_matched_lines` called `text_lines` over the complete PDFs. A page-specific run therefore attached document-wide text metrics to the correct page image.

## Testing

- TDD: the new page-scope regression first failed because `report_geometry` accepted no page argument
- `python3 -m unittest discover -s scripts/tests` (95 passed)

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: this changes audit-tool reporting only; office conversion and PDF rendering are untouched.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Documentation freshness audit passed
