### PR TITLE
fix(tooling): apply full text transforms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,14 +181,17 @@ producing the files is not itself inspection.
 
 For layout defects, run `python3 scripts/compare_layout.py <GT.pdf> <output.pdf> --audit`
 first: it matches text lines from `mutool` traces and reports missing/extra/
-re-wrapped lines, baseline dy, pitch and width drift, and a rect census, with
-GT noise floors built in (`--noise-floor 0.12` Word, `0.5` Excel). Its numbers
-are assertable; pixel counts are only a tripwire. Repeated strings are matched
-as separate spatial instances: a chart title and legend both named `Sales`
-appear as `Sales [1/2]` and `Sales [2/2]`, with their own `dx`/`dy`. The audit
-exits nonzero when any instance moves more than 5pt (override with
-`--large-shift PT` for a justified fixture-specific threshold); inspect and
-track every named instance before marking alignment as matching.
+re-wrapped lines, spatial-anchor dy, pitch and width drift, and a rect census,
+with GT noise floors built in (`--noise-floor 0.12` Word, `0.5` Excel).
+Horizontal text uses its true baseline; a rotated or skewed `fill_text` stays
+one visual run and uses the minimum fully transformed glyph x/y as its
+comparable anchor. Its numbers are assertable; pixel counts are only a
+tripwire. Repeated strings are matched as separate spatial instances: a chart
+title and legend both named `Sales` appear as `Sales [1/2]` and `Sales [2/2]`,
+with their own `dx`/`dy`. The audit exits nonzero when any instance moves more
+than 5pt (override with `--large-shift PT` for a justified fixture-specific
+threshold); inspect and track every named instance before marking alignment as
+matching.
 
 **Its width column measures origin-to-origin and so counts invisible trailing
 glyphs.** Word emits a trailing space after a paragraph's last character where

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -7,8 +7,10 @@ lines by their text, and reports typed deviations:
 
 - matched / missing / extra lines, and wrap-point differences (text that is
   present but breaks at a different word) counted separately from real loss;
-- baseline dy statistics, per-line dx0, line-width drift, inter-line pitch
-  deltas between consecutive matched lines;
+- spatial-anchor dy statistics, per-line dx0, line-width drift, inter-line
+  pitch deltas between consecutive matched lines. Horizontal text uses its
+  true baseline; a rotated or skewed `fill_text` stays one visual run and uses
+  the minimum fully transformed glyph x/y as its comparable anchor;
 - a fill/stroke rect census with nearest-match position deltas.
 
 A noise floor (default 0.12pt — native Word exports quantise coordinates to a
@@ -98,12 +100,11 @@ class Line:
 
     @property
     def x0(self) -> float:
-        return self.glyphs[0].x
+        return min(glyph.x for glyph in self.glyphs)
 
     @property
     def x1(self) -> float:
-        last = self.glyphs[-1]
-        return last.x + last.advance
+        return max(glyph.x + glyph.advance for glyph in self.glyphs)
 
     @property
     def width(self) -> float:
@@ -134,34 +135,55 @@ def parse_trace(trace_xml: str) -> list[PageLayout]:
     for page_match in PAGE_RE.finditer(trace_xml):
         content = page_match.group(1)
         glyphs: list[Glyph] = []
+        rotated_lines: list[Line] = []
         for op_attrs, op_body in FILL_TEXT_RE.findall(content):
             transform = parse_transform(op_attrs)
             if transform is None:
                 continue
-            a, _b, _c, d, e, f = transform
+            a, b, c, d, e, f = transform
+            transformed_run: list[Glyph] = []
             for span_attrs, span_body in SPAN_RE.findall(op_body):
                 trm = TRM_RE.search(span_attrs)
                 size_units = float(trm.group(1)) if trm else 0.0
-                size_pt = abs(size_units * a)
+                size_pt = abs(size_units) * (a * a + b * b) ** 0.5
                 for unicode_char, gx, gy, adv in GLYPH_RE.findall(span_body):
-                    glyphs.append(
+                    glyph_x = float(gx)
+                    glyph_y = float(gy)
+                    transformed_run.append(
                         Glyph(
-                            x=a * float(gx) + e,
-                            y=d * float(gy) + f,
+                            x=a * glyph_x + c * glyph_y + e,
+                            y=b * glyph_x + d * glyph_y + f,
                             unicode=unescape(unicode_char),
                             size=size_pt,
-                            advance=float(adv) * size_units * abs(a),
+                            advance=abs(float(adv) * size_units * a),
                         )
                     )
+            if not transformed_run:
+                continue
+            if abs(b) > 1e-9 or abs(c) > 1e-9:
+                # A rotated/skewed fill_text is already one visual run. Its
+                # glyphs have different device y coordinates by construction;
+                # feeding them into horizontal baseline bucketing fragments
+                # one label into many lines and invents off-page shifts.
+                rotated_lines.append(
+                    Line(
+                        y=min(glyph.y for glyph in transformed_run),
+                        glyphs=transformed_run,
+                    )
+                )
+            else:
+                glyphs.extend(transformed_run)
         rects: list[Rect] = []
         for kind, op_attrs, op_body in PATH_RE.findall(content):
             transform = parse_transform(op_attrs) or (1, 0, 0, 1, 0, 0)
-            a, _b, _c, d, e, f = transform
+            a, b, c, d, e, f = transform
             xs: list[float] = []
             ys: list[float] = []
             for px, py in POINT_RE.findall(op_body):
-                xs.append(a * float(px) + e)
-                ys.append(d * float(py) + f)
+                point_x = float(px)
+                point_y = float(py)
+                xs.append(a * point_x + c * point_y + e)
+                ys.append(b * point_x + d * point_y + f)
             if xs:
                 rects.append(
                     Rect(
@@ -172,7 +194,10 @@ def parse_trace(trace_xml: str) -> list[PageLayout]:
                         y1=max(ys),
                     )
                 )
-        pages.append(PageLayout(lines=build_lines(glyphs), rects=rects))
+        lines = build_lines(glyphs)
+        lines.extend(rotated_lines)
+        lines.sort(key=lambda line: (line.y, line.x0))
+        pages.append(PageLayout(lines=lines, rects=rects))
     return pages
 
 

--- a/scripts/compare_render.py
+++ b/scripts/compare_render.py
@@ -45,7 +45,7 @@ WORD_RE = re.compile(
     re.S,
 )
 FILL_TEXT_RE = re.compile(
-    r'<fill_text[^>]*transform="([-0-9.]+) [-0-9.]+ [-0-9.]+ ([-0-9.]+) '
+    r'<fill_text[^>]*transform="([-0-9.]+) ([-0-9.]+) ([-0-9.]+) ([-0-9.]+) '
     r'([-0-9.]+) ([-0-9.]+)"[^>]*>(.*?)</fill_text>',
     re.S,
 )
@@ -149,15 +149,18 @@ def require_vision_artifact_dependencies(artifacts_dir: Path | None) -> None:
 
 
 def baseline_lines(pdf: Path) -> list[TextLine]:
-    """Text lines positioned by their true baseline, via `mutool draw -F trace`.
+    """Text-line anchors from `mutool draw -F trace` affine coordinates.
 
-    A `<fill_text>` carries the text-space matrix, so a glyph's baseline is
-    `ty + d * gy` and its x is `a * gx + tx`. Office exports on macOS place
-    text in a scaled space (`transform=".24 0 0 -.24 0 201.8"` with `trm="92"`
-    for 22pt text) while ours are plain translations; one formula covers both.
+    A `<fill_text>` carries the complete text-space matrix, so each glyph maps
+    to `x = a * gx + c * gy + tx` and `y = b * gx + d * gy + ty`. Office
+    exports on macOS often use scaled or rotated text spaces while ours are
+    commonly plain translations; the same affine formula covers both.
 
-    Baselines jitter by fractions of a point inside one visual line, so rows
-    are bucketed to 1pt before being joined.
+    For non-rotated text, baselines jitter by fractions of a point inside one
+    visual line, so rows are bucketed to 1pt before being joined. A rotated or
+    skewed `<fill_text>` is already one visual run and cannot share a horizontal
+    baseline bucket; it stays intact and uses the minimum transformed glyph
+    coordinates as its comparable spatial anchor.
     """
     trace = subprocess.run(
         ["mutool", "draw", "-F", "trace", "-o", "-", str(pdf)],
@@ -169,17 +172,38 @@ def baseline_lines(pdf: Path) -> list[TextLine]:
     lines: list[TextLine] = []
     for page_index, page in enumerate(TRACE_PAGE_RE.split(trace.stdout)[1:]):
         rows: dict[int, list[tuple[float, float, str]]] = {}
+        rotated_lines: list[TextLine] = []
         for match in FILL_TEXT_RE.finditer(page):
-            scale_x, scale_y = float(match.group(1)), float(match.group(2))
-            translate_x, translate_y = float(match.group(3)), float(match.group(4))
-            for glyph in GLYPH_RE.finditer(match.group(5)):
+            scale_x = float(match.group(1))
+            shear_y = float(match.group(2))
+            shear_x = float(match.group(3))
+            scale_y = float(match.group(4))
+            translate_x, translate_y = float(match.group(5)), float(match.group(6))
+            transformed_glyphs: list[tuple[float, float, str]] = []
+            for glyph in GLYPH_RE.finditer(match.group(7)):
                 char = glyph.group(1)
                 if not char.strip():
                     continue
-                baseline = translate_y + scale_y * float(glyph.group(3))
-                rows.setdefault(round(baseline), []).append(
-                    (translate_x + scale_x * float(glyph.group(2)), baseline, char)
-                )
+                glyph_x, glyph_y = float(glyph.group(2)), float(glyph.group(3))
+                x = translate_x + scale_x * glyph_x + shear_x * glyph_y
+                y = translate_y + shear_y * glyph_x + scale_y * glyph_y
+                transformed_glyphs.append((x, y, char))
+            if abs(shear_x) > 1e-9 or abs(shear_y) > 1e-9:
+                text = re.sub(
+                    r"\s+", " ", "".join(glyph[2] for glyph in transformed_glyphs)
+                ).strip()
+                if text:
+                    rotated_lines.append(
+                        TextLine(
+                            page_index,
+                            min(glyph[0] for glyph in transformed_glyphs),
+                            min(glyph[1] for glyph in transformed_glyphs),
+                            text,
+                        )
+                    )
+            else:
+                for x, baseline, char in transformed_glyphs:
+                    rows.setdefault(round(baseline), []).append((x, baseline, char))
         for key in sorted(rows):
             glyphs = sorted(rows[key])
             text = re.sub(r"\s+", " ", "".join(glyph[2] for glyph in glyphs)).strip()
@@ -196,6 +220,7 @@ def baseline_lines(pdf: Path) -> list[TextLine]:
                         text,
                     )
                 )
+        lines.extend(rotated_lines)
     return lines
 
 

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -140,6 +140,27 @@ class ParseTraceTest(unittest.TestCase):
         texts = [line.text for line in pages[0].lines]
         self.assertEqual(texts, ["AB", "C"])
 
+    def test_rotated_fill_text_uses_the_full_affine_transform_and_stays_one_run(self) -> None:
+        page = """<fill_text transform="1 2 3 4 5 6">
+          <span font="AAAAAA+ArialMT" trm="10 0 0 10">
+            <g unicode="A" glyph="A" x="7" y="11" adv=".5"/>
+            <g unicode="B" glyph="B" x="8" y="11" adv=".5"/>
+          </span>
+        </fill_text>"""
+        lines = compare_layout.parse_trace(trace_document(page))[0].lines
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0].text, "AB")
+        self.assertAlmostEqual(lines[0].x0, 45.0)
+        self.assertAlmostEqual(lines[0].y, 64.0)
+
+    def test_rect_bbox_uses_the_full_affine_transform(self) -> None:
+        page = """<fill_path transform="1 2 3 4 5 6">
+          <moveto x="7" y="11"/>
+          <lineto x="8" y="12"/>
+        </fill_path>"""
+        rect = compare_layout.parse_trace(trace_document(page))[0].rects[0]
+        self.assertEqual((rect.x0, rect.y0, rect.x1, rect.y1), (45.0, 64.0, 49.0, 70.0))
+
     def test_rects_capture_device_bbox_and_kind(self) -> None:
         page = "\n".join(
             [rect_op(69.36, 792.96, 525.84, 793.44), rect_op(10, 20, 30, 21, "stroke_path")]

--- a/scripts/tests/test_compare_render.py
+++ b/scripts/tests/test_compare_render.py
@@ -45,6 +45,21 @@ def text_op(char: str, x: float, baseline_y: float) -> str:
     )
 
 
+def rotated_text_op(text: str, origin_x: float, origin_y: float) -> str:
+    """One 45-degree fill_text whose glyphs share a text-space baseline."""
+    glyphs = "\n".join(
+        f'<g unicode="{char}" glyph="2" x="{index * 10}" y="100" adv=".5"/>'
+        for index, char in enumerate(text)
+    )
+    return (
+        '<fill_text transform=".70710678 -.70710678 .70710678 .70710678 '
+        f'{origin_x} {origin_y}">\n'
+        '<span font="AAAAAA+ArialMT" wmode="0" trm="44 0 0 44">\n'
+        f"{glyphs}\n"
+        "</span>\n</fill_text>"
+    )
+
+
 class TracePageSplitTest(unittest.TestCase):
     def test_splits_page_without_number_attribute(self) -> None:
         doc = trace_page(text_op("A", 72.0, 100.0), numbered=False)
@@ -62,6 +77,20 @@ class TracePageSplitTest(unittest.TestCase):
             ]
         )
         self.assertEqual(len(compare_render.TRACE_PAGE_RE.split(doc)[1:]), 2)
+
+
+class AffineTextPositionTest(unittest.TestCase):
+    def test_rotated_text_uses_the_complete_affine_transform(self) -> None:
+        trace = trace_page(rotated_text_op("AB", 500.0, 600.0), numbered=True)
+
+        with mock.patch.object(compare_render.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=0, stdout=trace)
+            lines = compare_render.baseline_lines(Path("rotated.pdf"))
+
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0].text, "AB")
+        self.assertAlmostEqual(lines[0].x_min, 570.710678, places=5)
+        self.assertAlmostEqual(lines[0].y_min, 663.6396102, places=5)
 
 
 def only_on_path(*names: str):


### PR DESCRIPTION
## Summary

- preserve every affine component from `mutool draw -F trace` text transforms
- transform glyph coordinates with the full PDF matrix before comparing positions
- keep rotated/skewed text as one spatial instance, while retaining baseline grouping for ordinary text
- add a 45-degree regression trace that previously invented off-page coordinates

## Related issue

Fixes #1009

## Testing

- `uv run pytest -q scripts/tests/test_compare_render.py` (96 passed)

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: This changes only the visual comparison harness; converter output is unchanged.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
