### PR TITLE
feat(tooling): census diff clusters in render comparison

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -71,6 +71,7 @@
 | Rotation/flip | <!-- status --> |
 | Fill | <!-- status --> |
 | Stroke/border | <!-- status --> |
+| Shape outline geometry | <!-- status --> |
 | Text content | <!-- status --> |
 | Font family/weight/style | <!-- status --> |
 | Text color | <!-- status --> |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ This project follows a **6-month rolling MSRV policy** (aligned with [tokio](htt
 
 ### Visual check discipline (harness rules)
 
-- **Enumerate before fixing.** For every compared page, walk this checklist and record each deviation before touching code: page count/order; element presence; position; size; rotation/flip; fill; stroke/border (incl. dash style); text content; font family/weight/style; text color; alignment; line/paragraph spacing; clipping/overflow.
+- **Enumerate before fixing.** For every compared page, walk this checklist and record each deviation before touching code: page count/order; element presence; position; size; rotation/flip; fill; stroke/border (incl. dash style); shape outline geometry (corner rounding, curved edges — a panel drawn as its bounding box, #1029); text content; font family/weight/style; text color; alignment; line/paragraph spacing; clipping/overflow.
 - **One issue per root cause.** When one image reveals multiple independent defects, file a separate issue for each — never bundle them into one issue or one PR. Fix them sequentially.
 - **Closing condition.** An issue may be closed only when a fresh GT comparison shows its specific defect gone. Every remaining visible deviation on that comparison must already have its own open issue — file the missing ones before closing.
 - **After images are re-audited.** When posting an after image, re-run the checklist on it; each still-visible deviation gets an issue reference in the PR body ("remaining, tracked in #N").
@@ -234,6 +234,13 @@ cut the error from 86pt to 4.4pt barely moved it, because re-proportioning
 columns changes where pixels are, not how many differ. Use `RMSE` or
 `AE -fuzz 1%` when magnitude matters, and treat all of them as a regression
 tripwire rather than evidence.
+
+The script's **Diff clusters** section localises that count: contiguous mask
+regions with bounding boxes in points, largest first. Disposition every listed
+cluster — an accepted rendering difference or an issue reference. The two
+~5,100pt² corner clusters of #1029 sailed through a bare 84,400-pixel count;
+the census names them and their page region, and text-line geometry cannot see
+them at all.
 
 **Text layer (`scripts/compare_text_layer.py`)** is a fourth axis none of the
 three above can see. Some defects change what a reader can select and search

--- a/scripts/check_visual_pr.py
+++ b/scripts/check_visual_pr.py
@@ -32,6 +32,7 @@ AUDIT_ROWS = (
     "Rotation/flip",
     "Fill",
     "Stroke/border",
+    "Shape outline geometry",
     "Text content",
     "Font family/weight/style",
     "Text color",

--- a/scripts/compare_render.py
+++ b/scripts/compare_render.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Compare a rendered PDF against a native Office export on three axes.
+"""Compare a rendered PDF against a native Office export across several axes.
 
 No single measure is trustworthy alone, and each one's blind spot is
 another's strength:
@@ -16,6 +16,11 @@ another's strength:
   differing pixels without weighing how different they are, so it scores a
   layout shift and a colour inversion alike, and it can *rise* when a fix is
   correct but the element is still displaced by an unrelated defect.
+- **Diff clusters** localise the pixel axis: the 5%-fuzz mask's contiguous
+  regions, each with a bounding box in points. A bare count let #1029's
+  squared-off panel corners survive an audit — two ~5,100pt² regions hiding
+  inside one number. Every listed cluster must be dispositioned: an accepted
+  rendering difference, or an issue.
 
 Read them together. A fix that improves geometry while leaving the
 histogram flat has moved something without changing what is drawn, which is
@@ -58,6 +63,20 @@ HISTOGRAM_BINS = 32
 # Every ImageMagick tool the colour and pixel axes reach for. Named here so the
 # availability check and the call sites cannot drift apart.
 IMAGEMAGICK_TOOLS = ("convert", "identify", "compare")
+# A diff region smaller than this is glyph antialiasing, not a defect: a 20pt²
+# cluster is roughly one 4.5pt-square blob. Everything at or above it is
+# listed for disposition.
+CLUSTER_MIN_AREA_PT2 = 20.0
+CLUSTER_REPORT_LIMIT = 12
+# One contiguous region this large is never rasterisation noise. #1029's
+# squared-off panel corners measured ~5,100pt² each while every axis said the
+# pages agreed; this threshold is what turns such a region into a finding.
+CLUSTER_DOMINANT_AREA_PT2 = 500.0
+COMPONENT_LINE_RE = re.compile(
+    r"^\s*\d+:\s+(?P<w>\d+)x(?P<h>\d+)\+(?P<x>\d+)\+(?P<y>\d+)\s+"
+    r"(?P<cx>[\d.eE+-]+),(?P<cy>[\d.eE+-]+)\s+(?P<area>[\d.eE+]+)\s+"
+    r"(?P<color>\S.*)$"
+)
 
 
 @dataclass(frozen=True)
@@ -88,6 +107,18 @@ class TextLineMatch:
     @property
     def dy(self) -> float:
         return self.candidate.y_min - self.reference.y_min
+
+
+@dataclass(frozen=True)
+class DiffCluster:
+    """One contiguous region of differing pixels, in page points."""
+
+    x_pt: float
+    y_pt: float
+    width_pt: float
+    height_pt: float
+    area_pt2: float
+    region: str
 
 
 def render_page(pdf: Path, page: int, dpi: int, out_dir: Path, role: str) -> Path:
@@ -468,8 +499,12 @@ def cumulative_distance(reference: list[float], candidate: list[float]) -> float
     return total / (channels * HISTOGRAM_BINS)
 
 
-def report_pixels(gt_png: Path, other_png: Path, out_dir: Path) -> None:
-    """Whole-page difference, as a coarse catch-all."""
+def report_pixels(gt_png: Path, other_png: Path, out_dir: Path) -> Path:
+    """Whole-page difference, as a coarse catch-all.
+
+    Returns the size-normalised GT so the cluster census compares the same
+    pair of images the counts above were measured on.
+    """
     normalised = out_dir / "gt-normalised.png"
     size = subprocess.run(
         [*(imagemagick_command("identify") or []), "-format", "%wx%h", str(other_png)],
@@ -495,6 +530,133 @@ def report_pixels(gt_png: Path, other_png: Path, out_dir: Path) -> None:
             capture_output=True, text=True,
         )
         print(f"  {label}      {result.stderr.strip()}")
+    return normalised
+
+
+def component_is_white(color: str) -> bool:
+    """Whether a connected-component mean colour reads as mask-white.
+
+    The mask is binary, but `area-threshold` merges sub-threshold specks into
+    their neighbour, leaving near-pure means such as `gray(254.7)`; percentages
+    appear when a build reports srgba. Thresholding at half intensity accepts
+    both without enumerating ImageMagick's colour spellings.
+    """
+    value = re.search(r"([\d.]+)", color)
+    if value is None:
+        return False
+    return float(value.group(1)) > (50.0 if "%" in color else 127.5)
+
+
+def page_region(cx: float, cy: float, width: float, height: float) -> str:
+    """Name the page third a centroid falls in, e.g. `bottom-right`."""
+    column = "left" if cx < width / 3 else "right" if cx > 2 * width / 3 else "center"
+    row = "top" if cy < height / 3 else "bottom" if cy > 2 * height / 3 else "middle"
+    if row == "middle":
+        return "center" if column == "center" else column
+    return row if column == "center" else f"{row}-{column}"
+
+
+def parse_diff_clusters(
+    verbose: str, dpi: int, min_area_pt2: float = CLUSTER_MIN_AREA_PT2
+) -> list[DiffCluster]:
+    """White connected components of the diff mask, largest first, in points.
+
+    The page extent comes from the union of every component's bounding box:
+    the black background component normally spans the full page, and when it
+    does not, the union still bounds everything that was compared.
+    """
+    scale = 72.0 / dpi
+    components: list[tuple[float, float, float, float, float, float, float]] = []
+    page_width = page_height = 0.0
+    for line in verbose.splitlines():
+        match = COMPONENT_LINE_RE.match(line)
+        if match is None:
+            continue
+        x, y = float(match.group("x")), float(match.group("y"))
+        w, h = float(match.group("w")), float(match.group("h"))
+        page_width = max(page_width, x + w)
+        page_height = max(page_height, y + h)
+        if not component_is_white(match.group("color")):
+            continue
+        components.append(
+            (x, y, w, h, float(match.group("cx")), float(match.group("cy")),
+             float(match.group("area")))
+        )
+    clusters = [
+        DiffCluster(
+            x_pt=x * scale,
+            y_pt=y * scale,
+            width_pt=w * scale,
+            height_pt=h * scale,
+            area_pt2=area * scale * scale,
+            region=page_region(cx, cy, page_width, page_height),
+        )
+        for x, y, w, h, cx, cy, area in components
+        if area * scale * scale >= min_area_pt2
+    ]
+    clusters.sort(key=lambda cluster: cluster.area_pt2, reverse=True)
+    return clusters
+
+
+def diff_cluster_census(
+    gt_png: Path, other_png: Path, out_dir: Path, dpi: int
+) -> list[DiffCluster] | None:
+    """Label the 5%-fuzz diff mask's contiguous regions, or None if unsupported.
+
+    A single-pixel morphological open drops isolated antialiasing specks first,
+    and 4-connectivity keeps diagonally-touching glyph noise from chaining into
+    one page-spanning blob the way 8-connectivity does. `area-threshold` merges
+    the sub-25px remnants so the verbose listing stays bounded.
+    """
+    mask = out_dir / "diff-mask.png"
+    # `compare` exits 1 whenever the images differ; only a missing mask is
+    # a failure.
+    subprocess.run(
+        [*(imagemagick_command("compare") or []), "-metric", "AE", "-fuzz", "5%",
+         "-compose", "src", "-highlight-color", "white", "-lowlight-color",
+         "black", str(gt_png), str(other_png), str(mask)],
+        capture_output=True,
+    )
+    if not mask.is_file():
+        return None
+    census = subprocess.run(
+        [*(imagemagick_command("convert") or []), str(mask),
+         "-morphology", "Open", "Square:1",
+         "-define", "connected-components:verbose=true",
+         "-define", "connected-components:area-threshold=25",
+         "-connected-components", "4", "null:"],
+        capture_output=True,
+        text=True,
+    )
+    if census.returncode != 0:
+        return None
+    # The objects listing has moved between stdout and stderr across
+    # ImageMagick releases; parse both.
+    return parse_diff_clusters(census.stdout + census.stderr, dpi)
+
+
+def report_diff_clusters(clusters: list[DiffCluster] | None) -> None:
+    """List every contiguous diff region large enough to need a disposition."""
+    print("## Diff clusters — where the differing pixels sit")
+    if clusters is None:
+        print("  SKIPPED: this ImageMagick build lacks -connected-components;")
+        print("  inspect the diff image by eye and disposition each region.")
+        return
+    if not clusters:
+        print(f"  none of {CLUSTER_MIN_AREA_PT2:.0f}pt² or more — what differs is")
+        print("  dispersed specks (glyph rasterisation and antialiasing).")
+        return
+    print("  Disposition every cluster: an accepted rendering difference (glyph")
+    print("  rasterisation) or an issue reference. A cluster hugging a shape's")
+    print("  corner or edge while colour and position agree is outline geometry —")
+    print("  compare the shape's path, not its fill or its box (#1029).")
+    for index, cluster in enumerate(clusters[:CLUSTER_REPORT_LIMIT], start=1):
+        print(f"  {index:>2}. {cluster.width_pt:6.1f} x {cluster.height_pt:6.1f}pt "
+              f"at ({cluster.x_pt:6.1f}, {cluster.y_pt:6.1f})  "
+              f"area {cluster.area_pt2:7.0f}pt2  {cluster.region}")
+    if len(clusters) > CLUSTER_REPORT_LIMIT:
+        print(f"  … and {len(clusters) - CLUSTER_REPORT_LIMIT} more of "
+              f"{CLUSTER_MIN_AREA_PT2:.0f}pt2 or more")
 
 
 def shift_crop_box(
@@ -630,7 +792,9 @@ def preserve_vision_artifacts(
 
 
 def diagnose(
-    geometry: dict[str, float], histogram_result: dict[str, float] | None
+    geometry: dict[str, float],
+    histogram_result: dict[str, float] | None,
+    clusters: list[DiffCluster] | None = None,
 ) -> None:
     """Say what the combination of axes means, and what to look at next.
 
@@ -734,6 +898,24 @@ def diagnose(
             "colours but at the wrong size, or a font renders at a different "
             "weight."
         )
+    dominant = [
+        cluster
+        for cluster in (clusters or [])
+        if cluster.area_pt2 >= CLUSTER_DOMINANT_AREA_PT2
+    ]
+    if dominant:
+        largest = dominant[0]
+        findings.append(
+            f"A contiguous diff cluster of {largest.area_pt2:.0f}pt2 sits at "
+            f"({largest.x_pt:.0f}, {largest.y_pt:.0f}) ({largest.region})"
+            + (f", plus {len(dominant) - 1} more of {CLUSTER_DOMINANT_AREA_PT2:.0f}pt2 or larger"
+               if len(dominant) > 1 else "")
+            + " — a structural difference: a missing element, a displaced "
+            "block, or a shape outline (rounded corner, curved edge) drawn as "
+            "its bounding box. The per-line geometry above only measures text, "
+            "so it cannot see this; disposition the cluster before concluding "
+            "the pages agree."
+        )
 
     if not findings:
         print("  No axis shows a material difference. What remains is font")
@@ -829,6 +1011,7 @@ def main() -> None:
         report_matched_lines(args.gt, args.output, page=args.page)
         print()
     histogram_result: dict[str, float] | None = None
+    clusters: list[DiffCluster] | None = None
     if has_imagemagick():
         with tempfile.TemporaryDirectory() as raw_dir:
             out_dir = Path(raw_dir)
@@ -836,7 +1019,10 @@ def main() -> None:
             other_png = render_page(args.output, args.page, args.dpi, out_dir, "candidate")
             histogram_result = report_histogram(gt_png, other_png)
             print()
-            report_pixels(gt_png, other_png, out_dir)
+            normalised = report_pixels(gt_png, other_png, out_dir)
+            print()
+            clusters = diff_cluster_census(normalised, other_png, out_dir, args.dpi)
+            report_diff_clusters(clusters)
             if args.artifacts_dir is not None:
                 matches = match_text_line_instances(
                     page_text_lines(args.gt, args.page),
@@ -863,7 +1049,7 @@ def main() -> None:
               f"{', '.join(f'`{tool}`' for tool in IMAGEMAGICK_TOOLS)} (6.x)")
         print("  is on PATH. Install `imagemagick` to measure colour and ink.")
     print()
-    diagnose(geometry, histogram_result)
+    diagnose(geometry, histogram_result, clusters)
     if args.audit and geometry.get("large_shift_count", 0.0):
         print()
         print(

--- a/scripts/tests/test_compare_render.py
+++ b/scripts/tests/test_compare_render.py
@@ -267,5 +267,126 @@ class RepeatedTextGeometryTest(unittest.TestCase):
         self.assertGreaterEqual(top + height, round(match.candidate.y_min * 2))
 
 
+class DiffClusterParseTest(unittest.TestCase):
+    """The cluster census turns the diff mask into dispositionable regions.
+
+    Issue #1029's squared-off panel corners survived a 5% fuzz sweep because
+    the sweep printed one count for the whole page; nothing named where the
+    differing pixels sat. The census parses ImageMagick's
+    connected-components listing so each contiguous diff region becomes a
+    line item with coordinates.
+    """
+
+    # Verbatim shape of `-define connected-components:verbose=true` output.
+    # Component 0 is the black background, 235/257 are the #1029 corner
+    # clusters, 2 is a glyph-rasterisation blob, 99 is a sub-threshold speck.
+    VERBOSE = "\n".join(
+        [
+            "Objects (id: bounding-box centroid area mean-color):",
+            "  0: 2000x1125+0+0 987.4,553.9 2.2002e+06 gray(0)",
+            "  235: 203x329+1797+796 1941.2,1038.4 22130 gray(255)",
+            "  257: 198x313+1004+812 1060.3,1040.6 20988 gray(255)",
+            "  2: 67x63+1624+118 1652.8,155.0 1343 gray(255)",
+            "  99: 5x5+10+10 12.0,12.0 25 gray(255)",
+        ]
+    )
+
+    def clusters(self) -> list:
+        return compare_render.parse_diff_clusters(self.VERBOSE, dpi=150)
+
+    def test_reports_only_white_components(self) -> None:
+        regions = self.clusters()
+        self.assertEqual(len(regions), 3)
+
+    def test_sorts_largest_first(self) -> None:
+        areas = [region.area_pt2 for region in self.clusters()]
+        self.assertEqual(areas, sorted(areas, reverse=True))
+
+    def test_converts_pixels_to_points_at_the_given_dpi(self) -> None:
+        largest = self.clusters()[0]
+        # 203x329px at +1797+796, 150 DPI: 1px = 0.48pt.
+        self.assertAlmostEqual(largest.x_pt, 862.56, places=2)
+        self.assertAlmostEqual(largest.y_pt, 382.08, places=2)
+        self.assertAlmostEqual(largest.width_pt, 97.44, places=2)
+        self.assertAlmostEqual(largest.height_pt, 157.92, places=2)
+        self.assertAlmostEqual(largest.area_pt2, 22130 * 0.48 * 0.48, places=1)
+
+    def test_drops_specks_below_the_area_floor(self) -> None:
+        # 25px at 150 DPI is 5.76pt² — glyph antialiasing, not a defect region.
+        areas_px = [region.area_pt2 / (0.48 * 0.48) for region in self.clusters()]
+        self.assertNotIn(25, [round(area) for area in areas_px])
+
+    def test_names_the_page_region_from_the_centroid(self) -> None:
+        regions = self.clusters()
+        # Page is 2000x1125px; centroids in the bottom-right and bottom-center
+        # thirds. Both #1029 corner clusters read as bottom-edge regions.
+        self.assertEqual(regions[0].region, "bottom-right")
+        self.assertEqual(regions[1].region, "bottom")
+        self.assertEqual(regions[2].region, "top-right")
+
+    def test_a_merged_component_still_counts_as_white(self) -> None:
+        # area-threshold merging leaves near-pure means such as gray(254.7).
+        verbose = "\n".join(
+            [
+                "Objects (id: bounding-box centroid area mean-color):",
+                "  0: 100x100+0+0 50.0,50.0 9000 gray(0.3)",
+                "  1: 40x40+30+30 50.0,50.0 1000 gray(254.7)",
+            ]
+        )
+        regions = compare_render.parse_diff_clusters(verbose, dpi=150)
+        self.assertEqual(len(regions), 1)
+        self.assertEqual(regions[0].region, "center")
+
+
+class DiagnoseWithClustersTest(unittest.TestCase):
+    """A dominant contiguous cluster routes attention to structure, not noise."""
+
+    GEOMETRY = {
+        "mad_y": 0.1,
+        "mad_x": 0.1,
+        "page_mismatch": 0.0,
+        "matched": 40.0,
+        "coverage": 0.9,
+    }
+    HISTOGRAM = {"intersection": 1.0, "shift": 0.0, "ink_delta": 0.0}
+
+    def render(self, clusters) -> str:
+        from io import StringIO
+        from contextlib import redirect_stdout
+
+        buffer = StringIO()
+        with redirect_stdout(buffer):
+            compare_render.diagnose(self.GEOMETRY, self.HISTOGRAM, clusters)
+        return buffer.getvalue()
+
+    def big_cluster(self) -> object:
+        return compare_render.DiffCluster(
+            x_pt=862.6,
+            y_pt=382.1,
+            width_pt=97.4,
+            height_pt=157.9,
+            area_pt2=5100.0,
+            region="bottom-right",
+        )
+
+    def test_a_dominant_cluster_is_a_finding_even_when_the_axes_agree(self) -> None:
+        report = self.render([self.big_cluster()])
+        self.assertNotIn("No axis shows a material difference", report)
+        self.assertIn("outline", report)
+
+    def test_small_clusters_do_not_override_agreement(self) -> None:
+        small = compare_render.DiffCluster(
+            x_pt=10.0, y_pt=10.0, width_pt=8.0, height_pt=8.0,
+            area_pt2=40.0, region="top-left",
+        )
+        report = self.render([small])
+        self.assertIn("No axis shows a material difference", report)
+
+    def test_no_clusters_keeps_the_old_reading(self) -> None:
+        report = self.render(None)
+        self.assertIn("No axis shows a material difference", report)
+
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- add a **Diff clusters** census to `scripts/compare_render.py`: the 5%-fuzz diff mask's contiguous regions, labelled via ImageMagick connected components and listed with bounding boxes in points and a page-region name, largest first
- surface a dominant cluster (≥500pt²) as a `## Reading` finding even when geometry, colour, and ink all agree — text-line geometry cannot see a shape outline
- add a `Shape outline geometry` row to the visual PR contract (`scripts/check_visual_pr.py` `AUDIT_ROWS` and `.github/PULL_REQUEST_TEMPLATE.md`)
- name corner rounding / curved edges explicitly in the CLAUDE.md visual check discipline checklist

## Related issue

Related: #1029

Issue #1029's squared-off panel corners survived PR #1028's audit: the 5% fuzz sweep printed one 84,400-pixel count and nothing named where those pixels sat. On that page the census now ranks the two corner regions first by an order of magnitude:

```
## Diff clusters — where the differing pixels sit
   1.   97.4 x  157.9pt at ( 862.6,  382.1)  area    5099pt2  bottom-right
   2.   95.0 x  150.2pt at ( 481.9,  389.8)  area    4836pt2  bottom
   3.   32.2 x   30.2pt at ( 779.5,   56.6)  area     309pt2  top-right
```

## Testing

- `python3 -m unittest discover -s scripts/tests -p 'test_compare_render.py'` (18 tests)
- all six script suites run as CI invokes them (`test_check_visual_pr`, `test_compare_layout`, `test_compare_render`, `test_compare_text_layer`, `test_check_gt_integrity`, `test_validate_business_golden_mocks`): OK
- end-to-end on issue #1029's fixture page (native PowerPoint GT vs current-main output, page 14, 150 DPI): the census reports the two corner clusters first and the Reading routes to outline geometry
- documentation freshness audit: PASS

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: tooling and contract only; no converter code is touched.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
