### PR TITLE
chore: publish 0.6.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ No LibreOffice, no Chromium, no Docker — just a single binary powered by [Typs
 
 ```toml
 [dependencies]
-office2pdf = "0.6.6"
+office2pdf = "0.6.7"
 ```
 
 ### CLI
@@ -51,7 +51,7 @@ Every [GitHub release](https://github.com/developer0hye/office2pdf/releases) shi
 On Linux and macOS, download, extract, and place the binary on your `PATH`:
 
 ```sh
-VERSION=v0.6.6
+VERSION=v0.6.7
 TARGET=x86_64-unknown-linux-gnu  # pick your platform's target from the table above
 curl -L "https://github.com/developer0hye/office2pdf/releases/download/${VERSION}/office2pdf-${VERSION}-${TARGET}.tar.gz" | tar xz
 sudo install "office2pdf-${VERSION}-${TARGET}/office2pdf" /usr/local/bin/

--- a/crates/office2pdf-cli/Cargo.toml
+++ b/crates/office2pdf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf-cli"
-version = "0.6.6"
+version = "0.6.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ path = "src/main.rs"
 server = ["tiny_http"]
 
 [dependencies]
-office2pdf = { version = "0.6.6", path = "../office2pdf", features = ["pdf-ops"] }
+office2pdf = { version = "0.6.7", path = "../office2pdf", features = ["pdf-ops"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 rayon = "1"

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf"
-version = "0.6.6"
+version = "0.6.7"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- bump `office2pdf` and `office2pdf-cli` to 0.6.7, align the CLI's `office2pdf` requirement, and update the README's install examples

## Related issue

Related: #959, #1041 — 0.6.6's crates.io publish failed on the fork-only `word_wrap` field; #1042 restored publishability (its Publish Verification CI job now guards it), and this version completes the registry release #959 requests.

## Testing

- `cargo metadata`: both packages at 0.6.7, CLI requirement `^0.6.7`
- `cargo test --offline --workspace`: library, CLI, and integration suites pass; the `perf_validation` gross-regression tests flaked only under cross-workspace CPU contention from a concurrent local build and pass on a quiet machine (re-verified before merge)
- `git diff --check` clean; documentation freshness: README examples bumped in the same commit (the 0.6.6 audit's finding, applied from the start)

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: version metadata and README examples only.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue