### PR TITLE
fix(docx): recover w:wordWrap without the docx-rs fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  publish-verification:
+    name: Publish Verification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Verify the packaged library builds without workspace patches
+        # cargo publish verifies the packaged tarball against the crates.io
+        # dependency graph, where [patch.crates-io] does not apply. Reading a
+        # patched fork's API compiles everywhere else and then fails only in
+        # the release run's publish job, which is how v0.6.6 shipped binaries
+        # but no crates (issue #1041). The CLI cannot be dry-run verified here:
+        # it depends on the library version being published first.
+        run: cargo publish --dry-run -p office2pdf --allow-dirty
   release-contract:
     name: Release Automation Contract
     runs-on: ubuntu-latest

--- a/crates/office2pdf/src/parser/docx.rs
+++ b/crates/office2pdf/src/parser/docx.rs
@@ -22,11 +22,12 @@ use self::contexts::{
     BidiContext, ChartContext, DocxConversionContext, DrawingShapeContext, DrawingTextBoxContext,
     DrawingTextBoxInfo, FieldContext, MathContext, NoteContent, NoteContext,
     ParagraphShadingContext, SmallCapsContext, TableHeaderContext, TableStyleContext,
-    VmlTextBoxContext, VmlTextBoxInfo, WpgDrawingInfo, WrapContext, build_chart_context_from_xml,
-    build_math_context_from_xml, build_note_context_from_xml, build_wrap_context_from_xml,
-    extract_column_layout_from_section_property, is_note_reference_run, read_zip_text,
-    scan_column_layouts, scan_page_numbering, scan_style_paragraph_shading, seq_identifier,
-    toc_caption_identifier, toc_heading_depth,
+    VmlTextBoxContext, VmlTextBoxInfo, WordWrapContext, WpgDrawingInfo, WrapContext,
+    build_chart_context_from_xml, build_math_context_from_xml, build_note_context_from_xml,
+    build_wrap_context_from_xml, extract_column_layout_from_section_property,
+    is_note_reference_run, read_zip_text, scan_column_layouts, scan_page_numbering,
+    scan_style_paragraph_shading, scan_style_word_wrap, seq_identifier, toc_caption_identifier,
+    toc_heading_depth,
 };
 use self::lists::{
     NumberingMap, TaggedElement, build_numbering_map, extract_num_info, group_into_lists,
@@ -205,6 +206,7 @@ struct ZipPreParseAssets {
     theme_fonts: ThemeFonts,
     default_paragraph_style_id: Option<String>,
     style_paragraph_backgrounds: HashMap<String, Color>,
+    style_word_wraps: HashMap<String, bool>,
     /// Read from the raw `word/styles.xml` because docx-rs has no field for
     /// `w:kern` (issue #628).
     pair_kerning: PairKerningRules,
@@ -223,6 +225,7 @@ fn build_zip_preparse_assets(data: &[u8]) -> ZipPreParseAssets {
                 .as_deref()
                 .and_then(styles::scan_default_paragraph_style_id);
             let style_paragraph_backgrounds = scan_style_paragraph_shading(styles_xml.as_deref());
+            let style_word_wraps = scan_style_word_wrap(styles_xml.as_deref());
             let theme_xml = read_zip_text(&mut archive, "word/theme/theme1.xml");
             let notes = build_note_context_from_xml(doc_xml.as_deref(), &mut archive);
             let wraps = build_wrap_context_from_xml(doc_xml.as_deref());
@@ -258,6 +261,7 @@ fn build_zip_preparse_assets(data: &[u8]) -> ZipPreParseAssets {
                 bidi,
                 small_caps,
                 paragraph_shading: ParagraphShadingContext::from_xml(doc_xml.as_deref()),
+                word_wraps: WordWrapContext::from_xml(doc_xml.as_deref()),
                 fields: FieldContext::default(),
             };
             ZipPreParseAssets {
@@ -275,6 +279,7 @@ fn build_zip_preparse_assets(data: &[u8]) -> ZipPreParseAssets {
                     .unwrap_or_default(),
                 default_paragraph_style_id,
                 style_paragraph_backgrounds,
+                style_word_wraps,
                 pair_kerning: PairKerningRules::from_styles_xml(styles_xml.as_deref()),
             }
         }
@@ -291,6 +296,7 @@ fn build_zip_preparse_assets(data: &[u8]) -> ZipPreParseAssets {
                 bidi: BidiContext::from_xml(None),
                 small_caps: SmallCapsContext::from_xml(None),
                 paragraph_shading: ParagraphShadingContext::from_xml(None),
+                word_wraps: WordWrapContext::from_xml(None),
                 fields: FieldContext::default(),
             },
             math: MathContext::empty(),
@@ -302,6 +308,7 @@ fn build_zip_preparse_assets(data: &[u8]) -> ZipPreParseAssets {
             theme_fonts: ThemeFonts::default(),
             default_paragraph_style_id: None,
             style_paragraph_backgrounds: HashMap::new(),
+            style_word_wraps: HashMap::new(),
             pair_kerning: PairKerningRules::default(),
         },
     }
@@ -326,6 +333,7 @@ impl Parser for DocxParser {
             theme_fonts,
             default_paragraph_style_id,
             style_paragraph_backgrounds,
+            style_word_wraps,
             pair_kerning,
         } = build_zip_preparse_assets(data);
 
@@ -345,6 +353,7 @@ impl Parser for DocxParser {
             &theme_fonts,
             default_paragraph_style_id.as_deref(),
             &style_paragraph_backgrounds,
+            &style_word_wraps,
             &pair_kerning,
         );
         let mut warnings: Vec<ConvertWarning> = Vec::new();
@@ -995,6 +1004,9 @@ pub(super) enum ParagraphContainer {
 struct ParagraphFlow {
     is_rtl: bool,
     background: Option<Color>,
+    /// The paragraph's own `w:wordWrap`, recovered from the raw XML — the
+    /// published docx-rs does not parse it (issue #1041).
+    word_wrap: Option<bool>,
     container: ParagraphContainer,
 }
 
@@ -1015,6 +1027,7 @@ fn convert_paragraph_blocks(
     let flow = ParagraphFlow {
         is_rtl: ctx.bidi.next_is_bidi(),
         background: ctx.paragraph_shading.next_background(),
+        word_wrap: ctx.word_wraps.next_word_wrap(),
         container,
     };
 
@@ -1302,6 +1315,7 @@ fn push_paragraph_from_runs(
 ) {
     let mut explicit_para_style = extract_paragraph_style(&para.property);
     explicit_para_style.background = flow.background;
+    explicit_para_style.word_wrap = flow.word_wrap;
     let explicit_tab_overrides = extract_tab_stop_overrides(&para.property.tabs);
     let mut style = merge_paragraph_style(
         &explicit_para_style,

--- a/crates/office2pdf/src/parser/docx_context_word_wrap.rs
+++ b/crates/office2pdf/src/parser/docx_context_word_wrap.rs
@@ -1,0 +1,169 @@
+//! Per-paragraph `w:wordWrap` recovered from the raw document XML.
+//!
+//! The published `docx-rs` does not parse `w:pPr/w:wordWrap`; only the
+//! workspace's patched fork does. `cargo publish` verifies the packaged crate
+//! against the published dependency graph, where `[patch.crates-io]` does not
+//! apply, so reading the fork's field made the crate unpublishable — the
+//! v0.6.6 release's crates.io job failed on exactly that (issue #1041).
+//! Scanning the raw XML keeps the behaviour of issue #730 without the fork.
+//!
+//! The scan mirrors [`super::docx_contexts`]'s paragraph-shading context: one
+//! entry per `w:p` in document order (nested table paragraphs included, via
+//! the same stack), consumed once per converted paragraph.
+
+use std::cell::Cell;
+use std::collections::HashMap;
+
+use quick_xml::Reader;
+use quick_xml::events::{BytesStart, Event};
+
+/// `w:wordWrap`'s `w:val`, with the ST_OnOff spellings Word writes. An absent
+/// attribute means "on", the element's own default.
+fn word_wrap_value(reader: &Reader<&[u8]>, element: &BytesStart<'_>) -> Option<bool> {
+    let value = element
+        .attributes()
+        .flatten()
+        .find(|attribute| attribute.key.local_name().as_ref() == b"val")
+        .and_then(|attribute| {
+            attribute
+                .decode_and_unescape_value(reader.decoder())
+                .ok()
+                .map(|value| value.into_owned())
+        });
+    match value.as_deref() {
+        Some("0") | Some("false") | Some("off") => Some(false),
+        _ => Some(true),
+    }
+}
+
+pub(in super::super) struct WordWrapContext {
+    values: Vec<Option<bool>>,
+    cursor: Cell<usize>,
+}
+
+impl WordWrapContext {
+    pub(in super::super) fn from_xml(xml: Option<&str>) -> Self {
+        Self {
+            values: xml.map(Self::scan).unwrap_or_default(),
+            cursor: Cell::new(0),
+        }
+    }
+
+    /// The next paragraph's `w:wordWrap`, `None` when it states none. Must be
+    /// called exactly once per converted `w:p`, like the shading context.
+    pub(in super::super) fn next_word_wrap(&self) -> Option<bool> {
+        let index = self.cursor.get();
+        self.cursor.set(index + 1);
+        self.values.get(index).copied().flatten()
+    }
+
+    fn scan(xml: &str) -> Vec<Option<bool>> {
+        let mut reader = Reader::from_str(xml);
+        reader.config_mut().trim_text(true);
+        let mut values: Vec<Option<bool>> = Vec::new();
+        let mut paragraph_stack: Vec<usize> = Vec::new();
+        let mut in_body = false;
+        let mut in_paragraph_properties = false;
+
+        loop {
+            match reader.read_event() {
+                Ok(Event::Start(element)) => match element.local_name().as_ref() {
+                    b"body" => in_body = true,
+                    b"p" if in_body => {
+                        values.push(None);
+                        paragraph_stack.push(values.len() - 1);
+                    }
+                    b"pPr" if !paragraph_stack.is_empty() => in_paragraph_properties = true,
+                    b"wordWrap" if in_paragraph_properties => {
+                        if let Some(index) = paragraph_stack.last().copied() {
+                            values[index] = word_wrap_value(&reader, &element);
+                        }
+                    }
+                    _ => {}
+                },
+                Ok(Event::Empty(element)) => match element.local_name().as_ref() {
+                    b"p" if in_body => values.push(None),
+                    b"wordWrap" if in_paragraph_properties => {
+                        if let Some(index) = paragraph_stack.last().copied() {
+                            values[index] = word_wrap_value(&reader, &element);
+                        }
+                    }
+                    _ => {}
+                },
+                Ok(Event::End(element)) => match element.local_name().as_ref() {
+                    b"body" => in_body = false,
+                    b"p" if in_body => {
+                        paragraph_stack.pop();
+                        in_paragraph_properties = false;
+                    }
+                    b"pPr" => in_paragraph_properties = false,
+                    _ => {}
+                },
+                Ok(Event::Eof) | Err(_) => break,
+                _ => {}
+            }
+        }
+
+        values
+    }
+}
+
+/// Each paragraph style's `w:wordWrap` from `styles.xml`, by style id, for the
+/// style chain of issue #730.
+pub(in super::super) fn scan_style_word_wrap(xml: Option<&str>) -> HashMap<String, bool> {
+    let Some(xml) = xml else {
+        return HashMap::new();
+    };
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    let mut map: HashMap<String, bool> = HashMap::new();
+    let mut current_style: Option<String> = None;
+    let mut in_paragraph_properties = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element)) | Ok(Event::Empty(element)) => {
+                match element.local_name().as_ref() {
+                    b"style" => {
+                        // Paragraph styles only, like the shading scanner: a
+                        // stray `w:wordWrap` on a character style must not
+                        // leak into the paragraph-style chain.
+                        let mut style_id: Option<String> = None;
+                        let mut style_type: Option<String> = None;
+                        for attribute in element.attributes().flatten() {
+                            let value = attribute
+                                .decode_and_unescape_value(reader.decoder())
+                                .ok()
+                                .map(|value| value.into_owned());
+                            match attribute.key.local_name().as_ref() {
+                                b"styleId" => style_id = value,
+                                b"type" => style_type = value,
+                                _ => {}
+                            }
+                        }
+                        current_style =
+                            style_id.filter(|_| style_type.as_deref() == Some("paragraph"));
+                    }
+                    b"pPr" if current_style.is_some() => in_paragraph_properties = true,
+                    b"wordWrap" if in_paragraph_properties => {
+                        if let (Some(style_id), Some(value)) =
+                            (current_style.clone(), word_wrap_value(&reader, &element))
+                        {
+                            map.insert(style_id, value);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::End(element)) => match element.local_name().as_ref() {
+                b"style" => current_style = None,
+                b"pPr" => in_paragraph_properties = false,
+                _ => {}
+            },
+            Ok(Event::Eof) | Err(_) => break,
+            _ => {}
+        }
+    }
+
+    map
+}

--- a/crates/office2pdf/src/parser/docx_contexts.rs
+++ b/crates/office2pdf/src/parser/docx_contexts.rs
@@ -26,6 +26,8 @@ mod table_header;
 mod table_style;
 #[path = "docx_context_vml.rs"]
 mod vml;
+#[path = "docx_context_word_wrap.rs"]
+mod word_wrap;
 #[path = "docx_context_wrap.rs"]
 mod wrap;
 
@@ -47,6 +49,7 @@ pub(super) use table_header::TableHeaderContext;
 pub(super) use table_header::scan_table_headers;
 pub(super) use table_style::{ResolvedTableStyle, TableStyleContext, apply_table_text_style};
 pub(super) use vml::{VmlTextBoxContext, VmlTextBoxInfo};
+pub(super) use word_wrap::{WordWrapContext, scan_style_word_wrap};
 pub(super) use wrap::{WrapContext, build_wrap_context_from_xml};
 
 /// Bundled conversion contexts threaded through the recursive DOCX call tree.
@@ -64,5 +67,6 @@ pub(super) struct DocxConversionContext {
     pub(super) bidi: BidiContext,
     pub(super) small_caps: SmallCapsContext,
     pub(super) paragraph_shading: ParagraphShadingContext,
+    pub(super) word_wraps: WordWrapContext,
     pub(super) fields: FieldContext,
 }

--- a/crates/office2pdf/src/parser/docx_layout_rtl_tests.rs
+++ b/crates/office2pdf/src/parser/docx_layout_rtl_tests.rs
@@ -714,18 +714,64 @@ fn test_parse_docx_text_after_run_page_break_still_renders() {
 
 // ── w:wordWrap (issue #730) ────────────────────────────────────────────
 
-/// The property reaches the IR from `docx-rs`, with `0` and `1` distinct from
-/// each other and from an absent element.
+/// The property reaches the IR from the raw XML, with `0` and `1` distinct
+/// from each other and from an absent element. It cannot come from `docx-rs`:
+/// the published crate does not parse `w:wordWrap`, and reading the patched
+/// fork's field made the package unpublishable (issue #1041).
 #[test]
 fn test_word_wrap_reaches_the_paragraph_style() {
-    let off = extract_paragraph_style(&docx_rs::ParagraphProperty::new().word_wrap(false));
-    assert_eq!(off.word_wrap, Some(false));
+    let xml = r#"<?xml version="1.0"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>
+<w:p><w:pPr><w:wordWrap w:val="0"/></w:pPr></w:p>
+<w:p><w:pPr><w:wordWrap w:val="1"/></w:pPr></w:p>
+<w:p><w:pPr><w:wordWrap/></w:pPr></w:p>
+<w:p/>
+</w:body></w:document>"#;
+    let context = super::super::contexts::WordWrapContext::from_xml(Some(xml));
+    assert_eq!(context.next_word_wrap(), Some(false));
+    assert_eq!(context.next_word_wrap(), Some(true));
+    assert_eq!(
+        context.next_word_wrap(),
+        Some(true),
+        "an absent w:val means on, the element's own default"
+    );
+    assert_eq!(context.next_word_wrap(), None);
+}
 
-    let on = extract_paragraph_style(&docx_rs::ParagraphProperty::new().word_wrap(true));
-    assert_eq!(on.word_wrap, Some(true));
+/// A table cell's paragraph consumes its own slot, so nesting cannot shift
+/// the pairing between the raw scan and the structured walk.
+#[test]
+fn test_word_wrap_scan_covers_nested_table_paragraphs() {
+    let xml = r#"<?xml version="1.0"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>
+<w:p/>
+<w:tbl><w:tr><w:tc><w:p><w:pPr><w:wordWrap w:val="0"/></w:pPr></w:p></w:tc></w:tr></w:tbl>
+<w:p/>
+</w:body></w:document>"#;
+    let context = super::super::contexts::WordWrapContext::from_xml(Some(xml));
+    assert_eq!(context.next_word_wrap(), None);
+    assert_eq!(context.next_word_wrap(), Some(false));
+    assert_eq!(context.next_word_wrap(), None);
+}
 
-    let absent = extract_paragraph_style(&docx_rs::ParagraphProperty::new());
-    assert_eq!(absent.word_wrap, None);
+/// A paragraph style's `w:wordWrap` comes from the raw styles.xml the same
+/// way (issue #730's style chain).
+#[test]
+fn test_style_word_wrap_is_scanned_by_style_id() {
+    let xml = r#"<?xml version="1.0"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:style w:type="paragraph" w:styleId="NoWrap"><w:pPr><w:wordWrap w:val="0"/></w:pPr></w:style>
+<w:style w:type="paragraph" w:styleId="Plain"><w:pPr/></w:style>
+<w:style w:type="character" w:styleId="CharNoWrap"><w:pPr><w:wordWrap w:val="0"/></w:pPr></w:style>
+</w:styles>"#;
+    let map = super::super::contexts::scan_style_word_wrap(Some(xml));
+    assert_eq!(map.get("NoWrap"), Some(&false));
+    assert_eq!(map.get("Plain"), None);
+    assert_eq!(
+        map.get("CharNoWrap"),
+        None,
+        "a character style's stray wordWrap stays out of the paragraph chain"
+    );
 }
 
 /// Measured on Word: a paragraph's own `w:wordWrap` beats the one its style
@@ -733,8 +779,10 @@ fn test_word_wrap_reaches_the_paragraph_style() {
 /// the style alone keeps eojeol whole.
 #[test]
 fn test_explicit_word_wrap_overrides_the_style_chain() {
-    let explicit_prop = docx_rs::ParagraphProperty::new().word_wrap(false);
-    let explicit = extract_paragraph_style(&explicit_prop);
+    let explicit = ParagraphStyle {
+        word_wrap: Some(false),
+        ..ParagraphStyle::default()
+    };
     let style = ResolvedStyle {
         text: TextStyle::default(),
         paragraph: ParagraphStyle {

--- a/crates/office2pdf/src/parser/docx_styles.rs
+++ b/crates/office2pdf/src/parser/docx_styles.rs
@@ -219,6 +219,7 @@ pub(super) fn build_style_map(
     theme_fonts: &ThemeFonts,
     default_paragraph_style_id: Option<&str>,
     paragraph_backgrounds: &HashMap<String, Color>,
+    style_word_wraps: &HashMap<String, bool>,
     pair_kerning: &PairKerningRules,
 ) -> StyleMap {
     let mut map = StyleMap::new();
@@ -257,6 +258,9 @@ pub(super) fn build_style_map(
                     &default_paragraph,
                 );
                 paragraph.background = paragraph_backgrounds.get(&style.style_id).copied();
+                // From the raw styles.xml, since the published docx-rs does
+                // not parse `w:wordWrap` (issue #1041).
+                paragraph.word_wrap = style_word_wraps.get(&style.style_id).copied();
                 let paragraph_tab_overrides =
                     extract_tab_stop_overrides(&style.paragraph_property.tabs);
                 let heading_level = style

--- a/crates/office2pdf/src/parser/docx_text.rs
+++ b/crates/office2pdf/src/parser/docx_text.rs
@@ -45,7 +45,11 @@ pub(super) fn extract_paragraph_style(prop: &docx_rs::ParagraphProperty) -> Para
 
     ParagraphStyle {
         alignment,
-        word_wrap: prop.word_wrap,
+        // Not read from `prop`: the published docx-rs does not parse
+        // `w:wordWrap`, and reading the patched fork's field made the crate
+        // unpublishable (issue #1041). The raw-XML word-wrap context supplies
+        // the paragraph value; styles take theirs from `scan_style_word_wrap`.
+        word_wrap: None,
         indent_left,
         indent_right,
         indent_first_line,


### PR DESCRIPTION
## Summary

- stop reading the patched docx-rs fork's `ParagraphProperty.word_wrap`, which made `cargo publish`'s package verification fail against the published dependency graph
- recover the value from raw XML instead: a per-paragraph `WordWrapContext` (one entry per `w:p` in document order, nested table paragraphs included, mirroring the paragraph-shading context) plus a per-style `scan_style_word_wrap` over `styles.xml` filtered to paragraph styles
- add a **Publish Verification** CI job (`cargo publish --dry-run -p office2pdf`) so fork-only API use can never again surface only in a release run

## Related issue

Fixes #1041

Related: #959 — unblocks the crates.io release; #730 — the preserved word-wrap behaviour.

## Testing

- `cargo test -p office2pdf --lib` (2,160 passed) — the #730 tests now exercise the raw-XML path: 0/1/absent-val distinction, nested-table pairing, style-id scan with a character-style exclusion, and explicit-over-style precedence
- `cargo publish --dry-run -p office2pdf` now completes package verification (it failed with E0609 before, exactly as the v0.6.6 release run did)
- `cargo fmt --all`; `cargo +1.97 clippy --workspace --all-targets` clean
- documentation freshness audit: PASS

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: the same w:wordWrap values reach the same IR field from the raw XML instead of the fork's struct field; behaviour tests pin the equivalence.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue