### PR TITLE
chore: publish 0.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ No LibreOffice, no Chromium, no Docker — just a single binary powered by [Typs
 
 ```toml
 [dependencies]
-office2pdf = "0.6.5"
+office2pdf = "0.6.6"
 ```
 
 ### CLI
@@ -51,7 +51,7 @@ Every [GitHub release](https://github.com/developer0hye/office2pdf/releases) shi
 On Linux and macOS, download, extract, and place the binary on your `PATH`:
 
 ```sh
-VERSION=v0.6.5
+VERSION=v0.6.6
 TARGET=x86_64-unknown-linux-gnu  # pick your platform's target from the table above
 curl -L "https://github.com/developer0hye/office2pdf/releases/download/${VERSION}/office2pdf-${VERSION}-${TARGET}.tar.gz" | tar xz
 sudo install "office2pdf-${VERSION}-${TARGET}/office2pdf" /usr/local/bin/

--- a/crates/office2pdf-cli/Cargo.toml
+++ b/crates/office2pdf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf-cli"
-version = "0.6.5"
+version = "0.6.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ path = "src/main.rs"
 server = ["tiny_http"]
 
 [dependencies]
-office2pdf = { version = "0.6.5", path = "../office2pdf", features = ["pdf-ops"] }
+office2pdf = { version = "0.6.6", path = "../office2pdf", features = ["pdf-ops"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 rayon = "1"

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf"
-version = "0.6.5"
+version = "0.6.6"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- bump `office2pdf` and `office2pdf-cli` to 0.6.6, align the CLI's `office2pdf` requirement, and update the README's install examples

## Related issue

Related: #959 — the requester depends on crates.io and needs a registry release containing #745; 0.6.5 predates it. This release also carries today's PPTX fixes (#1012, #1018, #1022, #1023, #1025, #1029, #1035 pending merge, #683).

## Testing

- `cargo metadata`: both packages at 0.6.6, CLI requirement `^0.6.6`
- `cargo test --offline --workspace`: all suites pass
- `git diff --check` clean; documentation freshness audit: PASS (README examples bumped in the same commit)

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: version metadata and README examples only.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue