### PR TITLE
fix(tooling): apply full text transforms

### DIFF
--- a/scripts/compare_render.py
+++ b/scripts/compare_render.py
@@ -45,7 +45,7 @@ WORD_RE = re.compile(
     re.S,
 )
 FILL_TEXT_RE = re.compile(
-    r'<fill_text[^>]*transform="([-0-9.]+) [-0-9.]+ [-0-9.]+ ([-0-9.]+) '
+    r'<fill_text[^>]*transform="([-0-9.]+) ([-0-9.]+) ([-0-9.]+) ([-0-9.]+) '
     r'([-0-9.]+) ([-0-9.]+)"[^>]*>(.*?)</fill_text>',
     re.S,
 )
@@ -149,15 +149,18 @@ def require_vision_artifact_dependencies(artifacts_dir: Path | None) -> None:
 
 
 def baseline_lines(pdf: Path) -> list[TextLine]:
-    """Text lines positioned by their true baseline, via `mutool draw -F trace`.
+    """Text-line anchors from `mutool draw -F trace` affine coordinates.
 
-    A `<fill_text>` carries the text-space matrix, so a glyph's baseline is
-    `ty + d * gy` and its x is `a * gx + tx`. Office exports on macOS place
-    text in a scaled space (`transform=".24 0 0 -.24 0 201.8"` with `trm="92"`
-    for 22pt text) while ours are plain translations; one formula covers both.
+    A `<fill_text>` carries the complete text-space matrix, so each glyph maps
+    to `x = a * gx + c * gy + tx` and `y = b * gx + d * gy + ty`. Office
+    exports on macOS often use scaled or rotated text spaces while ours are
+    commonly plain translations; the same affine formula covers both.
 
-    Baselines jitter by fractions of a point inside one visual line, so rows
-    are bucketed to 1pt before being joined.
+    For non-rotated text, baselines jitter by fractions of a point inside one
+    visual line, so rows are bucketed to 1pt before being joined. A rotated or
+    skewed `<fill_text>` is already one visual run and cannot share a horizontal
+    baseline bucket; it stays intact and uses the minimum transformed glyph
+    coordinates as its comparable spatial anchor.
     """
     trace = subprocess.run(
         ["mutool", "draw", "-F", "trace", "-o", "-", str(pdf)],
@@ -169,17 +172,38 @@ def baseline_lines(pdf: Path) -> list[TextLine]:
     lines: list[TextLine] = []
     for page_index, page in enumerate(TRACE_PAGE_RE.split(trace.stdout)[1:]):
         rows: dict[int, list[tuple[float, float, str]]] = {}
+        rotated_lines: list[TextLine] = []
         for match in FILL_TEXT_RE.finditer(page):
-            scale_x, scale_y = float(match.group(1)), float(match.group(2))
-            translate_x, translate_y = float(match.group(3)), float(match.group(4))
-            for glyph in GLYPH_RE.finditer(match.group(5)):
+            scale_x = float(match.group(1))
+            shear_y = float(match.group(2))
+            shear_x = float(match.group(3))
+            scale_y = float(match.group(4))
+            translate_x, translate_y = float(match.group(5)), float(match.group(6))
+            transformed_glyphs: list[tuple[float, float, str]] = []
+            for glyph in GLYPH_RE.finditer(match.group(7)):
                 char = glyph.group(1)
                 if not char.strip():
                     continue
-                baseline = translate_y + scale_y * float(glyph.group(3))
-                rows.setdefault(round(baseline), []).append(
-                    (translate_x + scale_x * float(glyph.group(2)), baseline, char)
-                )
+                glyph_x, glyph_y = float(glyph.group(2)), float(glyph.group(3))
+                x = translate_x + scale_x * glyph_x + shear_x * glyph_y
+                y = translate_y + shear_y * glyph_x + scale_y * glyph_y
+                transformed_glyphs.append((x, y, char))
+            if abs(shear_x) > 1e-9 or abs(shear_y) > 1e-9:
+                text = re.sub(
+                    r"\s+", " ", "".join(glyph[2] for glyph in transformed_glyphs)
+                ).strip()
+                if text:
+                    rotated_lines.append(
+                        TextLine(
+                            page_index,
+                            min(glyph[0] for glyph in transformed_glyphs),
+                            min(glyph[1] for glyph in transformed_glyphs),
+                            text,
+                        )
+                    )
+            else:
+                for x, baseline, char in transformed_glyphs:
+                    rows.setdefault(round(baseline), []).append((x, baseline, char))
         for key in sorted(rows):
             glyphs = sorted(rows[key])
             text = re.sub(r"\s+", " ", "".join(glyph[2] for glyph in glyphs)).strip()
@@ -196,6 +220,7 @@ def baseline_lines(pdf: Path) -> list[TextLine]:
                         text,
                     )
                 )
+        lines.extend(rotated_lines)
     return lines
 
 

--- a/scripts/tests/test_compare_render.py
+++ b/scripts/tests/test_compare_render.py
@@ -45,6 +45,21 @@ def text_op(char: str, x: float, baseline_y: float) -> str:
     )
 
 
+def rotated_text_op(text: str, origin_x: float, origin_y: float) -> str:
+    """One 45-degree fill_text whose glyphs share a text-space baseline."""
+    glyphs = "\n".join(
+        f'<g unicode="{char}" glyph="2" x="{index * 10}" y="100" adv=".5"/>'
+        for index, char in enumerate(text)
+    )
+    return (
+        '<fill_text transform=".70710678 -.70710678 .70710678 .70710678 '
+        f'{origin_x} {origin_y}">\n'
+        '<span font="AAAAAA+ArialMT" wmode="0" trm="44 0 0 44">\n'
+        f"{glyphs}\n"
+        "</span>\n</fill_text>"
+    )
+
+
 class TracePageSplitTest(unittest.TestCase):
     def test_splits_page_without_number_attribute(self) -> None:
         doc = trace_page(text_op("A", 72.0, 100.0), numbered=False)
@@ -62,6 +77,20 @@ class TracePageSplitTest(unittest.TestCase):
             ]
         )
         self.assertEqual(len(compare_render.TRACE_PAGE_RE.split(doc)[1:]), 2)
+
+
+class AffineTextPositionTest(unittest.TestCase):
+    def test_rotated_text_uses_the_complete_affine_transform(self) -> None:
+        trace = trace_page(rotated_text_op("AB", 500.0, 600.0), numbered=True)
+
+        with mock.patch.object(compare_render.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=0, stdout=trace)
+            lines = compare_render.baseline_lines(Path("rotated.pdf"))
+
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0].text, "AB")
+        self.assertAlmostEqual(lines[0].x_min, 570.710678, places=5)
+        self.assertAlmostEqual(lines[0].y_min, 663.6396102, places=5)
 
 
 def only_on_path(*names: str):


### PR DESCRIPTION
## Summary

- apply every term of mutool's six-value affine text transform
- keep each rotated/skewed `fill_text` run intact with a comparable transformed anchor
- add a focused 45-degree trace regression

Closes #1009
Related to #841

## Root cause

The geometry harness used only `a`, `d`, `e`, and `f` from `transform="a b c d e f"`. Dropping `b` and `c` put diagonal PowerPoint chart labels hundreds of points away from their visible location and generated false large-shift findings.

## Testing

- TDD: the rotated trace regression first reported x = 500pt instead of 570.710678pt
- `python3 -m unittest discover -s scripts/tests` (96 passed)
- live slide-14 recheck: the false off-page `Bruttofortjeneste` x coordinate changed from 1023.85pt to its rendered 642.01pt anchor

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: this changes audit-tool coordinate extraction only; office conversion and PDF rendering are untouched.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Documentation freshness audit passed
