### PR TITLE
feat(golden): per-page layout deviation baselines with a regression-checking pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y poppler-utils
       - name: Test business golden validator
         run: python3 -m unittest discover -s scripts/tests -p 'test_validate_business_golden_mocks.py'
+      - name: Test layout baseline producer
+        run: python3 -m unittest discover -s scripts/tests -p 'test_generate_layout_baselines.py'
+      - name: Test layout baseline consumer
+        run: python3 -m unittest discover -s scripts/tests -p 'test_check_layout_baselines.py'
       - name: Validate business golden corpus
         run: python3 scripts/validate_business_golden_mocks.py
 

--- a/scripts/check_layout_baselines.py
+++ b/scripts/check_layout_baselines.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Compare a fresh layout baseline against the stored one under tolerance.
+
+The stored baseline (``tests/golden_mocks/business/baselines/layout.json``)
+records per-page deviation vectors from ``compare_layout``. A fix PR
+regenerates the file with ``generate_layout_baselines.py``; this tool diffs
+the two documents and classifies every material change as a regression or an
+improvement, so the numeric before/after and any collateral damage surface
+without a full manual re-audit.
+
+Tolerance policy — the vectors carry measurement noise that must not re-file
+known quantisation artefacts as regressions (issues #630 and #649 both turned
+on deltas smaller than the GT's own lattice):
+
+- pt metrics move materially only past 0.24pt for Word/PowerPoint cases (the
+  native export quantises coordinates to a 0.24pt grid) and 1.0pt for Excel
+  cases (the Quartz export rounds every advance to a whole point);
+- width percentages move materially only past 0.5%;
+- counts (missing/extra lines, wraps, reflows, deviant lines, large shifts,
+  rect census gap, page parity gap) compare exactly — any increase is a
+  regression.
+
+Exit status is nonzero only when a regression is found; improvements alone
+exit zero so a fix PR can paste the report as its acceptance evidence.
+
+Usage:
+    check_layout_baselines.py --fresh PATH [--baseline PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BASELINE_PATH = (
+    PROJECT_ROOT / "tests" / "golden_mocks" / "business" / "baselines" / "layout.json"
+)
+
+SUPPORTED_SCHEMA_VERSION = 2
+PT_TOLERANCE = {"docx": 0.24, "pptx": 0.24, "xlsx": 1.0}
+WIDTH_PCT_TOLERANCE = 0.5
+
+# Lower is better for every metric below; count metrics compare exactly.
+COUNT_METRICS = (
+    ("lines", "missing"),
+    ("lines", "extra"),
+    ("lines", "deviant"),
+    ("wraps", "count"),
+    ("reflow", "gt_lines"),
+    ("instances", "large_shift_count"),
+)
+PT_METRICS = (
+    ("baseline", "mean_abs_dy"),
+    ("baseline", "worst_dy"),
+    ("dx0", "mean_abs"),
+    ("pitch", "worst_delta"),
+    ("rects", "mean_center_delta"),
+)
+PCT_METRICS = (
+    ("width", "mean_abs_pct"),
+    ("width", "worst_pct"),
+)
+
+
+class BaselineComparisonError(RuntimeError):
+    """The two documents cannot be compared metric-by-metric."""
+
+
+def finding(
+    kind: str,
+    case_id: str,
+    page: int | None,
+    metric: str,
+    stored: float,
+    fresh: float,
+    tolerance: float | None,
+) -> dict:
+    return {
+        "kind": kind,
+        "case": case_id,
+        "page": page,
+        "metric": metric,
+        "stored": stored,
+        "fresh": fresh,
+        "delta": fresh - stored,
+        "tolerance": tolerance,
+    }
+
+
+def classify_delta(stored: float, fresh: float, tolerance: float) -> str | None:
+    delta = fresh - stored
+    if delta > tolerance:
+        return "regression"
+    if delta < -tolerance:
+        return "improvement"
+    return None
+
+
+def compare_page(
+    case_id: str,
+    page_number: int,
+    pt_tolerance: float,
+    stored_vector: dict,
+    fresh_vector: dict,
+) -> list[dict]:
+    findings: list[dict] = []
+    for section, key in COUNT_METRICS:
+        stored_count = int(stored_vector[section][key])
+        fresh_count = int(fresh_vector[section][key])
+        if fresh_count != stored_count:
+            kind = "regression" if fresh_count > stored_count else "improvement"
+            findings.append(
+                finding(
+                    kind, case_id, page_number, f"{section}.{key}",
+                    stored_count, fresh_count, None,
+                )
+            )
+    for metrics, tolerance in ((PT_METRICS, pt_tolerance), (PCT_METRICS, WIDTH_PCT_TOLERANCE)):
+        for section, key in metrics:
+            stored_value = abs(float(stored_vector[section][key]))
+            fresh_value = abs(float(fresh_vector[section][key]))
+            kind = classify_delta(stored_value, fresh_value, tolerance)
+            if kind is not None:
+                findings.append(
+                    finding(
+                        kind, case_id, page_number, f"{section}.{key}",
+                        stored_value, fresh_value, tolerance,
+                    )
+                )
+    stored_gap = abs(
+        int(stored_vector["rects"]["gt_count"]) - int(stored_vector["rects"]["out_count"])
+    )
+    fresh_gap = abs(
+        int(fresh_vector["rects"]["gt_count"]) - int(fresh_vector["rects"]["out_count"])
+    )
+    if fresh_gap != stored_gap:
+        kind = "regression" if fresh_gap > stored_gap else "improvement"
+        findings.append(
+            finding(kind, case_id, page_number, "rects.census_gap", stored_gap, fresh_gap, None)
+        )
+    return findings
+
+
+def compare_case(stored_case: dict, fresh_case: dict) -> list[dict]:
+    case_id = str(stored_case["id"])
+    if stored_case["noise_floor_pt"] != fresh_case["noise_floor_pt"]:
+        raise BaselineComparisonError(
+            f"{case_id}: noise floor differs between documents "
+            f"({stored_case['noise_floor_pt']} vs {fresh_case['noise_floor_pt']}) — "
+            "the vectors were measured under different parameters"
+        )
+    if stored_case["gt_pages"] != fresh_case["gt_pages"]:
+        raise BaselineComparisonError(
+            f"{case_id}: gt_pages changed ({stored_case['gt_pages']} vs "
+            f"{fresh_case['gt_pages']}) — the ground truth itself differs, "
+            "so regenerate the stored baseline from the current corpus first"
+        )
+
+    findings: list[dict] = []
+    stored_gap = abs(int(stored_case["gt_pages"]) - int(stored_case["out_pages"]))
+    fresh_gap = abs(int(fresh_case["gt_pages"]) - int(fresh_case["out_pages"]))
+    if fresh_gap != stored_gap:
+        kind = "regression" if fresh_gap > stored_gap else "improvement"
+        findings.append(finding(kind, case_id, None, "page_parity_gap", stored_gap, fresh_gap, None))
+
+    pt_tolerance = PT_TOLERANCE[str(stored_case["format"])]
+    stored_pages = stored_case["pages"]
+    fresh_pages = fresh_case["pages"]
+    for index in range(min(len(stored_pages), len(fresh_pages))):
+        findings.extend(
+            compare_page(case_id, index + 1, pt_tolerance, stored_pages[index], fresh_pages[index])
+        )
+    return findings
+
+
+def compare_baselines(stored: dict, fresh: dict) -> list[dict]:
+    for label, document in (("stored", stored), ("fresh", fresh)):
+        if document.get("schema_version") != SUPPORTED_SCHEMA_VERSION:
+            raise BaselineComparisonError(
+                f"{label} document has schema_version {document.get('schema_version')}; "
+                f"this tool compares schema_version {SUPPORTED_SCHEMA_VERSION}"
+            )
+    stored_cases = {str(case["id"]): case for case in stored["cases"]}
+    fresh_cases = {str(case["id"]): case for case in fresh["cases"]}
+    if set(stored_cases) != set(fresh_cases):
+        missing = sorted(set(stored_cases) - set(fresh_cases))
+        added = sorted(set(fresh_cases) - set(stored_cases))
+        raise BaselineComparisonError(
+            f"case sets differ (missing from fresh: {missing}, new in fresh: {added}) — "
+            "regenerate both documents from the same manifest"
+        )
+
+    findings: list[dict] = []
+    for case_id in sorted(stored_cases):
+        findings.extend(compare_case(stored_cases[case_id], fresh_cases[case_id]))
+    findings.sort(key=lambda item: (item["kind"] != "regression", item["case"], item["page"] or 0))
+    return findings
+
+
+def render_finding(item: dict) -> str:
+    location = f"page {item['page']}" if item["page"] is not None else "case"
+    tolerance = (
+        f" (tolerance ±{item['tolerance']})" if item["tolerance"] is not None else ""
+    )
+    return (
+        f"{item['kind'].upper()}  {item['case']} {location} {item['metric']}: "
+        f"{item['stored']:g} -> {item['fresh']:g} ({item['delta']:+.2f}){tolerance}"
+    )
+
+
+def render_report(findings: list[dict]) -> str:
+    if not findings:
+        return "no material change against the stored baseline"
+    lines = [render_finding(item) for item in findings]
+    regressions = sum(1 for item in findings if item["kind"] == "regression")
+    improvements = len(findings) - regressions
+    lines.append("")
+    lines.append(f"{regressions} regression(s), {improvements} improvement(s)")
+    return "\n".join(lines)
+
+
+def exit_code(findings: list[dict]) -> int:
+    return 1 if any(item["kind"] == "regression" for item in findings) else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=DEFAULT_BASELINE_PATH,
+        help="stored baseline (default: baselines/layout.json)",
+    )
+    parser.add_argument(
+        "--fresh",
+        type=Path,
+        required=True,
+        help="freshly generated baseline to compare against the stored one",
+    )
+    args = parser.parse_args()
+
+    stored = json.loads(args.baseline.read_text(encoding="utf-8"))
+    fresh = json.loads(args.fresh.read_text(encoding="utf-8"))
+    try:
+        findings = compare_baselines(stored, fresh)
+    except BaselineComparisonError as error:
+        print(f"baseline comparison failed: {error}", file=sys.stderr)
+        return 1
+    print(render_report(findings))
+    return exit_code(findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_layout_baselines.py
+++ b/scripts/generate_layout_baselines.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Produce the per-page layout deviation baseline for the business golden mocks.
+
+For every case in ``tests/golden_mocks/business/manifest.json`` this pipeline:
+
+1. runs the GT integrity gate (``check_gt_integrity``) and refuses to record
+   anything from an invalid export — a corrupt GT baked into a baseline is how
+   issue #616 propagated;
+2. converts the source with a locally built ``office2pdf`` binary;
+3. traces both PDFs with ``mutool draw -F trace`` and stores the
+   ``compare_layout`` deviation vector for every page, using the per-format
+   noise floor (0.12pt for Word/PowerPoint GT, whose exports quantise to a
+   0.24pt grid; 0.5pt for Excel GT, whose Quartz export rounds every advance
+   to a whole point).
+
+A trace that parses to zero pages is a hard failure, never an empty vector: on
+mutool 1.23.x that state used to look exactly like a perfect comparison
+(issue #808), which would have recorded a baseline that passes everything
+silently, forever.
+
+The output is deterministic for a given tree (floats rounded, keys ordered),
+so regenerating it in a fix PR makes ``git diff`` on the baseline file the
+quantitative before/after. ``scripts/check_layout_baselines.py`` compares two
+generated documents under the tolerance policy.
+
+Usage:
+    generate_layout_baselines.py --office2pdf PATH [--output PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_gt_integrity
+import compare_layout
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CORPUS_ROOT = PROJECT_ROOT / "tests" / "golden_mocks" / "business"
+MANIFEST_PATH = CORPUS_ROOT / "manifest.json"
+DEFAULT_BASELINE_PATH = CORPUS_ROOT / "baselines" / "layout.json"
+
+SCHEMA_VERSION = 2
+# Word and PowerPoint native exports quantise coordinates to a 0.24pt grid;
+# Excel's Quartz export rounds every advance to a whole point.
+NOISE_FLOOR_PT = {"docx": 0.12, "pptx": 0.12, "xlsx": 0.5}
+LARGE_SHIFT_PT = 5.0
+FLOAT_PRECISION = 2
+
+
+class BaselineError(RuntimeError):
+    """A condition under which recording a baseline would be misleading."""
+
+
+def round_floats(value: object) -> object:
+    """Round every float to a stable precision so regenerated files diff cleanly."""
+    if isinstance(value, float):
+        return round(value, FLOAT_PRECISION)
+    if isinstance(value, dict):
+        return {key: round_floats(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [round_floats(item) for item in value]
+    return value
+
+
+def run_ground_truth_gate(gt_pdf: Path, source: Path) -> dict:
+    return check_gt_integrity.check(gt_pdf, source)
+
+
+def convert_source(office2pdf_binary: Path, source: Path, output_pdf: Path) -> None:
+    result = subprocess.run(
+        [str(office2pdf_binary), str(source), "-o", str(output_pdf)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not output_pdf.is_file():
+        raise BaselineError(
+            f"conversion failed for {source.name}: {result.stderr.strip() or 'no output'}"
+        )
+
+
+def trace_pages(pdf: Path) -> list[compare_layout.PageLayout]:
+    return compare_layout.parse_trace(compare_layout.run_mutool(pdf))
+
+
+def build_case_record(
+    case: dict,
+    office2pdf_binary: Path,
+    corpus_root: Path,
+    work_directory: Path,
+) -> dict:
+    case_id = str(case["id"])
+    source_format = str(case["format"])
+    source = corpus_root / str(case["source"])
+    gt_pdf = corpus_root / str(case["expected_pdf"])
+
+    gate = run_ground_truth_gate(gt_pdf, source)
+    if gate["invalid"]:
+        raise BaselineError(
+            f"{case_id}: GT failed the integrity gate "
+            f"(periodicity={gate['periodicity']}) — re-export before recording a baseline"
+        )
+
+    converted_pdf = work_directory / f"{case_id}.pdf"
+    try:
+        convert_source(office2pdf_binary, source, converted_pdf)
+    except BaselineError as error:
+        raise BaselineError(f"{case_id}: {error}") from error
+
+    gt_pages = trace_pages(gt_pdf)
+    out_pages = trace_pages(converted_pdf)
+    for label, pdf, pages in (("GT", gt_pdf, gt_pages), ("output", converted_pdf, out_pages)):
+        if not pages:
+            raise BaselineError(
+                f"{case_id}: no pages parsed from the {label} trace ({pdf}) — "
+                "an empty trace is indistinguishable from a perfect comparison "
+                "and must never be recorded"
+            )
+
+    noise_floor = NOISE_FLOOR_PT[source_format]
+    vectors = [
+        compare_layout.diff_page(
+            gt_pages[index],
+            out_pages[index],
+            noise_floor=noise_floor,
+            large_shift=LARGE_SHIFT_PT,
+        )
+        for index in range(min(len(gt_pages), len(out_pages)))
+    ]
+    return {
+        "id": case_id,
+        "format": source_format,
+        "noise_floor_pt": noise_floor,
+        "gt_pages": len(gt_pages),
+        "out_pages": len(out_pages),
+        "page_parity": len(gt_pages) == len(out_pages),
+        "pages": vectors,
+    }
+
+
+def build_baseline_document(
+    case_records: list[dict], repository_commit: str, office2pdf_version: str
+) -> dict:
+    pages = [vector for record in case_records for vector in record["pages"]]
+    summary = {
+        "cases": len(case_records),
+        "page_parity_cases": sum(1 for record in case_records if record["page_parity"]),
+        "pages_compared": len(pages),
+        "missing_lines": sum(vector["lines"]["missing"] for vector in pages),
+        "extra_lines": sum(vector["lines"]["extra"] for vector in pages),
+        "deviant_lines": sum(vector["lines"]["deviant"] for vector in pages),
+        "large_shifts": sum(vector["instances"]["large_shift_count"] for vector in pages),
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generator": "scripts/generate_layout_baselines.py",
+        "repository_commit": repository_commit,
+        "office2pdf_version": office2pdf_version,
+        "noise_floors_pt": dict(NOISE_FLOOR_PT),
+        "large_shift_pt": LARGE_SHIFT_PT,
+        "summary": summary,
+        "cases": case_records,
+    }
+
+
+def serialize_baseline(document: dict) -> str:
+    return json.dumps(round_floats(document), indent=1, sort_keys=True) + "\n"
+
+
+def describe_repository_commit() -> str:
+    commit = subprocess.run(
+        ["git", "-C", str(PROJECT_ROOT), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    status = subprocess.run(
+        ["git", "-C", str(PROJECT_ROOT), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    return f"{commit}-dirty" if status else commit
+
+
+def describe_office2pdf_version(office2pdf_binary: Path) -> str:
+    return subprocess.run(
+        [str(office2pdf_binary), "--version"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--office2pdf",
+        type=Path,
+        required=True,
+        help="path to a locally built office2pdf binary",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=MANIFEST_PATH,
+        help="corpus manifest (default: the business golden mock manifest)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_BASELINE_PATH,
+        help="baseline file to write (default: baselines/layout.json)",
+    )
+    args = parser.parse_args()
+
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    corpus_root = args.manifest.resolve().parent
+    case_records: list[dict] = []
+    try:
+        with tempfile.TemporaryDirectory() as scratch:
+            for case in manifest["cases"]:
+                case_records.append(
+                    build_case_record(case, args.office2pdf, corpus_root, Path(scratch))
+                )
+                record = case_records[-1]
+                print(
+                    f"{record['id']}: {record['out_pages']}/{record['gt_pages']} pages, "
+                    f"{sum(v['lines']['missing'] for v in record['pages'])} missing, "
+                    f"{sum(v['instances']['large_shift_count'] for v in record['pages'])} "
+                    "large shifts"
+                )
+    except BaselineError as error:
+        print(f"baseline generation failed: {error}", file=sys.stderr)
+        return 1
+
+    document = build_baseline_document(
+        case_records,
+        repository_commit=describe_repository_commit(),
+        office2pdf_version=describe_office2pdf_version(args.office2pdf),
+    )
+    args.output.write_text(serialize_baseline(document), encoding="utf-8")
+    summary = document["summary"]
+    print(
+        f"wrote {args.output}: {summary['cases']} cases, "
+        f"{summary['pages_compared']} pages, "
+        f"{summary['page_parity_cases']} with page parity"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_layout_baselines.py
+++ b/scripts/tests/test_check_layout_baselines.py
@@ -1,0 +1,240 @@
+"""Unit tests for the layout-baseline consumer.
+
+The consumer is a pure function of two baseline documents, so every test
+builds small in-memory documents and asserts on the findings and exit
+semantics — no external tools are involved.
+"""
+
+from __future__ import annotations
+
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import check_layout_baselines as checker
+
+
+def page_vector(**overrides: object) -> dict:
+    vector = {
+        "lines": {
+            "gt": 10,
+            "out": 10,
+            "matched": 10,
+            "missing": 0,
+            "extra": 0,
+            "deviant": 0,
+            "missing_text": [],
+            "extra_text": [],
+        },
+        "baseline": {
+            "mean_abs_dy": 0.5,
+            "worst_dy": 1.0,
+            "worst_dy_signed": -1.0,
+            "worst_line": "Line",
+        },
+        "dx0": {"mean_abs": 0.2, "worst": 0.4},
+        "width": {"mean_abs_pct": 0.3, "worst_pct": 0.9},
+        "instances": {
+            "large_shift_threshold": 5.0,
+            "large_shift_count": 0,
+            "large_shifts": [],
+        },
+        "pitch": {"pairs": 9, "worst_delta": 0.3},
+        "wraps": {"count": 0, "samples": []},
+        "reflow": {"gt_lines": 0, "out_lines": 0, "samples": []},
+        "rects": {"gt_count": 4, "out_count": 4, "matched": 4, "mean_center_delta": 0.5},
+        "noise_floor": 0.12,
+    }
+    for dotted_key, value in overrides.items():
+        section, _, key = dotted_key.partition("__")
+        if key:
+            vector[section][key] = value
+        else:
+            vector[section] = value
+    return vector
+
+
+def baseline_document(cases: list[dict] | None = None) -> dict:
+    if cases is None:
+        cases = [
+            {
+                "id": "docx-invoice-en",
+                "format": "docx",
+                "noise_floor_pt": 0.12,
+                "gt_pages": 1,
+                "out_pages": 1,
+                "page_parity": True,
+                "pages": [page_vector()],
+            }
+        ]
+    return {
+        "schema_version": 2,
+        "repository_commit": "abc123",
+        "office2pdf_version": "office2pdf 0.6.3",
+        "large_shift_pt": 5.0,
+        "noise_floors_pt": {"docx": 0.12, "pptx": 0.12, "xlsx": 0.5},
+        "summary": {},
+        "cases": cases,
+    }
+
+
+def xlsx_document(**page_overrides: object) -> dict:
+    document = baseline_document()
+    case = document["cases"][0]
+    case["id"] = "xlsx-budget-ko"
+    case["format"] = "xlsx"
+    case["noise_floor_pt"] = 0.5
+    case["pages"] = [page_vector(noise_floor=0.5, **page_overrides)]
+    return document
+
+
+class ToleranceTests(unittest.TestCase):
+    def test_word_tolerance_matches_the_gt_quantisation_lattice(self) -> None:
+        self.assertEqual(checker.PT_TOLERANCE["docx"], 0.24)
+        self.assertEqual(checker.PT_TOLERANCE["pptx"], 0.24)
+
+    def test_excel_tolerance_covers_whole_point_advance_rounding(self) -> None:
+        self.assertEqual(checker.PT_TOLERANCE["xlsx"], 1.0)
+
+    def test_pt_shift_within_tolerance_is_noise(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["pages"][0]["baseline"]["mean_abs_dy"] = 0.7  # +0.2 <= 0.24
+        self.assertEqual(checker.compare_baselines(stored, fresh), [])
+
+    def test_pt_shift_beyond_tolerance_is_a_regression(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["pages"][0]["baseline"]["mean_abs_dy"] = 1.0  # +0.5 > 0.24
+        findings = checker.compare_baselines(stored, fresh)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["kind"], "regression")
+        self.assertEqual(findings[0]["metric"], "baseline.mean_abs_dy")
+
+    def test_excel_gets_the_wider_tolerance(self) -> None:
+        stored = xlsx_document()
+        fresh = copy.deepcopy(stored)
+        # +0.9pt would regress a Word case but sits inside Excel's ±1.0pt.
+        fresh["cases"][0]["pages"][0]["baseline"]["mean_abs_dy"] = 1.4
+        self.assertEqual(checker.compare_baselines(stored, fresh), [])
+
+    def test_pt_improvement_beyond_tolerance_is_reported(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["pages"][0]["baseline"]["mean_abs_dy"] = 0.1  # -0.4
+        findings = checker.compare_baselines(stored, fresh)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["kind"], "improvement")
+
+    def test_width_uses_the_percent_tolerance(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["pages"][0]["width"]["worst_pct"] = 1.3  # +0.4 <= 0.5%
+        self.assertEqual(checker.compare_baselines(stored, fresh), [])
+        fresh["cases"][0]["pages"][0]["width"]["worst_pct"] = 2.0  # +1.1 > 0.5%
+        findings = checker.compare_baselines(stored, fresh)
+        self.assertEqual(findings[0]["metric"], "width.worst_pct")
+
+
+class CountTests(unittest.TestCase):
+    def test_any_count_increase_is_a_regression(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["pages"][0]["lines"]["missing"] = 1
+        findings = checker.compare_baselines(stored, fresh)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["kind"], "regression")
+        self.assertEqual(findings[0]["metric"], "lines.missing")
+
+    def test_any_count_decrease_is_an_improvement(self) -> None:
+        stored = baseline_document()
+        stored["cases"][0]["pages"][0]["instances"]["large_shift_count"] = 2
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["pages"][0]["instances"]["large_shift_count"] = 0
+        findings = checker.compare_baselines(stored, fresh)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["kind"], "improvement")
+
+    def test_rect_census_gap_widening_is_a_regression(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["pages"][0]["rects"]["out_count"] = 7  # gap 0 -> 3
+        findings = checker.compare_baselines(stored, fresh)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["metric"], "rects.census_gap")
+        self.assertEqual(findings[0]["kind"], "regression")
+
+
+class PageParityTests(unittest.TestCase):
+    def test_output_page_count_drifting_from_gt_is_a_regression(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["out_pages"] = 2
+        fresh["cases"][0]["page_parity"] = False
+        findings = checker.compare_baselines(stored, fresh)
+        kinds = {finding["metric"]: finding["kind"] for finding in findings}
+        self.assertEqual(kinds.get("page_parity_gap"), "regression")
+
+    def test_gt_page_count_change_makes_documents_incomparable(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["gt_pages"] = 3
+        with self.assertRaisesRegex(checker.BaselineComparisonError, "gt_pages"):
+            checker.compare_baselines(stored, fresh)
+
+
+class ComparabilityTests(unittest.TestCase):
+    def test_case_set_mismatch_is_an_error(self) -> None:
+        stored = baseline_document()
+        fresh = baseline_document()
+        fresh["cases"][0]["id"] = "docx-something-else"
+        with self.assertRaisesRegex(checker.BaselineComparisonError, "case"):
+            checker.compare_baselines(stored, fresh)
+
+    def test_noise_floor_mismatch_is_an_error(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["noise_floor_pt"] = 0.5
+        with self.assertRaisesRegex(checker.BaselineComparisonError, "noise floor"):
+            checker.compare_baselines(stored, fresh)
+
+    def test_schema_version_mismatch_is_an_error(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["schema_version"] = 1
+        with self.assertRaisesRegex(checker.BaselineComparisonError, "schema"):
+            checker.compare_baselines(stored, fresh)
+
+
+class ReportTests(unittest.TestCase):
+    def test_report_names_case_page_metric_and_delta(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["pages"][0]["baseline"]["mean_abs_dy"] = 1.0
+        findings = checker.compare_baselines(stored, fresh)
+        report = checker.render_report(findings)
+        self.assertIn("docx-invoice-en", report)
+        self.assertIn("page 1", report)
+        self.assertIn("baseline.mean_abs_dy", report)
+        self.assertIn("+0.50", report)
+
+    def test_identical_documents_report_no_material_change(self) -> None:
+        stored = baseline_document()
+        report = checker.render_report(
+            checker.compare_baselines(stored, copy.deepcopy(stored))
+        )
+        self.assertIn("no material change", report)
+
+    def test_exit_code_is_nonzero_only_on_regressions(self) -> None:
+        improvement = {"kind": "improvement"}
+        regression = {"kind": "regression"}
+        self.assertEqual(checker.exit_code([]), 0)
+        self.assertEqual(checker.exit_code([improvement]), 0)
+        self.assertEqual(checker.exit_code([improvement, regression]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_generate_layout_baselines.py
+++ b/scripts/tests/test_generate_layout_baselines.py
@@ -1,0 +1,220 @@
+"""Unit tests for the layout-baseline producer.
+
+The producer's subprocess boundaries (office2pdf conversion, mutool traces,
+the GT integrity gate) are replaced with fakes so the pipeline logic —
+per-format noise floors, the zero-page and invalid-GT hard failures, float
+rounding, and the schema of the emitted document — is exercised without
+external tools.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import generate_layout_baselines as producer
+
+
+def manifest_case(case_id: str = "docx-invoice-en", source_format: str = "docx") -> dict:
+    extension = {"docx": ".docx", "pptx": ".pptx", "xlsx": ".xlsx"}[source_format]
+    return {
+        "id": case_id,
+        "format": source_format,
+        "source": f"sources/{source_format}/01_case{extension}",
+        "expected_pdf": f"expected/{source_format}/01_case.pdf",
+        "expected_pages": 1,
+    }
+
+
+def synthetic_page_layout() -> "producer.compare_layout.PageLayout":
+    compare_layout = producer.compare_layout
+    glyph = compare_layout.Glyph(x=72.0, y=100.0, unicode="A", size=11.0, advance=6.0)
+    line = compare_layout.Line(y=100.0, glyphs=[glyph])
+    return compare_layout.PageLayout(lines=[line], rects=[])
+
+
+class FakePipeline:
+    """Stub out every subprocess boundary the producer crosses."""
+
+    def __init__(
+        self,
+        test_case: unittest.TestCase,
+        gt_pages: int = 1,
+        out_pages: int = 1,
+        gt_invalid: bool = False,
+        conversion_error: str | None = None,
+    ) -> None:
+        module = producer
+        originals = (
+            module.run_ground_truth_gate,
+            module.convert_source,
+            module.trace_pages,
+        )
+        test_case.addCleanup(
+            lambda: (
+                setattr(module, "run_ground_truth_gate", originals[0]),
+                setattr(module, "convert_source", originals[1]),
+                setattr(module, "trace_pages", originals[2]),
+            )
+        )
+        module.run_ground_truth_gate = lambda gt, source: {
+            "pages": gt_pages,
+            "periodicity": 3 if gt_invalid else None,
+            "invalid": gt_invalid,
+        }
+
+        def fake_convert(office2pdf_binary, source, output_pdf):
+            if conversion_error is not None:
+                raise producer.BaselineError(conversion_error)
+            Path(output_pdf).write_bytes(b"%PDF-fake")
+
+        module.convert_source = fake_convert
+        # The GT lives under the corpus `expected/` tree; the converted PDF
+        # lives in the producer's scratch directory.
+        module.trace_pages = lambda pdf: [
+            synthetic_page_layout()
+            for _ in range(gt_pages if "expected" in str(pdf) else out_pages)
+        ]
+
+
+class NoiseFloorTests(unittest.TestCase):
+    def test_word_and_powerpoint_use_the_quantisation_floor(self) -> None:
+        self.assertEqual(producer.NOISE_FLOOR_PT["docx"], 0.12)
+        self.assertEqual(producer.NOISE_FLOOR_PT["pptx"], 0.12)
+
+    def test_excel_uses_the_whole_point_floor(self) -> None:
+        self.assertEqual(producer.NOISE_FLOOR_PT["xlsx"], 0.5)
+
+    def test_case_record_carries_its_format_floor(self) -> None:
+        FakePipeline(self)
+        with tempfile.TemporaryDirectory() as tmp:
+            record = producer.build_case_record(
+                manifest_case("xlsx-budget-ko", "xlsx"),
+                Path("office2pdf"),
+                Path(tmp),
+                Path(tmp),
+            )
+        self.assertEqual(record["noise_floor_pt"], 0.5)
+
+
+class HardFailureTests(unittest.TestCase):
+    def test_zero_page_trace_is_a_hard_failure_not_a_clean_vector(self) -> None:
+        # A trace parsed to zero pages looks exactly like a perfect comparison
+        # (issue #808); the producer must refuse to record it.
+        FakePipeline(self, gt_pages=0)
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(producer.BaselineError, "no pages parsed"):
+                producer.build_case_record(
+                    manifest_case(), Path("office2pdf"), Path(tmp), Path(tmp)
+                )
+
+    def test_invalid_ground_truth_blocks_recording(self) -> None:
+        # Recording a baseline from a corrupt GT bakes the corruption in
+        # (issue #616); the gate result must stop the producer.
+        FakePipeline(self, gt_invalid=True)
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(producer.BaselineError, "integrity"):
+                producer.build_case_record(
+                    manifest_case(), Path("office2pdf"), Path(tmp), Path(tmp)
+                )
+
+    def test_conversion_failure_names_the_case(self) -> None:
+        FakePipeline(self, conversion_error="conversion exploded")
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(producer.BaselineError, "conversion exploded"):
+                producer.build_case_record(
+                    manifest_case(), Path("office2pdf"), Path(tmp), Path(tmp)
+                )
+
+
+class CaseRecordTests(unittest.TestCase):
+    def test_happy_path_record_shape(self) -> None:
+        FakePipeline(self, gt_pages=2, out_pages=2)
+        with tempfile.TemporaryDirectory() as tmp:
+            record = producer.build_case_record(
+                manifest_case(), Path("office2pdf"), Path(tmp), Path(tmp)
+            )
+        self.assertEqual(record["id"], "docx-invoice-en")
+        self.assertEqual(record["format"], "docx")
+        self.assertEqual(record["gt_pages"], 2)
+        self.assertEqual(record["out_pages"], 2)
+        self.assertTrue(record["page_parity"])
+        self.assertEqual(len(record["pages"]), 2)
+        for page_vector in record["pages"]:
+            self.assertIn("lines", page_vector)
+            self.assertIn("baseline", page_vector)
+            self.assertIn("pitch", page_vector)
+            self.assertIn("rects", page_vector)
+
+    def test_page_count_mismatch_still_records_with_parity_false(self) -> None:
+        FakePipeline(self, gt_pages=3, out_pages=2)
+        with tempfile.TemporaryDirectory() as tmp:
+            record = producer.build_case_record(
+                manifest_case(), Path("office2pdf"), Path(tmp), Path(tmp)
+            )
+        self.assertFalse(record["page_parity"])
+        self.assertEqual(len(record["pages"]), 2)
+
+
+class DocumentTests(unittest.TestCase):
+    def test_floats_round_recursively_for_stable_diffs(self) -> None:
+        rounded = producer.round_floats(
+            {"a": 1.23456, "b": [{"c": -0.005}, 2, "text"], "d": {"e": 0.1}}
+        )
+        self.assertEqual(rounded, {"a": 1.23, "b": [{"c": -0.01}, 2, "text"], "d": {"e": 0.1}})
+
+    def test_document_metadata_and_summary(self) -> None:
+        record = {
+            "id": "docx-invoice-en",
+            "format": "docx",
+            "noise_floor_pt": 0.12,
+            "gt_pages": 1,
+            "out_pages": 1,
+            "page_parity": True,
+            "pages": [
+                {
+                    "lines": {"missing": 1, "extra": 0, "matched": 5, "deviant": 2},
+                    "instances": {"large_shift_count": 1},
+                }
+            ],
+        }
+        document = producer.build_baseline_document(
+            [record], repository_commit="abc123", office2pdf_version="office2pdf 0.6.3"
+        )
+        self.assertEqual(document["schema_version"], 2)
+        self.assertEqual(document["repository_commit"], "abc123")
+        self.assertEqual(document["office2pdf_version"], "office2pdf 0.6.3")
+        self.assertEqual(document["large_shift_pt"], 5.0)
+        self.assertEqual(document["noise_floors_pt"]["xlsx"], 0.5)
+        summary = document["summary"]
+        self.assertEqual(summary["cases"], 1)
+        self.assertEqual(summary["page_parity_cases"], 1)
+        self.assertEqual(summary["pages_compared"], 1)
+        self.assertEqual(summary["missing_lines"], 1)
+        self.assertEqual(summary["large_shifts"], 1)
+
+    def test_serialisation_is_deterministic(self) -> None:
+        record = {
+            "id": "docx-invoice-en",
+            "format": "docx",
+            "noise_floor_pt": 0.12,
+            "gt_pages": 1,
+            "out_pages": 1,
+            "page_parity": True,
+            "pages": [],
+        }
+        document = producer.build_baseline_document(
+            [record], repository_commit="abc123", office2pdf_version="office2pdf 0.6.3"
+        )
+        first = producer.serialize_baseline(document)
+        second = producer.serialize_baseline(json.loads(first))
+        self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_validate_business_golden_mocks.py
+++ b/scripts/tests/test_validate_business_golden_mocks.py
@@ -17,10 +17,12 @@ class BusinessGoldenMockValidatorTests(unittest.TestCase):
     def setUp(self) -> None:
         self.original_corpus_root = validator.CORPUS_ROOT
         self.original_manifest_path = validator.MANIFEST_PATH
+        self.original_baseline_path = validator.BASELINE_PATH
 
     def tearDown(self) -> None:
         validator.CORPUS_ROOT = self.original_corpus_root
         validator.MANIFEST_PATH = self.original_manifest_path
+        validator.BASELINE_PATH = self.original_baseline_path
 
     def test_repository_corpus_passes(self) -> None:
         validator.validate_manifest()
@@ -126,6 +128,96 @@ class BusinessGoldenMockValidatorTests(unittest.TestCase):
 
         with self.assertRaisesRegex(AssertionError, "table_count mismatch"):
             validator.validate_case(case, self.manifest)
+
+
+class LayoutBaselineValidationTests(unittest.TestCase):
+    """The tracked layout baseline must stay structurally consistent with the manifest."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = json.loads(validator.MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    def setUp(self) -> None:
+        self.original_baseline_path = validator.BASELINE_PATH
+
+    def tearDown(self) -> None:
+        validator.BASELINE_PATH = self.original_baseline_path
+
+    def write_baseline(self, document: dict) -> None:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        baseline_path = Path(directory.name) / "layout.json"
+        baseline_path.write_text(json.dumps(document), encoding="utf-8")
+        validator.BASELINE_PATH = baseline_path
+
+    def baseline_for_manifest(self) -> dict:
+        return {
+            "schema_version": 2,
+            "cases": [
+                {
+                    "id": case["id"],
+                    "format": case["format"],
+                    "gt_pages": int(case["expected_pages"]),
+                    "out_pages": int(case["expected_pages"]),
+                    "page_parity": True,
+                    "pages": [
+                        {
+                            section: {}
+                            for section in validator.LAYOUT_VECTOR_SECTIONS
+                        }
+                        for _ in range(int(case["expected_pages"]))
+                    ],
+                }
+                for case in self.manifest["cases"]
+            ],
+        }
+
+    def test_missing_baseline_fails(self) -> None:
+        validator.BASELINE_PATH = Path("/nonexistent/layout.json")
+        with self.assertRaisesRegex(AssertionError, "layout baseline missing"):
+            validator.validate_layout_baseline(self.manifest["cases"])
+
+    def test_consistent_baseline_passes(self) -> None:
+        self.write_baseline(self.baseline_for_manifest())
+        validator.validate_layout_baseline(self.manifest["cases"])
+
+    def test_rejects_wrong_schema_version(self) -> None:
+        document = self.baseline_for_manifest()
+        document["schema_version"] = 1
+        self.write_baseline(document)
+        with self.assertRaisesRegex(AssertionError, "schema_version"):
+            validator.validate_layout_baseline(self.manifest["cases"])
+
+    def test_rejects_case_set_drift(self) -> None:
+        document = self.baseline_for_manifest()
+        document["cases"][0]["id"] = "docx-not-in-manifest"
+        self.write_baseline(document)
+        with self.assertRaisesRegex(AssertionError, "do not match the manifest"):
+            validator.validate_layout_baseline(self.manifest["cases"])
+
+    def test_rejects_gt_page_disagreement(self) -> None:
+        document = self.baseline_for_manifest()
+        document["cases"][0]["gt_pages"] += 1
+        document["cases"][0]["pages"].append(
+            {section: {} for section in validator.LAYOUT_VECTOR_SECTIONS}
+        )
+        self.write_baseline(document)
+        with self.assertRaisesRegex(AssertionError, "gt_pages"):
+            validator.validate_layout_baseline(self.manifest["cases"])
+
+    def test_rejects_incomplete_page_vectors(self) -> None:
+        document = self.baseline_for_manifest()
+        document["cases"][0]["pages"] = []
+        self.write_baseline(document)
+        with self.assertRaisesRegex(AssertionError, "page vectors"):
+            validator.validate_layout_baseline(self.manifest["cases"])
+
+    def test_rejects_vector_missing_a_section(self) -> None:
+        document = self.baseline_for_manifest()
+        del document["cases"][0]["pages"][0]["rects"]
+        self.write_baseline(document)
+        with self.assertRaisesRegex(AssertionError, "rects"):
+            validator.validate_layout_baseline(self.manifest["cases"])
 
 
 if __name__ == "__main__":

--- a/scripts/validate_business_golden_mocks.py
+++ b/scripts/validate_business_golden_mocks.py
@@ -18,6 +18,19 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 CORPUS_ROOT = PROJECT_ROOT / "tests" / "golden_mocks" / "business"
 FIXTURES_ROOT = PROJECT_ROOT / "tests" / "fixtures"
 MANIFEST_PATH = CORPUS_ROOT / "manifest.json"
+BASELINE_PATH = CORPUS_ROOT / "baselines" / "layout.json"
+LAYOUT_BASELINE_SCHEMA_VERSION = 2
+LAYOUT_VECTOR_SECTIONS = (
+    "lines",
+    "baseline",
+    "dx0",
+    "width",
+    "instances",
+    "pitch",
+    "wraps",
+    "reflow",
+    "rects",
+)
 EXPECTED_COUNTS = {"docx": 10, "pptx": 10, "xlsx": 10}
 SOURCE_SUFFIXES = {"docx": ".docx", "pptx": ".pptx", "xlsx": ".xlsx"}
 PPTX_SLIDE_PATTERN = re.compile(r"ppt/slides/slide[0-9]+\.xml$")
@@ -309,6 +322,51 @@ def validate_directory_inventory(cases: list[dict[str, object]]) -> None:
             fail(f"{source_format}: expected-PDF directory does not match manifest inventory")
 
 
+def validate_layout_baseline(cases: list[dict[str, object]]) -> None:
+    """Keep the tracked layout baseline structurally consistent with the manifest.
+
+    The numeric comparison lives in ``check_layout_baselines.py`` and needs a
+    locally built converter; this check only guards the invariants CI can
+    verify from the files alone, so the baseline can never silently return to
+    being an orphaned artefact nothing reads.
+    """
+    if not BASELINE_PATH.is_file():
+        fail(
+            "layout baseline missing: baselines/layout.json "
+            "(generate it with scripts/generate_layout_baselines.py)"
+        )
+    baseline = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    if baseline.get("schema_version") != LAYOUT_BASELINE_SCHEMA_VERSION:
+        fail(
+            f"layout baseline schema_version must be {LAYOUT_BASELINE_SCHEMA_VERSION}, "
+            f"found {baseline.get('schema_version')}"
+        )
+    baseline_cases = {str(record["id"]): record for record in baseline.get("cases", [])}
+    manifest_ids = {str(case["id"]) for case in cases}
+    if set(baseline_cases) != manifest_ids:
+        fail("layout baseline cases do not match the manifest case IDs")
+    expected_pages_by_id = {str(case["id"]): int(case["expected_pages"]) for case in cases}
+    for case_id, record in baseline_cases.items():
+        if int(record["gt_pages"]) != expected_pages_by_id[case_id]:
+            fail(
+                f"{case_id}: layout baseline gt_pages ({record['gt_pages']}) disagrees "
+                f"with manifest expected_pages ({expected_pages_by_id[case_id]})"
+            )
+        compared_pages = min(int(record["gt_pages"]), int(record["out_pages"]))
+        if len(record["pages"]) != compared_pages:
+            fail(
+                f"{case_id}: layout baseline page vectors cover {len(record['pages'])} "
+                f"page(s) but {compared_pages} were compared"
+            )
+        for page_number, vector in enumerate(record["pages"], start=1):
+            for section in LAYOUT_VECTOR_SECTIONS:
+                if section not in vector:
+                    fail(
+                        f"{case_id}: layout baseline page {page_number} vector "
+                        f"is missing the '{section}' section"
+                    )
+
+
 def validate_manifest() -> None:
     manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
     cases = manifest.get("cases")
@@ -328,7 +386,10 @@ def validate_manifest() -> None:
     for case in cases:
         validate_case(case, manifest)
 
+    validate_layout_baseline(cases)
+
     print("validated 30 business golden mocks (10 DOCX, 10 PPTX, 10 XLSX)")
+    print("validated the layout baseline against the manifest")
 
 
 def main() -> int:

--- a/tests/golden_mocks/business/README.md
+++ b/tests/golden_mocks/business/README.md
@@ -36,7 +36,8 @@ tests/golden_mocks/business/
 │   ├── docx/    # Native Microsoft Word PDF exports
 │   ├── pptx/    # Native Microsoft PowerPoint PDF exports
 │   └── xlsx/    # Native Microsoft Excel PDF exports
-├── baselines/   # Conversion status and page-count baseline by tested commit
+├── baselines/   # layout.json: per-page layout deviation baseline (regenerated);
+│                # main-3e788d0.json: historical hand-recorded conversion status
 └── audits/      # Historical per-run visual metrics and review snapshots
 ```
 
@@ -128,3 +129,38 @@ python3 scripts/validate_business_golden_mocks.py
 ```
 
 The `Business Golden Contract` CI job runs both checks on every push and pull request.
+
+## Layout deviation baseline
+
+`baselines/layout.json` stores the `compare_layout.py` deviation vector for
+every page of every case (matched/missing/extra lines, baseline dy statistics,
+line-width drift, pitch deltas, wrap and reflow counts, large instance shifts,
+and the rect census), measured against the native GT with the per-format noise
+floor (0.12pt Word/PowerPoint, 0.5pt Excel). Regenerate it with a local build:
+
+```sh
+cargo build -p office2pdf-cli
+python3 scripts/generate_layout_baselines.py --office2pdf target/debug/office2pdf
+```
+
+The producer refuses to record anything when a GT fails the
+`check_gt_integrity.py` gate or when a trace parses to zero pages — both
+states would bake a silently wrong baseline in.
+
+A PR that changes conversion output regenerates the file; the git diff is the
+quantitative before/after. To classify the change under the measurement-noise
+tolerance policy (±0.24pt for Word/PowerPoint cases, ±1.0pt for Excel cases,
+±0.5% width, counts exact):
+
+```sh
+python3 scripts/generate_layout_baselines.py \
+  --office2pdf target/debug/office2pdf --output /tmp/fresh-layout.json
+python3 scripts/check_layout_baselines.py --fresh /tmp/fresh-layout.json
+```
+
+`check_layout_baselines.py` exits nonzero only on a regression, and its report
+names every case, page, and metric that moved materially in either direction.
+CI validates the baseline structurally (schema, case set, page coverage
+against the manifest); the numeric comparison needs a local converter build,
+so it is a review-time tool, not a CI gate. `main-3e788d0.json` is the
+historical hand-recorded predecessor, kept for provenance.

--- a/tests/golden_mocks/business/baselines/layout.json
+++ b/tests/golden_mocks/business/baselines/layout.json
@@ -1,0 +1,3241 @@
+{
+ "cases": [
+  {
+   "format": "docx",
+   "gt_pages": 1,
+   "id": "docx-invoice-en",
+   "noise_floor_pt": 0.12,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.15,
+      "worst_dy": 0.58,
+      "worst_dy_signed": -0.58,
+      "worst_line": "Paymentterms:Net30.Pleasereferencetheinvoicenumberinyourwire"
+     },
+     "dx0": {
+      "mean_abs": 0.04,
+      "worst": 0.1
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 3,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 14,
+      "matched": 14,
+      "missing": 0,
+      "missing_text": [],
+      "out": 14
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 13,
+      "worst_delta": 0.69
+     },
+     "rects": {
+      "gt_count": 139,
+      "matched": 67,
+      "mean_center_delta": 1.44,
+      "out_count": 101
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 2.53,
+      "worst_pct": 17.1
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "docx",
+   "gt_pages": 1,
+   "id": "docx-contract-ko",
+   "noise_floor_pt": 0.12,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.1,
+      "worst_dy": 0.24,
+      "worst_dy_signed": -0.24,
+      "worst_line": "2026\ub1447\uc6d417\uc77c"
+     },
+     "dx0": {
+      "mean_abs": 0.04,
+      "worst": 0.05
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 9,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 21,
+      "matched": 21,
+      "missing": 0,
+      "missing_text": [],
+      "out": 21
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 20,
+      "worst_delta": 0.28
+     },
+     "rects": {
+      "gt_count": 34,
+      "matched": 11,
+      "mean_center_delta": 0.85,
+      "out_count": 20
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 2.75,
+      "worst_pct": 18.29
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "docx",
+   "gt_pages": 1,
+   "id": "docx-meeting-minutes-ko",
+   "noise_floor_pt": 0.12,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.38,
+      "worst_dy": 0.71,
+      "worst_dy_signed": -0.71,
+      "worst_line": "2.\uacb0\uc815\uc0ac\ud56d"
+     },
+     "dx0": {
+      "mean_abs": 0.03,
+      "worst": 0.05
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 17,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 20,
+      "matched": 20,
+      "missing": 0,
+      "missing_text": [],
+      "out": 20
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 19,
+      "worst_delta": 0.7
+     },
+     "rects": {
+      "gt_count": 128,
+      "matched": 60,
+      "mean_center_delta": 1.2,
+      "out_count": 89
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 3.4,
+      "worst_pct": 18.29
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "docx",
+   "gt_pages": 1,
+   "id": "docx-resume-en",
+   "noise_floor_pt": 0.12,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.37,
+      "worst_dy": 0.62,
+      "worst_dy_signed": -0.62,
+      "worst_line": "SKILLS"
+     },
+     "dx0": {
+      "mean_abs": 0.05,
+      "worst": 0.05
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 15,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 16,
+      "matched": 16,
+      "missing": 0,
+      "missing_text": [],
+      "out": 16
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 15,
+      "worst_delta": 0.28
+     },
+     "rects": {
+      "gt_count": 1,
+      "matched": 1,
+      "mean_center_delta": 0.05,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 2.69,
+      "worst_pct": 8.81
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "docx",
+   "gt_pages": 2,
+   "id": "docx-technical-manual-en",
+   "noise_floor_pt": 0.12,
+   "out_pages": 2,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.08,
+      "worst_dy": 0.26,
+      "worst_dy_signed": -0.26,
+      "worst_line": "1.Installation"
+     },
+     "dx0": {
+      "mean_abs": 0.05,
+      "worst": 0.05
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 3,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 21,
+      "matched": 21,
+      "missing": 0,
+      "missing_text": [],
+      "out": 21
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 20,
+      "worst_delta": 0.18
+     },
+     "rects": {
+      "gt_count": 7,
+      "matched": 6,
+      "mean_center_delta": 0.05,
+      "out_count": 7
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 2.8,
+      "worst_pct": 17.1
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.04,
+      "worst_dy": 0.1,
+      "worst_dy_signed": -0.1,
+      "worst_line": "AppendixA.ExitCodes"
+     },
+     "dx0": {
+      "mean_abs": 0.03,
+      "worst": 0.05
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 0,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 7,
+      "matched": 7,
+      "missing": 0,
+      "missing_text": [],
+      "out": 7
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 6,
+      "worst_delta": 0.1
+     },
+     "rects": {
+      "gt_count": 51,
+      "matched": 24,
+      "mean_center_delta": 0.89,
+      "out_count": 37
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 3.36,
+      "worst_pct": 17.1
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "docx",
+   "gt_pages": 1,
+   "id": "docx-official-letter-ko",
+   "noise_floor_pt": 0.12,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.1,
+      "worst_dy": 0.31,
+      "worst_dy_signed": -0.31,
+      "worst_line": "\uc608\uc815\uc774\uc624\ub2c8,\ud611\ub825\uc0ac\uc5ec\ub7ec\ubd84\uc758\uc801\uadf9\uc801\uc778\ud611\uc870\ub97c\ubd80\ud0c1\ub4dc\ub9bd\ub2c8\ub2e4."
+     },
+     "dx0": {
+      "mean_abs": 0.05,
+      "worst": 0.05
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 5,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 17,
+      "matched": 17,
+      "missing": 0,
+      "missing_text": [],
+      "out": 17
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 16,
+      "worst_delta": 0.27
+     },
+     "rects": {
+      "gt_count": 2,
+      "matched": 0,
+      "mean_center_delta": 0.0,
+      "out_count": 2
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 3.15,
+      "worst_pct": 18.29
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "docx",
+   "gt_pages": 1,
+   "id": "docx-product-spec-en",
+   "noise_floor_pt": 0.12,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.13,
+      "worst_dy": 0.43,
+      "worst_dy_signed": -0.43,
+      "worst_line": "Throughputmeasuredonthestandardcorpus(mixed1\u201320pagedocuments"
+     },
+     "dx0": {
+      "mean_abs": 0.02,
+      "worst": -0.03
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 2,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 12,
+      "matched": 12,
+      "missing": 0,
+      "missing_text": [],
+      "out": 12
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 11,
+      "worst_delta": 0.53
+     },
+     "rects": {
+      "gt_count": 215,
+      "matched": 119,
+      "mean_center_delta": 0.88,
+      "out_count": 176
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 1.85,
+      "worst_pct": 17.1
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "docx",
+   "gt_pages": 1,
+   "id": "docx-newsletter-en",
+   "noise_floor_pt": 0.12,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.69,
+      "worst_dy": 0.96,
+      "worst_dy_signed": -0.96,
+      "worst_line": "Shout-outs"
+     },
+     "dx0": {
+      "mean_abs": 0.04,
+      "worst": 0.05
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 12,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 14,
+      "matched": 14,
+      "missing": 0,
+      "missing_text": [],
+      "out": 14
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 13,
+      "worst_delta": 0.91
+     },
+     "rects": {
+      "gt_count": 51,
+      "matched": 25,
+      "mean_center_delta": 1.43,
+      "out_count": 37
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 1.56,
+      "worst_pct": 6.57
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "docx",
+   "gt_pages": 1,
+   "id": "docx-offer-letter-en",
+   "noise_floor_pt": 0.12,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.07,
+      "worst_dy": 0.13,
+      "worst_dy_signed": -0.13,
+      "worst_line": "DearAlexKim,"
+     },
+     "dx0": {
+      "mean_abs": 0.05,
+      "worst": 0.05
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 2,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 17,
+      "matched": 17,
+      "missing": 0,
+      "missing_text": [],
+      "out": 17
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 16,
+      "worst_delta": 0.17
+     },
+     "rects": {
+      "gt_count": 1,
+      "matched": 0,
+      "mean_center_delta": 0.0,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 2.63,
+      "worst_pct": 17.1
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "docx",
+   "gt_pages": 2,
+   "id": "docx-research-report-ko",
+   "noise_floor_pt": 0.12,
+   "out_pages": 2,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.09,
+      "worst_dy": 0.25,
+      "worst_dy_signed": -0.25,
+      "worst_line": "\uc774\ub2e4.\ub9cc\uc871\uc751\ub2f5\ube44\uc728\uc740\uc870\uc0ac\uae30\uac04\ub3d9\uc54858.0%\uc5d0\uc11c76.0%\ub85c\ud06c\uac8c\uc0c1\uc2b9\ud558\uc600\ub2e4."
+     },
+     "dx0": {
+      "mean_abs": 0.02,
+      "worst": 0.05
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 8,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 29,
+      "matched": 29,
+      "missing": 0,
+      "missing_text": [],
+      "out": 29
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 28,
+      "worst_delta": 0.28
+     },
+     "rects": {
+      "gt_count": 448,
+      "matched": 269,
+      "mean_center_delta": 0.85,
+      "out_count": 414
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 1.58,
+      "worst_pct": 18.29
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.07,
+      "worst_dy": 0.17,
+      "worst_dy_signed": 0.17,
+      "worst_line": "-2-"
+     },
+     "dx0": {
+      "mean_abs": 0.02,
+      "worst": 0.05
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 1,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 12,
+      "matched": 10,
+      "missing": 0,
+      "missing_text": [],
+      "out": 58
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 9,
+      "worst_delta": 0.17
+     },
+     "rects": {
+      "gt_count": 176,
+      "matched": 98,
+      "mean_center_delta": 0.87,
+      "out_count": 147
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 2.84,
+      "worst_pct": 18.29
+     },
+     "wraps": {
+      "count": 1,
+      "samples": [
+       "\uc8fc:\ubc18\uc62c\ub9bc\uc73c\ub85c\uc778\ud574\ud569\uacc4\uac00100.0%\uc640\uc77c\uce58\ud558\uc9c0\uc54a\uc744\uc218\uc788\uc74c.\ud45c\uac00\ud398\uc774\uc9c0\ub97c\ub118\uc5b4\uac00\ub294\uacbd\uc6b0\uba38\ub9ac\uae00\ud589\uc774\ubc18\ubcf5\ud45c"
+      ]
+     }
+    }
+   ]
+  },
+  {
+   "format": "pptx",
+   "gt_pages": 3,
+   "id": "pptx-startup-pitch-en",
+   "noise_floor_pt": 0.12,
+   "out_pages": 3,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.16,
+      "worst_dy": 0.43,
+      "worst_dy_signed": 0.43,
+      "worst_line": "SeedRound\u00b7July2026"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 1,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 0.43
+     },
+     "rects": {
+      "gt_count": 1,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.08,
+      "worst_pct": 0.19
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.38,
+      "worst_dy": 0.95,
+      "worst_dy_signed": -0.95,
+      "worst_line": "\u2022Server-sidedocumentconversionstilldependsonLibreOffice"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 5,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 7,
+      "matched": 7,
+      "missing": 0,
+      "missing_text": [],
+      "out": 7
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 6,
+      "worst_delta": 1.44
+     },
+     "rects": {
+      "gt_count": 2,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 25
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.01,
+      "worst_pct": 0.03
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.33,
+      "worst_dy": 0.47,
+      "worst_dy_signed": 0.47,
+      "worst_line": "2,300+$1.8M99.98%"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 3,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 0.69
+     },
+     "rects": {
+      "gt_count": 5,
+      "matched": 4,
+      "mean_center_delta": 0.03,
+      "out_count": 76
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.03,
+      "worst_pct": 0.05
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "pptx",
+   "gt_pages": 3,
+   "id": "pptx-quarterly-review-ko",
+   "noise_floor_pt": 0.12,
+   "out_pages": 3,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 1.94,
+      "worst_dy": 3.01,
+      "worst_dy_signed": 3.01,
+      "worst_line": "2025\ub1444\ubd84\uae30\uc2e4\uc801\ubcf4\uace0"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 3,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 1.63
+     },
+     "rects": {
+      "gt_count": 2,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.07,
+      "worst_pct": 0.11
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 2.35,
+      "worst_dy": 2.89,
+      "worst_dy_signed": 2.89,
+      "worst_line": "+24.6%"
+     },
+     "dx0": {
+      "mean_abs": 0.03,
+      "worst": 0.09
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 3,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 1.46
+     },
+     "rects": {
+      "gt_count": 3,
+      "matched": 2,
+      "mean_center_delta": 0.06,
+      "out_count": 26
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.05,
+      "worst_pct": 0.09
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.82,
+      "worst_dy": 2.75,
+      "worst_dy_signed": 2.75,
+      "worst_line": "\uc0ac\uc5c5\ubd80\ubcc4\uc2e4\uc801\uc694\uc57d"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 6,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 6,
+      "matched": 6,
+      "missing": 0,
+      "missing_text": [],
+      "out": 6
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 5,
+      "worst_delta": 2.52
+     },
+     "rects": {
+      "gt_count": 18,
+      "matched": 17,
+      "mean_center_delta": 0.01,
+      "out_count": 17
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.01,
+      "worst_pct": 0.02
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "pptx",
+   "gt_pages": 3,
+   "id": "pptx-product-launch-en",
+   "noise_floor_pt": 0.12,
+   "out_pages": 3,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.16,
+      "worst_dy": 0.43,
+      "worst_dy_signed": 0.43,
+      "worst_line": "August2026"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 1,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 0.43
+     },
+     "rects": {
+      "gt_count": 1,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.02,
+      "worst_pct": 0.04
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.25,
+      "worst_dy": 0.31,
+      "worst_dy_signed": 0.31,
+      "worst_line": "BetafreezePressembargoPubliclaunchFollow-upwebinar"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 5,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 5,
+      "matched": 5,
+      "missing": 0,
+      "missing_text": [],
+      "out": 5
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 4,
+      "worst_delta": 0.48
+     },
+     "rects": {
+      "gt_count": 6,
+      "matched": 5,
+      "mean_center_delta": 0.02,
+      "out_count": 5
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.04,
+      "worst_pct": 0.2
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.28,
+      "worst_dy": 0.51,
+      "worst_dy_signed": -0.51,
+      "worst_line": "\u2022Displayretargetingpausedpending"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 6,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 6,
+      "matched": 6,
+      "missing": 0,
+      "missing_text": [],
+      "out": 6
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 5,
+      "worst_delta": 0.68
+     },
+     "rects": {
+      "gt_count": 2,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 25
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.05,
+      "worst_pct": 0.09
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "pptx",
+   "gt_pages": 3,
+   "id": "pptx-training-deck-ko",
+   "noise_floor_pt": 0.12,
+   "out_pages": 3,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 1.94,
+      "worst_dy": 3.01,
+      "worst_dy_signed": 3.01,
+      "worst_line": "\uc2e0\uc785\uc0ac\uc6d0\ubcf4\uc548\uad50\uc721"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 3,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 1.63
+     },
+     "rects": {
+      "gt_count": 2,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.04,
+      "worst_pct": 0.09
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 1.64,
+      "worst_dy": 2.75,
+      "worst_dy_signed": 2.75,
+      "worst_line": "\uc624\ub298\ub2e4\ub8f0\ub0b4\uc6a9"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 8,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 8,
+      "matched": 8,
+      "missing": 0,
+      "missing_text": [],
+      "out": 8
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 7,
+      "worst_delta": 1.43
+     },
+     "rects": {
+      "gt_count": 2,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.03,
+      "worst_pct": 0.06
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 2.03,
+      "worst_dy": 2.75,
+      "worst_dy_signed": 2.75,
+      "worst_line": "\ud328\uc2a4\uc6cc\ub4dc\uad00\ub9ac\uc6d0\uce59"
+     },
+     "dx0": {
+      "mean_abs": 0.02,
+      "worst": 0.04
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 3,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 4,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 45
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 1.88
+     },
+     "rects": {
+      "gt_count": 5,
+      "matched": 4,
+      "mean_center_delta": 0.03,
+      "out_count": 76
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.03,
+      "worst_pct": 0.07
+     },
+     "wraps": {
+      "count": 1,
+      "samples": [
+       "\ud034\uc988:\"\ud68c\uc0ac\ub178\ud2b8\ubd81\uc5d0\uc11c\uac1c\uc778\ud074\ub77c\uc6b0\ub4dc\uc5d0\uc5c5\ubb34\ubb38\uc11c\ub97c\uc62c\ub824\ub3c4\ub41c\ub2e4?\"\u2014\uc815\ub2f5\uc740\ub2e4\uc74c\uc2ac\ub77c\uc774\ub4dc\uc5d0\uc11c."
+      ]
+     }
+    }
+   ]
+  },
+  {
+   "format": "pptx",
+   "gt_pages": 3,
+   "id": "pptx-company-intro-en",
+   "noise_floor_pt": 0.12,
+   "out_pages": 3,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.16,
+      "worst_dy": 0.43,
+      "worst_dy_signed": 0.43,
+      "worst_line": "2026"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 1,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 0.43
+     },
+     "rects": {
+      "gt_count": 1,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.03,
+      "worst_pct": 0.05
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.29,
+      "worst_dy": 0.43,
+      "worst_dy_signed": 0.43,
+      "worst_line": "Shipquality,measurefidelityDirectfeedback,sharedcontextTheir"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": -0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 3,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 4,
+      "matched": 4,
+      "missing": 0,
+      "missing_text": [],
+      "out": 4
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 3,
+      "worst_delta": 0.32
+     },
+     "rects": {
+      "gt_count": 5,
+      "matched": 4,
+      "mean_center_delta": 0.03,
+      "out_count": 4
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.0,
+      "worst_pct": 0.01
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.33,
+      "worst_dy": 0.47,
+      "worst_dy_signed": 0.47,
+      "worst_line": "872,300+38%"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 3,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 0.69
+     },
+     "rects": {
+      "gt_count": 5,
+      "matched": 4,
+      "mean_center_delta": 0.03,
+      "out_count": 76
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.02,
+      "worst_pct": 0.04
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "pptx",
+   "gt_pages": 2,
+   "id": "pptx-project-status-ko",
+   "noise_floor_pt": 0.12,
+   "out_pages": 2,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 1.94,
+      "worst_dy": 3.01,
+      "worst_dy_signed": 3.01,
+      "worst_line": "\ucc28\uc138\ub300ERP\uc804\ud658\ud504\ub85c\uc81d\ud2b8"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 3,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 1.63
+     },
+     "rects": {
+      "gt_count": 2,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.04,
+      "worst_pct": 0.05
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.74,
+      "worst_dy": 2.75,
+      "worst_dy_signed": 2.75,
+      "worst_line": "\uc6cc\ud06c\uc2a4\ud2b8\ub9bc\ubcc4\ud604\ud669"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 7,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 7,
+      "matched": 7,
+      "missing": 0,
+      "missing_text": [],
+      "out": 7
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 6,
+      "worst_delta": 2.52
+     },
+     "rects": {
+      "gt_count": 21,
+      "matched": 20,
+      "mean_center_delta": 0.01,
+      "out_count": 20
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.02,
+      "worst_pct": 0.04
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "pptx",
+   "gt_pages": 2,
+   "id": "pptx-conference-talk-en",
+   "noise_floor_pt": 0.12,
+   "out_pages": 2,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.16,
+      "worst_dy": 0.43,
+      "worst_dy_signed": 0.43,
+      "worst_line": "RustConf2026\u00b7JamieParker"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 1,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 0.43
+     },
+     "rects": {
+      "gt_count": 2,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.11,
+      "worst_pct": 0.21
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.35,
+      "worst_dy": 0.83,
+      "worst_dy_signed": -0.83,
+      "worst_line": "matchelement{"
+     },
+     "dx0": {
+      "mean_abs": 5.58,
+      "worst": -16.75
+     },
+     "instances": {
+      "large_shift_count": 3,
+      "large_shift_threshold": 5.0,
+      "large_shifts": [
+       {
+        "dx": -16.75,
+        "dy": -0.11,
+        "gt_x": 106.75,
+        "gt_y": 360.24,
+        "label": "b\"w:p\"=>blocks.push(parse_paragraph(r)?),",
+        "out_x": 90.0,
+        "out_y": 360.13,
+        "width_pct": 4.63
+       },
+       {
+        "dx": -16.75,
+        "dy": -0.35,
+        "gt_x": 106.75,
+        "gt_y": 377.28,
+        "label": "b\"w:tbl\"=>blocks.push(parse_table(r)?),",
+        "out_x": 90.0,
+        "out_y": 376.93,
+        "width_pct": 4.86
+       },
+       {
+        "dx": -16.75,
+        "dy": -0.35,
+        "gt_x": 106.75,
+        "gt_y": 394.08,
+        "label": "other=>warn!(?other,\"skippedunsupportedelement\"),",
+        "out_x": 90.0,
+        "out_y": 393.73,
+        "width_pct": 3.7
+       }
+      ]
+     },
+     "lines": {
+      "deviant": 7,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 9,
+      "matched": 9,
+      "missing": 0,
+      "missing_text": [],
+      "out": 9
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 8,
+      "worst_delta": 0.72
+     },
+     "rects": {
+      "gt_count": 3,
+      "matched": 2,
+      "mean_center_delta": 0.06,
+      "out_count": 2
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 1.52,
+      "worst_pct": 4.86
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "pptx",
+   "gt_pages": 3,
+   "id": "pptx-marketing-report-en",
+   "noise_floor_pt": 0.12,
+   "out_pages": 3,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.16,
+      "worst_dy": 0.43,
+      "worst_dy_signed": 0.43,
+      "worst_line": "July2026\u00b7GrowthTeam"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 1,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 0.43
+     },
+     "rects": {
+      "gt_count": 2,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.11,
+      "worst_pct": 0.27
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.33,
+      "worst_dy": 0.47,
+      "worst_dy_signed": 0.47,
+      "worst_line": "$412K18,200$22.6"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 3,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 0.69
+     },
+     "rects": {
+      "gt_count": 5,
+      "matched": 4,
+      "mean_center_delta": 0.03,
+      "out_count": 76
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.04,
+      "worst_pct": 0.06
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.22,
+      "worst_dy": 0.41,
+      "worst_dy_signed": 0.41,
+      "worst_line": "\u2022Localizedlandingpages(DE/KR/JP)liftedsignupconversion14%."
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 4,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 5,
+      "matched": 5,
+      "missing": 0,
+      "missing_text": [],
+      "out": 5
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 4,
+      "worst_delta": 0.56
+     },
+     "rects": {
+      "gt_count": 2,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.05,
+      "worst_pct": 0.23
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "pptx",
+   "gt_pages": 2,
+   "id": "pptx-lecture-ko",
+   "noise_floor_pt": 0.12,
+   "out_pages": 2,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 1.94,
+      "worst_dy": 3.01,
+      "worst_dy_signed": 3.01,
+      "worst_line": "\ud1b5\uacc4\ud559\uc785\ubb386\uac15"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 3,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 1.63
+     },
+     "rects": {
+      "gt_count": 2,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.07,
+      "worst_pct": 0.13
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 1.26,
+      "worst_dy": 2.75,
+      "worst_dy_signed": 2.75,
+      "worst_line": "\uc624\ub298\uc758\ud575\uc2ec\uc9c8\ubb38"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 12,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 12,
+      "matched": 12,
+      "missing": 0,
+      "missing_text": [],
+      "out": 12
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 11,
+      "worst_delta": 1.25
+     },
+     "rects": {
+      "gt_count": 3,
+      "matched": 2,
+      "mean_center_delta": 0.06,
+      "out_count": 2
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.06,
+      "worst_pct": 0.17
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "pptx",
+   "gt_pages": 2,
+   "id": "pptx-sales-proposal-en",
+   "noise_floor_pt": 0.12,
+   "out_pages": 2,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.16,
+      "worst_dy": 0.43,
+      "worst_dy_signed": 0.43,
+      "worst_line": "ValidthroughAugust31,2026"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 1,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 3,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 3
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 0.43
+     },
+     "rects": {
+      "gt_count": 1,
+      "matched": 1,
+      "mean_center_delta": 0.12,
+      "out_count": 1
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.16,
+      "worst_pct": 0.42
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.3,
+      "worst_dy": 0.59,
+      "worst_dy_signed": 0.59,
+      "worst_line": "$490/mo$1,490/moCustom"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 5,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 7,
+      "matched": 7,
+      "missing": 0,
+      "missing_text": [],
+      "out": 7
+     },
+     "noise_floor": 0.12,
+     "pitch": {
+      "pairs": 6,
+      "worst_delta": 0.59
+     },
+     "rects": {
+      "gt_count": 5,
+      "matched": 4,
+      "mean_center_delta": 0.03,
+      "out_count": 76
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.02,
+      "worst_pct": 0.09
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "xlsx",
+   "gt_pages": 2,
+   "id": "xlsx-quotation-ko",
+   "noise_floor_pt": 0.5,
+   "out_pages": 2,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 2.86,
+      "worst_dy": 5.62,
+      "worst_dy_signed": -5.62,
+      "worst_line": "\uacf5\uae09\uac00\uc561\ud569\uacc4"
+     },
+     "dx0": {
+      "mean_abs": 0.46,
+      "worst": -1.52
+     },
+     "instances": {
+      "large_shift_count": 1,
+      "large_shift_threshold": 5.0,
+      "large_shifts": [
+       {
+        "dx": -1.52,
+        "dy": -5.62,
+        "gt_x": 427.0,
+        "gt_y": 245.0,
+        "label": "\uacf5\uae09\uac00\uc561\ud569\uacc4",
+        "out_x": 425.48,
+        "out_y": 239.38,
+        "width_pct": 2.45
+       }
+      ]
+     },
+     "lines": {
+      "deviant": 7,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 12,
+      "matched": 8,
+      "missing": 0,
+      "missing_text": [],
+      "out": 16
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 7,
+      "worst_delta": 4.85
+     },
+     "rects": {
+      "gt_count": 18,
+      "matched": 2,
+      "mean_center_delta": 4.5,
+      "out_count": 69
+     },
+     "reflow": {
+      "gt_lines": 4,
+      "out_lines": 8,
+      "samples": [
+       "1\ubb38\uc11c\ubcc0\ud658\uc11c\ubc84\ub77c\uc774\uc120\uc2a4Enterprise,\uc5f0\uac0424,800,000",
+       "2\uae30\uc220\uc9c0\uc6d0\ud328\ud0a4\uc9c08\u00d75,\uc5f0\uac0412,400,000",
+       "3\ub3c4\uc785\ucee8\uc124\ud3052\uc8fc13,500,000"
+      ]
+     },
+     "width": {
+      "mean_abs_pct": 1.01,
+      "worst_pct": 2.45
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 4.09,
+      "worst_dy": 5.42,
+      "worst_dy_signed": -5.42,
+      "worst_line": "18,535,000"
+     },
+     "dx0": {
+      "mean_abs": 1.7,
+      "worst": 2.07
+     },
+     "instances": {
+      "large_shift_count": 4,
+      "large_shift_threshold": 5.0,
+      "large_shifts": [
+       {
+        "dx": 2.07,
+        "dy": -5.42,
+        "gt_x": 102.0,
+        "gt_y": 231.0,
+        "label": "1,350,000",
+        "out_x": 104.07,
+        "out_y": 225.58,
+        "width_pct": -5.63
+       },
+       {
+        "dx": 1.4,
+        "dy": -5.42,
+        "gt_x": 94.0,
+        "gt_y": 245.0,
+        "label": "16,850,000",
+        "out_x": 95.4,
+        "out_y": 239.58,
+        "width_pct": -4.01
+       },
+       {
+        "dx": 2.07,
+        "dy": -5.42,
+        "gt_x": 102.0,
+        "gt_y": 259.0,
+        "label": "1,685,000",
+        "out_x": 104.07,
+        "out_y": 253.58,
+        "width_pct": -5.63
+       },
+       {
+        "dx": 1.4,
+        "dy": -5.42,
+        "gt_x": 94.0,
+        "gt_y": 273.0,
+        "label": "18,535,000",
+        "out_x": 95.4,
+        "out_y": 267.58,
+        "width_pct": -4.01
+       }
+      ]
+     },
+     "lines": {
+      "deviant": 8,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 8,
+      "matched": 8,
+      "missing": 0,
+      "missing_text": [],
+      "out": 8
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 7,
+      "worst_delta": 1.65
+     },
+     "rects": {
+      "gt_count": 14,
+      "matched": 3,
+      "mean_center_delta": 3.17,
+      "out_count": 28
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 4.66,
+      "worst_pct": 5.63
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "xlsx",
+   "gt_pages": 2,
+   "id": "xlsx-financial-model-en",
+   "noise_floor_pt": 0.5,
+   "out_pages": 2,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.76,
+      "worst_dy": 1.47,
+      "worst_dy_signed": -1.47,
+      "worst_line": "SaaSRevenueModel\u2014Assumptions"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 6,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 6,
+      "matched": 6,
+      "missing": 0,
+      "missing_text": [],
+      "out": 6
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 5,
+      "worst_delta": 0.85
+     },
+     "rects": {
+      "gt_count": 10,
+      "matched": 1,
+      "mean_center_delta": 0.5,
+      "out_count": 32
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.72,
+      "worst_pct": 2.34
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 1.14,
+      "worst_dy": 1.47,
+      "worst_dy_signed": -1.47,
+      "worst_line": "12-MonthProjection"
+     },
+     "dx0": {
+      "mean_abs": 0.61,
+      "worst": 1.02
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 15,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 15,
+      "matched": 15,
+      "missing": 0,
+      "missing_text": [],
+      "out": 15
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 14,
+      "worst_delta": 0.35
+     },
+     "rects": {
+      "gt_count": 23,
+      "matched": 2,
+      "mean_center_delta": 0.5,
+      "out_count": 169
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.52,
+      "worst_pct": 2.9
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "xlsx",
+   "gt_pages": 4,
+   "id": "xlsx-inventory-en",
+   "noise_floor_pt": 0.5,
+   "out_pages": 4,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.65,
+      "worst_dy": 1.47,
+      "worst_dy_signed": -1.47,
+      "worst_line": "WarehouseInventorySnapshot\u20142026-07-15"
+     },
+     "dx0": {
+      "mean_abs": 0.91,
+      "worst": 1.3
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 47,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 47,
+      "matched": 47,
+      "missing": 0,
+      "missing_text": [],
+      "out": 47
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 46,
+      "worst_delta": 0.5
+     },
+     "rects": {
+      "gt_count": 55,
+      "matched": 1,
+      "mean_center_delta": 0.5,
+      "out_count": 604
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.39,
+      "worst_pct": 2.85
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.65,
+      "worst_dy": 1.12,
+      "worst_dy_signed": -1.12,
+      "worst_line": "SKUProductCategoryOnHandMinLevelUnitCost"
+     },
+     "dx0": {
+      "mean_abs": 0.91,
+      "worst": 0.93
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 16,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 16,
+      "matched": 16,
+      "missing": 0,
+      "missing_text": [],
+      "out": 16
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 15,
+      "worst_delta": 0.5
+     },
+     "rects": {
+      "gt_count": 33,
+      "matched": 1,
+      "mean_center_delta": 0.5,
+      "out_count": 226
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.32,
+      "worst_pct": 0.34
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.63,
+      "worst_dy": 1.12,
+      "worst_dy_signed": -1.12,
+      "worst_line": "Status"
+     },
+     "dx0": {
+      "mean_abs": 0.18,
+      "worst": -0.28
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 46,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 46,
+      "matched": 46,
+      "missing": 0,
+      "missing_text": [],
+      "out": 46
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 45,
+      "worst_delta": 0.5
+     },
+     "rects": {
+      "gt_count": 57,
+      "matched": 5,
+      "mean_center_delta": 0.5,
+      "out_count": 149
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 1.24,
+      "worst_pct": 1.5
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 0.65,
+      "worst_dy": 1.12,
+      "worst_dy_signed": -1.12,
+      "worst_line": "Status"
+     },
+     "dx0": {
+      "mean_abs": 0.2,
+      "worst": -0.28
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 16,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 16,
+      "matched": 16,
+      "missing": 0,
+      "missing_text": [],
+      "out": 16
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 15,
+      "worst_delta": 0.5
+     },
+     "rects": {
+      "gt_count": 25,
+      "matched": 3,
+      "mean_center_delta": 0.5,
+      "out_count": 53
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 1.27,
+      "worst_pct": 1.5
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "xlsx",
+   "gt_pages": 2,
+   "id": "xlsx-payroll-ko",
+   "noise_floor_pt": 0.5,
+   "out_pages": 2,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 2.25,
+      "worst_dy": 5.86,
+      "worst_dy_signed": -5.86,
+      "worst_line": "\u203b\uacf5\uc81c\ud56d\ubaa9:\uad6d\ubbfc\uc5f0\uae08,\uac74\uac15\ubcf4\ud5d8,\uace0\uc6a9\ubcf4\ud5d8,\uadfc\ub85c\uc18c\ub4dd\uc138(\uc0c1\uc138\ub0b4\uc5ed\uc740\uac1c\uc778\ubcc4\uba85\uc138\uc11c\ucc38\uc870)"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 1,
+      "large_shift_threshold": 5.0,
+      "large_shifts": [
+       {
+        "dx": 0.0,
+        "dy": -5.86,
+        "gt_x": 57.0,
+        "gt_y": 246.0,
+        "label": "\u203b\uacf5\uc81c\ud56d\ubaa9:\uad6d\ubbfc\uc5f0\uae08,\uac74\uac15\ubcf4\ud5d8,\uace0\uc6a9\ubcf4\ud5d8,\uadfc\ub85c\uc18c\ub4dd\uc138(\uc0c1\uc138\ub0b4\uc5ed\uc740\uac1c\uc778\ubcc4\uba85\uc138\uc11c\ucc38\uc870)",
+        "out_x": 57.0,
+        "out_y": 240.14,
+        "width_pct": 1.87
+       }
+      ]
+     },
+     "lines": {
+      "deviant": 2,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 9,
+      "matched": 3,
+      "missing": 0,
+      "missing_text": [],
+      "out": 15
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 2,
+      "worst_delta": 5.09
+     },
+     "rects": {
+      "gt_count": 18,
+      "matched": 0,
+      "mean_center_delta": 0.0,
+      "out_count": 118
+     },
+     "reflow": {
+      "gt_lines": 6,
+      "out_lines": 12,
+      "samples": [
+       "E-1021\uae40\ubbfc\uc900\uac1c\ubc1c\ud3004,200,000650,0004,850,000780,000",
+       "E-1034\uc774\uc11c\uc5f0\uac1c\ubc1c\ud3003,900,000520,0004,420,000700,000",
+       "E-1102\ubc15\uc9c0\ud638\uae30\ud68d\ud3003,600,000480,0004,080,000640,000"
+      ]
+     },
+     "width": {
+      "mean_abs_pct": 1.29,
+      "worst_pct": 1.87
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    },
+    {
+     "baseline": {
+      "mean_abs_dy": 4.18,
+      "worst_dy": 6.42,
+      "worst_dy_signed": -6.42,
+      "worst_line": "3,020,000"
+     },
+     "dx0": {
+      "mean_abs": 1.05,
+      "worst": 1.4
+     },
+     "instances": {
+      "large_shift_count": 3,
+      "large_shift_threshold": 5.0,
+      "large_shifts": [
+       {
+        "dx": 1.19,
+        "dy": -5.42,
+        "gt_x": 76.0,
+        "gt_y": 189.0,
+        "label": "3,230,000",
+        "out_x": 77.19,
+        "out_y": 183.58,
+        "width_pct": -4.1
+       },
+       {
+        "dx": 1.19,
+        "dy": -6.42,
+        "gt_x": 76.0,
+        "gt_y": 204.0,
+        "label": "3,020,000",
+        "out_x": 77.19,
+        "out_y": 197.58,
+        "width_pct": -4.1
+       },
+       {
+        "dx": 1.4,
+        "dy": -6.42,
+        "gt_x": 70.0,
+        "gt_y": 218.0,
+        "label": "17,480,000",
+        "out_x": 71.4,
+        "out_y": 211.58,
+        "width_pct": -4.01
+       }
+      ]
+     },
+     "lines": {
+      "deviant": 7,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 7,
+      "matched": 7,
+      "missing": 0,
+      "missing_text": [],
+      "out": 7
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 6,
+      "worst_delta": 1.65
+     },
+     "rects": {
+      "gt_count": 12,
+      "matched": 2,
+      "mean_center_delta": 3.0,
+      "out_count": 24
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 3.5,
+      "worst_pct": 4.1
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "xlsx",
+   "gt_pages": 1,
+   "id": "xlsx-project-schedule-en",
+   "noise_floor_pt": 0.5,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.75,
+      "worst_dy": 1.47,
+      "worst_dy_signed": -1.47,
+      "worst_line": "WebsiteRedesign\u2014ProjectSchedule"
+     },
+     "dx0": {
+      "mean_abs": 0.27,
+      "worst": 0.6
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 10,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 10,
+      "matched": 10,
+      "missing": 0,
+      "missing_text": [],
+      "out": 10
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 9,
+      "worst_delta": 0.5
+     },
+     "rects": {
+      "gt_count": 22,
+      "matched": 0,
+      "mean_center_delta": 0.0,
+      "out_count": 137
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.31,
+      "worst_pct": 2.32
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "xlsx",
+   "gt_pages": 1,
+   "id": "xlsx-sales-dashboard-en",
+   "noise_floor_pt": 0.5,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.75,
+      "worst_dy": 1.47,
+      "worst_dy_signed": -1.47,
+      "worst_line": "RegionalSalesDashboard\u2014H12026"
+     },
+     "dx0": {
+      "mean_abs": 0.01,
+      "worst": 0.06
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 8,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 9,
+      "matched": 9,
+      "missing": 0,
+      "missing_text": [],
+      "out": 9
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 8,
+      "worst_delta": 0.5
+     },
+     "rects": {
+      "gt_count": 49,
+      "matched": 30,
+      "mean_center_delta": 0.5,
+      "out_count": 173
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.62,
+      "worst_pct": 2.78
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "xlsx",
+   "gt_pages": 1,
+   "id": "xlsx-attendance-ko",
+   "noise_floor_pt": 0.5,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 2.75,
+      "worst_dy": 6.02,
+      "worst_dy_signed": -6.02,
+      "worst_line": "6\ud55c\ub3c4\uc724\u00d7\u00d7\u25cb\u25cb\u25cb60.0%"
+     },
+     "dx0": {
+      "mean_abs": 0.18,
+      "worst": 0.25
+     },
+     "instances": {
+      "large_shift_count": 2,
+      "large_shift_threshold": 5.0,
+      "large_shifts": [
+       {
+        "dx": 0.25,
+        "dy": -5.02,
+        "gt_x": 72.0,
+        "gt_y": 204.0,
+        "label": "5\uc815\ud558\uc724\u25cb\u25cb\u25cb\u25cb\u00d780.0%",
+        "out_x": 72.25,
+        "out_y": 198.98,
+        "width_pct": -0.31
+       },
+       {
+        "dx": 0.25,
+        "dy": -6.02,
+        "gt_x": 72.0,
+        "gt_y": 219.0,
+        "label": "6\ud55c\ub3c4\uc724\u00d7\u00d7\u25cb\u25cb\u25cb60.0%",
+        "out_x": 72.25,
+        "out_y": 212.98,
+        "width_pct": -0.31
+       }
+      ]
+     },
+     "lines": {
+      "deviant": 7,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 10,
+      "matched": 8,
+      "missing": 0,
+      "missing_text": [],
+      "out": 9
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 7,
+      "worst_delta": 1.0
+     },
+     "rects": {
+      "gt_count": 20,
+      "matched": 0,
+      "mean_center_delta": 0.0,
+      "out_count": 156
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.51,
+      "worst_pct": 2.13
+     },
+     "wraps": {
+      "count": 1,
+      "samples": [
+       "\uc77c\uc790\ubcc4\ucd9c\uc11d\uc778\uc6d0"
+      ]
+     }
+    }
+   ]
+  },
+  {
+   "format": "xlsx",
+   "gt_pages": 1,
+   "id": "xlsx-budget-ko",
+   "noise_floor_pt": 0.5,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.98,
+      "worst_dy": 2.02,
+      "worst_dy_signed": -2.02,
+      "worst_line": "\uacbd\uc601\uc9c0\uc6d094,000,00024.7%"
+     },
+     "dx0": {
+      "mean_abs": 0.0,
+      "worst": 0.0
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 3,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 12,
+      "matched": 4,
+      "missing": 0,
+      "missing_text": [],
+      "out": 20
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 3,
+      "worst_delta": 1.0
+     },
+     "rects": {
+      "gt_count": 18,
+      "matched": 0,
+      "mean_center_delta": 0.0,
+      "out_count": 82
+     },
+     "reflow": {
+      "gt_lines": 8,
+      "out_lines": 16,
+      "samples": [
+       "\ud074\ub77c\uc6b0\ub4dc\uc778\ud504\ub77c84,000,000",
+       "\uac1c\ubc1c\ud300\uac1c\ubc1c\ub3c4\uad6c\ub77c\uc774\uc120\uc2a422,000,000121,000,00031.8%",
+       "\uad50\uc721/\ucee8\ud37c\ub7f0\uc2a415,000,000"
+      ]
+     },
+     "width": {
+      "mean_abs_pct": 0.51,
+      "worst_pct": 1.67
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "xlsx",
+   "gt_pages": 1,
+   "id": "xlsx-expense-report-en",
+   "noise_floor_pt": 0.5,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.85,
+      "worst_dy": 1.47,
+      "worst_dy_signed": -1.47,
+      "worst_line": "BusinessTripExpenseReport\u2014Berlin,June2026"
+     },
+     "dx0": {
+      "mean_abs": 1.59,
+      "worst": 4.17
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 10,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 10,
+      "matched": 10,
+      "missing": 0,
+      "missing_text": [],
+      "out": 10
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 9,
+      "worst_delta": 0.5
+     },
+     "rects": {
+      "gt_count": 18,
+      "matched": 0,
+      "mean_center_delta": 0.0,
+      "out_count": 102
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.91,
+      "worst_pct": 2.46
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  },
+  {
+   "format": "xlsx",
+   "gt_pages": 1,
+   "id": "xlsx-kpi-tracker-en",
+   "noise_floor_pt": 0.5,
+   "out_pages": 1,
+   "page_parity": true,
+   "pages": [
+    {
+     "baseline": {
+      "mean_abs_dy": 0.75,
+      "worst_dy": 1.47,
+      "worst_dy_signed": -1.47,
+      "worst_line": "ProductKPITracker\u2014Q22026"
+     },
+     "dx0": {
+      "mean_abs": 0.04,
+      "worst": -0.33
+     },
+     "instances": {
+      "large_shift_count": 0,
+      "large_shift_threshold": 5.0,
+      "large_shifts": []
+     },
+     "lines": {
+      "deviant": 8,
+      "extra": 0,
+      "extra_text": [],
+      "gt": 9,
+      "matched": 9,
+      "missing": 0,
+      "missing_text": [],
+      "out": 9
+     },
+     "noise_floor": 0.5,
+     "pitch": {
+      "pairs": 8,
+      "worst_delta": 0.5
+     },
+     "rects": {
+      "gt_count": 16,
+      "matched": 0,
+      "mean_center_delta": 0.0,
+      "out_count": 103
+     },
+     "reflow": {
+      "gt_lines": 0,
+      "out_lines": 0,
+      "samples": []
+     },
+     "width": {
+      "mean_abs_pct": 0.96,
+      "worst_pct": 4.97
+     },
+     "wraps": {
+      "count": 0,
+      "samples": []
+     }
+    }
+   ]
+  }
+ ],
+ "generator": "scripts/generate_layout_baselines.py",
+ "large_shift_pt": 5.0,
+ "noise_floors_pt": {
+  "docx": 0.12,
+  "pptx": 0.12,
+  "xlsx": 0.5
+ },
+ "office2pdf_version": "office2pdf 0.6.7",
+ "repository_commit": "05f1df754c990ecb695e20b9e57914eea22dfa6c-dirty",
+ "schema_version": 2,
+ "summary": {
+  "cases": 30,
+  "deviant_lines": 394,
+  "extra_lines": 0,
+  "large_shifts": 14,
+  "missing_lines": 0,
+  "page_parity_cases": 30,
+  "pages_compared": 54
+ }
+}


### PR DESCRIPTION
## Summary

- `scripts/generate_layout_baselines.py` converts every business golden mock with a local office2pdf build and records the `compare_layout` per-page deviation vector (matched/missing/extra lines, baseline dy stats, dx0, width drift, pitch deltas, wraps/reflows, large instance shifts with labels, rect census) into `tests/golden_mocks/business/baselines/layout.json`, using the per-format noise floor (0.12pt Word/PowerPoint, 0.5pt Excel)
- the producer refuses to record from a GT that fails the `check_gt_integrity.py` gate (a corrupt export must never be baked into a baseline again, #616) and hard-fails on a zero-page trace, which on mutool 1.23.x used to look exactly like a perfect comparison (#808)
- `scripts/check_layout_baselines.py` diffs a fresh document against the stored one under the measurement-noise tolerance policy (±0.24pt for Word/PowerPoint cases — the native export quantises to a 0.24pt grid; ±1.0pt for Excel, whose Quartz export rounds advances to whole points; ±0.5% width; counts exact) and exits nonzero only on a regression, so a fix PR's regenerated baseline diff is the quantitative before/after and collateral regressions surface as vector deltas instead of a moved AE scalar
- the recorded baseline covers all 30 cases (54 pages, page parity everywhere, 0 missing lines, 14 large instance shifts preserved as the current known deviation); regeneration on the same tree is byte-identical
- the Business Golden Contract job now structurally validates the baseline against the manifest (schema version, case-ID set, `gt_pages` agreement, per-page vector coverage and sections) and runs the two new unit-test suites, so the file has a producer and a consumer from day one — the scoping comments on the issue found the previous `baselines/` file had neither

## Related issue

Related: #697

## Testing

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 143 tests, OK (29 new: 11 producer, 18 consumer; plus 7 new validator tests)
- `python3 scripts/validate_business_golden_mocks.py` — validates the corpus and the new baseline against the manifest
- determinism: two producer runs on the same tree produce byte-identical `layout.json`; `check_layout_baselines.py` on stored-vs-fresh reports "no material change" and exits 0
- documentation freshness audit: PASS

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: tooling and test-fixture metadata only; no converter code changes, so rendered output is unchanged.
