### PR TITLE
feat(tooling): add one-factor export probe harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
         run: python3 -m unittest discover -s scripts/tests -p 'test_compare_text_layer.py'
       - name: Test GT integrity gate
         run: python3 -m unittest discover -s scripts/tests -p 'test_check_gt_integrity.py'
+      - name: Test probe harness
+        run: python3 -m unittest discover -s scripts/tests -p 'test_probe_harness.py'
       - name: Validate visual PR contract
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,21 @@ The tool's `## Reading` section is the part to act on — it routes attention to
 the defect class (pagination, line advance, indent, fill, size) instead of
 leaving a bare number to be over-interpreted.
 
+### One-factor probe harness (`scripts/probe_harness.py`)
+
+To settle a layout rule, don't compare corpus files — patch one factor:
+`python3 scripts/probe_harness.py SPEC.json [--backend office2pdf|soffice|office]`
+takes a base fixture plus one-factor XML patches (JSON spec; see the script
+docstring), builds a variant package per patch and a no-patch re-zip control,
+exports the batch, and runs `compare_layout.py` into one table — one row per
+variant, keyed by the factor value. The control is a hard gate: if its export
+deviates from the base's, the run aborts, because repackaging (not the factor)
+changed the output. Differ failures abort likewise, never an empty row.
+Backend `office2pdf` answers "what does our code do" anywhere in seconds
+(`--converter` names the binary); `office` drives the native AppleScripts and
+answers "what does Office do" — its stage must sit on the internal disk (the
+Office sandbox cannot write to `/Volumes`; the harness enforces this).
+
 ### Fine-detail analysis (thin and small elements)
 
 Whole-page thumbnails at 80 DPI hide hairlines, dash patterns, font weight, and sub-pixel offsets. For every compared page:

--- a/scripts/probe_harness.py
+++ b/scripts/probe_harness.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+"""Semi-automated one-factor native-export probe harness (#698).
+
+Takes a base OOXML fixture plus a list of one-factor XML patches, generates a
+variant package per patch alongside a re-zip control (repackaged with no patch
+at all), batch-exports everything through a chosen backend, and runs the layout
+differ (``compare_layout.py``) over the results into one table per probe: one
+row per variant, keyed by the varied factor's value.
+
+The control is a hard gate, not an option: a variant differing from the control
+by anything other than the patched factor invalidates the whole series, and
+repackaging is the step most likely to introduce that. The harness aborts when
+the control's export deviates from the base's.
+
+Backends:
+
+- ``office2pdf`` (default) — our own converter. Answers "what does our code do
+  with this attribute", runs anywhere in seconds.
+- ``soffice`` — headless LibreOffice, the only reference available without a
+  Mac.
+- ``office`` — native Office via ``scripts/macos/export_*_pdfs.applescript``
+  (picked by the base fixture's extension). Answers "what does Office do".
+  The Office apps are sandboxed and cannot write to external volumes (a save
+  under ``/Volumes`` hangs with AppleEvent timeout -1712), so the stage must
+  sit on the internal disk.
+
+A differ failure always propagates: a probe row built from a differ that
+silently reported nothing would show the variant as identical to the control,
+which is exactly the answer a one-factor probe is looking for and exactly the
+wrong one (#810).
+
+Probe spec (JSON; paths resolve relative to the spec file)::
+
+    {
+      "name": "spcAft-linearity",
+      "base": "base.pptx",
+      "part": "ppt/slides/slide1.xml",
+      "factor": "a:spcAft val",
+      "page": 1,            // optional, forwarded to the differ
+      "noise_floor": 0.12,  // optional, forwarded to the differ
+      "variants": [
+        {"value": "500", "find": "val=\\"1000\\"", "replace": "val=\\"500\\""},
+        {"value": "ctr", "find": "anchor=\\"[a-z]+\\"", "replace": "anchor=\\"ctr\\"",
+         "regex": true, "count": 1}
+      ]
+    }
+
+Usage:
+    probe_harness.py SPEC.json [SPEC.json ...] [--backend office2pdf|soffice|office]
+                     [--converter PATH] [--stage-root DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPTS_DIR.parent
+COMPARE_LAYOUT = SCRIPTS_DIR / "compare_layout.py"
+APPLESCRIPT_BY_EXTENSION = {
+    ".docx": SCRIPTS_DIR / "macos" / "export_word_pdfs.applescript",
+    ".pptx": SCRIPTS_DIR / "macos" / "export_powerpoint_pdfs.applescript",
+    ".xlsx": SCRIPTS_DIR / "macos" / "export_excel_pdfs.applescript",
+}
+
+SPEC_KEYS = {"name", "base", "part", "factor", "page", "noise_floor", "variants"}
+SPEC_REQUIRED_KEYS = ("name", "base", "part", "variants")
+VARIANT_KEYS = {"value", "find", "replace", "regex", "count"}
+VARIANT_REQUIRED_KEYS = ("value", "find", "replace")
+
+
+class ProbeError(Exception):
+    """A condition that invalidates the probe; the run must stop, not report."""
+
+
+@dataclass(frozen=True)
+class Variant:
+    value: str
+    find: str
+    replace: str
+    regex: bool = False
+    count: int | None = None
+
+
+@dataclass(frozen=True)
+class Spec:
+    name: str
+    base: Path
+    part: str
+    factor: str
+    variants: list[Variant] = field(default_factory=list)
+    page: int | None = None
+    noise_floor: float | None = None
+
+
+def run_command(argv: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(argv, capture_output=True, text=True)
+
+
+def load_spec(path: Path) -> Spec:
+    try:
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        raise ProbeError(f"cannot read probe spec {path}: {error}") from error
+    if not isinstance(raw, dict):
+        raise ProbeError(f"probe spec {path} must be a JSON object")
+    for key in SPEC_REQUIRED_KEYS:
+        if key not in raw:
+            raise ProbeError(f"probe spec {path} is missing required key '{key}'")
+    unknown = sorted(set(raw) - SPEC_KEYS)
+    if unknown:
+        raise ProbeError(f"probe spec {path} has unknown key(s): {', '.join(unknown)}")
+
+    variants: list[Variant] = []
+    for index, entry in enumerate(raw["variants"]):
+        if not isinstance(entry, dict):
+            raise ProbeError(f"variant #{index + 1} must be a JSON object")
+        for key in VARIANT_REQUIRED_KEYS:
+            if key not in entry:
+                raise ProbeError(f"variant #{index + 1} is missing required key '{key}'")
+        unknown = sorted(set(entry) - VARIANT_KEYS)
+        if unknown:
+            raise ProbeError(f"variant #{index + 1} has unknown key(s): {', '.join(unknown)}")
+        variants.append(
+            Variant(
+                value=str(entry["value"]),
+                find=entry["find"],
+                replace=entry["replace"],
+                regex=bool(entry.get("regex", False)),
+                count=entry["count"] if entry.get("count") is not None else None,
+            )
+        )
+    if not variants:
+        raise ProbeError(f"probe spec {path} has no variants — nothing to probe")
+    values = [variant.value for variant in variants]
+    duplicates = sorted({value for value in values if values.count(value) > 1})
+    if duplicates:
+        raise ProbeError(f"duplicate variant value(s): {', '.join(duplicates)}")
+
+    return Spec(
+        name=str(raw["name"]),
+        base=(Path(path).resolve().parent / raw["base"]).resolve(),
+        part=raw["part"],
+        factor=str(raw.get("factor", "variant")),
+        variants=variants,
+        page=int(raw["page"]) if raw.get("page") is not None else None,
+        noise_floor=float(raw["noise_floor"]) if raw.get("noise_floor") is not None else None,
+    )
+
+
+def apply_patch(text: str, variant: Variant) -> tuple[str, int]:
+    """Apply one variant's patch, returning the patched text and match count.
+
+    Zero matches is an error: a no-op patch would export a variant identical
+    to the control, and the table would read "this factor does nothing".
+    """
+    if variant.regex:
+        patched, count = re.subn(variant.find, variant.replace, text)
+    else:
+        count = text.count(variant.find)
+        patched = text.replace(variant.find, variant.replace)
+    if count == 0:
+        raise ProbeError(f"variant '{variant.value}': patch matched nothing in the part")
+    if variant.count is not None and count != variant.count:
+        raise ProbeError(
+            f"variant '{variant.value}': expected {variant.count} match(es), found {count}"
+        )
+    return patched, count
+
+
+def suspicious_members(names: list[str]) -> list[str]:
+    """AppleDouble / Finder members that mark a fixture repackaged by macOS tools.
+
+    ``_rels/.rels`` is legitimate OOXML, so only the macOS artifacts are
+    flagged, not every dot-named member.
+    """
+    flagged = []
+    for name in names:
+        basename = name.rsplit("/", 1)[-1]
+        if basename.startswith("._") or basename == ".DS_Store":
+            flagged.append(name)
+    return flagged
+
+
+def build_package(base: Path, out: Path, replacements: dict[str, bytes]) -> None:
+    """Write a fresh archive with the base's members, applying ``replacements``.
+
+    Always opens the target in write mode: ``zip -r`` *updates* an existing
+    archive, so a second variant silently inherits the first's members — the
+    harness must never do that. Member order, timestamps, and attributes are
+    copied from the base so rebuilding the same package is byte-deterministic,
+    which is what lets the control gate byte-compare exported PDFs.
+    """
+    with zipfile.ZipFile(base) as source:
+        missing = sorted(set(replacements) - set(source.namelist()))
+        if missing:
+            raise ProbeError(f"part(s) not present in {base.name}: {', '.join(missing)}")
+        with zipfile.ZipFile(out, "w") as target:
+            for info in source.infolist():
+                member = zipfile.ZipInfo(info.filename, date_time=info.date_time)
+                member.compress_type = zipfile.ZIP_DEFLATED
+                member.external_attr = info.external_attr
+                member.create_system = 3
+                data = replacements.get(info.filename, source.read(info.filename))
+                target.writestr(member, data)
+
+
+def ensure_internal_disk(path: Path) -> None:
+    parts = Path(path).parts
+    if len(parts) >= 2 and parts[0] == "/" and parts[1] == "Volumes":
+        raise ProbeError(
+            f"{path} sits on an external volume; the Office sandbox cannot write there "
+            "(AppleEvent timeout -1712) — stage on the internal disk"
+        )
+
+
+def applescript_for(extension: str) -> Path:
+    script = APPLESCRIPT_BY_EXTENSION.get(extension.lower())
+    if script is None:
+        raise ProbeError(f"no native export AppleScript for '{extension.lstrip('.')}' fixtures")
+    return script
+
+
+def _check_export(argv: list[str], result: subprocess.CompletedProcess) -> None:
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise ProbeError(f"export command failed ({argv[0]}): {detail}")
+
+
+def _unite_excel_sheets(job_id: str, pdf_dir: Path, runner) -> None:
+    sheets = sorted(pdf_dir.glob(f"{job_id}-sheet-*.pdf"))
+    united = pdf_dir / f"{job_id}.pdf"
+    if not sheets:
+        raise ProbeError(f"no Excel sheet PDFs found for {job_id}")
+    if len(sheets) == 1:
+        shutil.copyfile(sheets[0], united)
+        return
+    argv = ["pdfunite", *[str(sheet) for sheet in sheets], str(united)]
+    _check_export(argv, runner(argv))
+
+
+def export_all(
+    backend: str,
+    jobs: list[tuple[str, Path]],
+    pdf_dir: Path,
+    converter: str = "office2pdf",
+    runner=run_command,
+) -> None:
+    """Export every (job_id, package) to ``pdf_dir/<job_id>.pdf`` via ``backend``."""
+    if backend == "office2pdf":
+        for job_id, package in jobs:
+            argv = [converter, str(package), "-o", str(pdf_dir / f"{job_id}.pdf")]
+            _check_export(argv, runner(argv))
+    elif backend == "soffice":
+        for _, package in jobs:
+            argv = [
+                "soffice",
+                "--headless",
+                "--convert-to",
+                "pdf",
+                "--outdir",
+                str(pdf_dir),
+                str(package),
+            ]
+            _check_export(argv, runner(argv))
+    elif backend == "office":
+        ensure_internal_disk(pdf_dir)
+        for _, package in jobs:
+            ensure_internal_disk(package)
+        extensions = {package.suffix.lower() for _, package in jobs}
+        if len(extensions) != 1:
+            raise ProbeError(f"mixed package extensions in one export batch: {sorted(extensions)}")
+        extension = next(iter(extensions))
+        argv = ["osascript", str(applescript_for(extension)), str(pdf_dir)]
+        for job_id, package in jobs:
+            argv += [job_id, str(package)]
+        _check_export(argv, runner(argv))
+        if extension == ".xlsx":
+            for job_id, _ in jobs:
+                _unite_excel_sheets(job_id, pdf_dir, runner)
+    else:
+        raise ProbeError(f"unknown backend '{backend}'")
+
+    for job_id, _ in jobs:
+        pdf = pdf_dir / f"{job_id}.pdf"
+        if not pdf.is_file() or pdf.stat().st_size == 0:
+            raise ProbeError(f"exporter produced no PDF for {job_id} ({pdf})")
+
+
+def run_differ(
+    gt: Path,
+    output: Path,
+    page: int | None = None,
+    noise_floor: float | None = None,
+    runner=run_command,
+) -> dict:
+    """Run compare_layout.py --json and return its report.
+
+    A nonzero exit always propagates. Before #810 a zero-page trace printed an
+    empty report with exit status 0, which reads as "no differences" — the
+    exact answer a one-factor probe is looking for, and exactly the wrong one.
+    """
+    argv = [sys.executable, str(COMPARE_LAYOUT), str(gt), str(output), "--json"]
+    if page is not None:
+        argv += ["--page", str(page)]
+    if noise_floor is not None:
+        argv += ["--noise-floor", str(noise_floor)]
+    result = runner(argv)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise ProbeError(f"layout differ failed on {output.name}: {detail}")
+    try:
+        return json.loads(result.stdout)
+    except ValueError as error:
+        raise ProbeError(f"layout differ emitted no JSON for {output.name}: {error}") from error
+
+
+def layout_identical_failures(report: dict) -> list[str]:
+    """Reasons the report is not layout-identical; empty means identical."""
+    failures: list[str] = []
+    if report["gt_pages"] != report["out_pages"]:
+        failures.append(f"page count {report['gt_pages']} vs {report['out_pages']}")
+    for index, vector in enumerate(report["pages"], start=1):
+        lines = vector["lines"]
+        for key in ("missing", "extra", "deviant"):
+            if lines[key]:
+                failures.append(f"page {index}: {lines[key]} {key} line(s)")
+        if vector["wraps"]["count"]:
+            failures.append(f"page {index}: {vector['wraps']['count']} re-wrapped paragraph(s)")
+        if vector["reflow"]["gt_lines"]:
+            failures.append(f"page {index}: {vector['reflow']['gt_lines']} re-grouped line(s)")
+        if vector["instances"]["large_shift_count"]:
+            failures.append(
+                f"page {index}: {vector['instances']['large_shift_count']} large shift(s)"
+            )
+        rects = vector["rects"]
+        if rects["gt_count"] != rects["out_count"]:
+            failures.append(f"page {index}: rects {rects['gt_count']} vs {rects['out_count']}")
+    return failures
+
+
+def verify_control(
+    base_pdf: Path,
+    control_pdf: Path,
+    page: int | None = None,
+    noise_floor: float | None = None,
+    runner=run_command,
+) -> str:
+    """Gate the run on the re-zip control; return the verdict for the report.
+
+    Byte equality is the strongest verdict; native Office stamps timestamps
+    into every export, so a clean differ report is the fallback there.
+    """
+    if base_pdf.read_bytes() == control_pdf.read_bytes():
+        return "byte-identical re-zip"
+    report = run_differ(base_pdf, control_pdf, page=page, noise_floor=noise_floor, runner=runner)
+    failures = layout_identical_failures(report)
+    if failures:
+        raise ProbeError(
+            "re-zip control deviates from the base export — repackaging changed the "
+            "output and no variant row can be trusted: " + "; ".join(failures)
+        )
+    return "layout-identical re-zip (bytes differ)"
+
+
+def variant_row(value: str, patched: int, report: dict) -> dict:
+    """Collapse a differ report into one table row for this variant."""
+    vectors = report["pages"]
+    matched = sum(vector["lines"]["matched"] for vector in vectors)
+    weighted_dy = sum(
+        vector["baseline"]["mean_abs_dy"] * vector["lines"]["matched"] for vector in vectors
+    )
+    worst_dy = max(
+        (vector["baseline"]["worst_dy_signed"] for vector in vectors), key=abs, default=0.0
+    )
+    return {
+        "value": value,
+        "patched": patched,
+        "pages": f"{report['gt_pages']}/{report['out_pages']}",
+        "matched": matched,
+        "missing": sum(vector["lines"]["missing"] for vector in vectors),
+        "extra": sum(vector["lines"]["extra"] for vector in vectors),
+        "wraps": sum(vector["wraps"]["count"] for vector in vectors),
+        "deviant": sum(vector["lines"]["deviant"] for vector in vectors),
+        "mean_abs_dy": weighted_dy / matched if matched else 0.0,
+        "worst_dy": worst_dy,
+        "worst_pitch": max((vector["pitch"]["worst_delta"] for vector in vectors), default=0.0),
+        "worst_width": max((vector["width"]["worst_pct"] for vector in vectors), default=0.0),
+        "large_shifts": sum(vector["instances"]["large_shift_count"] for vector in vectors),
+        "rects": "{}/{}".format(
+            sum(vector["rects"]["gt_count"] for vector in vectors),
+            sum(vector["rects"]["out_count"] for vector in vectors),
+        ),
+    }
+
+
+def render_table(spec: Spec, backend: str, control_verdict: str, rows: list[dict]) -> str:
+    """One markdown table per probe: one row per variant, keyed by the factor."""
+    columns = (
+        "patched",
+        "pages",
+        "matched",
+        "missing",
+        "extra",
+        "wraps",
+        "deviant",
+        "mean abs dy (pt)",
+        "worst dy (pt)",
+        "worst pitch (pt)",
+        "worst width (%)",
+        "large shifts",
+        "rects",
+    )
+    lines = [
+        f"# Probe: {spec.name}",
+        "",
+        f"- base: {spec.base.name}",
+        f"- part: {spec.part}",
+        f"- backend: {backend}",
+        f"- control: {control_verdict}",
+        "",
+        "| " + " | ".join((spec.factor, *columns)) + " |",
+        "| " + " | ".join("---" for _ in range(len(columns) + 1)) + " |",
+    ]
+    for row in rows:
+        cells = (
+            row["value"],
+            str(row["patched"]),
+            row["pages"],
+            str(row["matched"]),
+            str(row["missing"]),
+            str(row["extra"]),
+            str(row["wraps"]),
+            str(row["deviant"]),
+            f"{row['mean_abs_dy']:.2f}",
+            f"{row['worst_dy']:+.2f}",
+            f"{row['worst_pitch']:.2f}",
+            f"{row['worst_width']:.1f}",
+            str(row["large_shifts"]),
+            row["rects"],
+        )
+        lines.append("| " + " | ".join(cells) + " |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", value)
+
+
+def run_probe(
+    spec_path: Path,
+    backend: str = "office2pdf",
+    converter: str = "office2pdf",
+    stage_root: Path | None = None,
+    runner=run_command,
+) -> Path:
+    """Run one probe spec end to end; return the written report path."""
+    spec = load_spec(spec_path)
+    stage = (stage_root or REPO_ROOT / "target" / "probes") / spec.name
+    if backend == "office":
+        ensure_internal_disk(stage)
+    packages_dir = stage / "packages"
+    pdf_dir = stage / "pdfs"
+    packages_dir.mkdir(parents=True, exist_ok=True)
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+
+    if not spec.base.is_file():
+        raise ProbeError(f"base fixture not found: {spec.base}")
+    extension = spec.base.suffix.lower()
+    with zipfile.ZipFile(spec.base) as archive:
+        names = archive.namelist()
+        if spec.part not in names:
+            raise ProbeError(f"part '{spec.part}' not present in {spec.base.name}")
+        part_text = archive.read(spec.part).decode("utf-8")
+    flagged = suspicious_members(names)
+    if flagged:
+        print(
+            f"[{spec.name}] warning: base carries macOS artifact member(s) "
+            f"({', '.join(flagged)}); they are preserved, but the fixture was likely "
+            "repackaged by Finder/tar and is worth rebuilding",
+            file=sys.stderr,
+        )
+
+    # Patch every variant before exporting anything, so a bad patch aborts
+    # the run without a half-finished export batch behind it.
+    patched: list[tuple[Variant, int, Path]] = []
+    for variant in spec.variants:
+        text, count = apply_patch(part_text, variant)
+        package = packages_dir / f"variant-{_slug(variant.value)}{extension}"
+        build_package(spec.base, package, {spec.part: text.encode("utf-8")})
+        patched.append((variant, count, package))
+
+    base_package = packages_dir / f"base{extension}"
+    shutil.copyfile(spec.base, base_package)
+    control_package = packages_dir / f"control{extension}"
+    build_package(spec.base, control_package, {})
+
+    jobs = [("base", base_package), ("control", control_package)]
+    jobs += [(package.stem, package) for _, _, package in patched]
+    print(f"[{spec.name}] exporting {len(jobs)} package(s) via {backend}", file=sys.stderr)
+    export_all(backend, jobs, pdf_dir, converter=converter, runner=runner)
+
+    control_verdict = verify_control(
+        pdf_dir / "base.pdf",
+        pdf_dir / "control.pdf",
+        page=spec.page,
+        noise_floor=spec.noise_floor,
+        runner=runner,
+    )
+    print(f"[{spec.name}] control gate: {control_verdict}", file=sys.stderr)
+
+    rows = [
+        variant_row(
+            variant.value,
+            count,
+            run_differ(
+                pdf_dir / "control.pdf",
+                pdf_dir / f"{package.stem}.pdf",
+                page=spec.page,
+                noise_floor=spec.noise_floor,
+                runner=runner,
+            ),
+        )
+        for variant, count, package in patched
+    ]
+
+    report = render_table(spec, backend, control_verdict, rows)
+    report_path = stage / "report.md"
+    report_path.write_text(report, encoding="utf-8")
+    sys.stdout.write(report)
+    return report_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("specs", nargs="+", type=Path, help="probe spec JSON file(s)")
+    parser.add_argument(
+        "--backend",
+        choices=("office2pdf", "soffice", "office"),
+        default="office2pdf",
+        help="exporter: our converter (default), headless LibreOffice, or native Office",
+    )
+    parser.add_argument(
+        "--converter",
+        default="office2pdf",
+        help="office2pdf binary for the office2pdf backend (default: from PATH)",
+    )
+    parser.add_argument(
+        "--stage-root",
+        type=Path,
+        default=None,
+        help="directory to stage packages/PDFs/reports under (default: target/probes)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        for spec_path in args.specs:
+            run_probe(
+                spec_path,
+                backend=args.backend,
+                converter=args.converter,
+                stage_root=args.stage_root,
+            )
+    except ProbeError as error:
+        print(f"probe failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_probe_harness.py
+++ b/scripts/tests/test_probe_harness.py
@@ -1,0 +1,713 @@
+"""Unit tests for the one-factor native-export probe harness (#698).
+
+Every export and differ invocation goes through an injectable runner, so the
+platform-bound stages (AppleScript export, mutool) are exercised here without a
+Mac or a converter binary. The zip traps pinned below are the ones the manual
+loop hit in practice: `zip` updating an existing archive instead of replacing
+it, and dotfile/AppleDouble members leaking into a repackaged fixture. The
+differ tests pin the #810 contract: a differ failure must propagate, never
+read as an empty (all-identical) probe row.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import unittest
+import zipfile
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import probe_harness
+
+
+SLIDE_XML = '<p:sld><a:bodyPr anchor="t"/><a:spcAft val="1000"/></p:sld>'
+
+
+def write_base_package(path: Path, slide_xml: str = SLIDE_XML, extra: dict | None = None) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("[Content_Types].xml", "<Types/>")
+        archive.writestr("ppt/presentation.xml", "<p:presentation/>")
+        archive.writestr("ppt/slides/slide1.xml", slide_xml)
+        for name, data in (extra or {}).items():
+            archive.writestr(name, data)
+
+
+def write_spec(directory: Path, overrides: dict | None = None, base_name: str = "base.pptx") -> Path:
+    spec = {
+        "name": "spcAft-linearity",
+        "base": base_name,
+        "part": "ppt/slides/slide1.xml",
+        "factor": "a:spcAft val",
+        "variants": [
+            {"value": "500", "find": 'val="1000"', "replace": 'val="500"'},
+            {"value": "2000", "find": 'val="1000"', "replace": 'val="2000"'},
+        ],
+    }
+    spec.update(overrides or {})
+    path = directory / "probe.json"
+    path.write_text(json.dumps(spec))
+    return path
+
+
+def completed(argv: list[str], returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(argv, returncode, stdout=stdout, stderr=stderr)
+
+
+def page_vector(
+    matched: int = 12,
+    missing: int = 0,
+    extra: int = 0,
+    deviant: int = 0,
+    wraps: int = 0,
+    reflow: int = 0,
+    large_shifts: int = 0,
+    mean_abs_dy: float = 0.0,
+    worst_dy: float = 0.0,
+    worst_pitch: float = 0.0,
+    worst_width: float = 0.0,
+    rects: tuple[int, int] = (3, 3),
+) -> dict:
+    """A differ page vector with the same shape compare_layout.py --json emits."""
+    return {
+        "lines": {
+            "gt": matched + missing,
+            "out": matched + extra,
+            "matched": matched,
+            "missing": missing,
+            "extra": extra,
+            "deviant": deviant,
+            "missing_text": [],
+            "extra_text": [],
+        },
+        "baseline": {
+            "mean_abs_dy": mean_abs_dy,
+            "worst_dy": abs(worst_dy),
+            "worst_dy_signed": worst_dy,
+            "worst_line": "",
+        },
+        "dx0": {"mean_abs": 0.0, "worst": 0.0},
+        "width": {"mean_abs_pct": 0.0, "worst_pct": worst_width},
+        "instances": {
+            "large_shift_threshold": 5.0,
+            "large_shift_count": large_shifts,
+            "large_shifts": [],
+        },
+        "pitch": {"pairs": max(matched - 1, 0), "worst_delta": worst_pitch},
+        "wraps": {"count": wraps, "samples": []},
+        "reflow": {"gt_lines": reflow, "out_lines": reflow},
+        "rects": {
+            "gt_count": rects[0],
+            "out_count": rects[1],
+            "matched": min(rects),
+            "mean_center_delta": 0.0,
+        },
+        "noise_floor": 0.12,
+    }
+
+
+def differ_report(*vectors: dict, gt_pages: int | None = None, out_pages: int | None = None) -> dict:
+    return {
+        "pages": list(vectors),
+        "gt_pages": len(vectors) if gt_pages is None else gt_pages,
+        "out_pages": len(vectors) if out_pages is None else out_pages,
+    }
+
+
+class SpecTest(unittest.TestCase):
+    def test_base_path_resolves_relative_to_the_spec_file(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            write_base_package(tmp / "base.pptx")
+            spec = probe_harness.load_spec(write_spec(tmp))
+            self.assertEqual(spec.base, (tmp / "base.pptx").resolve())
+            self.assertEqual(spec.name, "spcAft-linearity")
+            self.assertEqual([v.value for v in spec.variants], ["500", "2000"])
+
+    def test_a_missing_required_key_is_a_probe_error(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            path = write_spec(tmp)
+            spec = json.loads(path.read_text())
+            del spec["part"]
+            path.write_text(json.dumps(spec))
+            with self.assertRaisesRegex(probe_harness.ProbeError, "part"):
+                probe_harness.load_spec(path)
+
+    def test_duplicate_variant_values_are_rejected(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            path = write_spec(
+                tmp,
+                {
+                    "variants": [
+                        {"value": "500", "find": "a", "replace": "b"},
+                        {"value": "500", "find": "a", "replace": "c"},
+                    ]
+                },
+            )
+            with self.assertRaisesRegex(probe_harness.ProbeError, "duplicate"):
+                probe_harness.load_spec(path)
+
+    def test_an_empty_variant_list_is_rejected(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            path = write_spec(tmp, {"variants": []})
+            with self.assertRaisesRegex(probe_harness.ProbeError, "variant"):
+                probe_harness.load_spec(path)
+
+
+class PatchTest(unittest.TestCase):
+    def variant(self, **overrides) -> probe_harness.Variant:
+        fields = {"value": "500", "find": 'val="1000"', "replace": 'val="500"'}
+        fields.update(overrides)
+        return probe_harness.Variant(**fields)
+
+    def test_a_literal_patch_replaces_and_reports_the_count(self):
+        patched, count = probe_harness.apply_patch(SLIDE_XML, self.variant())
+        self.assertIn('val="500"', patched)
+        self.assertNotIn('val="1000"', patched)
+        self.assertEqual(count, 1)
+
+    def test_a_patch_that_matches_nothing_is_an_error(self):
+        # A no-op patch would export a variant identical to the control and
+        # read as "this factor does nothing" — the probe must refuse to run.
+        with self.assertRaisesRegex(probe_harness.ProbeError, "500"):
+            probe_harness.apply_patch(SLIDE_XML, self.variant(find='val="9999"'))
+
+    def test_a_regex_patch_substitutes_by_pattern(self):
+        patched, count = probe_harness.apply_patch(
+            SLIDE_XML,
+            self.variant(find=r'anchor="[a-z]+"', replace='anchor="ctr"', regex=True),
+        )
+        self.assertIn('anchor="ctr"', patched)
+        self.assertEqual(count, 1)
+
+    def test_an_expected_count_mismatch_is_an_error(self):
+        with self.assertRaisesRegex(probe_harness.ProbeError, "expected 2"):
+            probe_harness.apply_patch(SLIDE_XML, self.variant(count=2))
+
+    def test_multiple_matches_are_allowed_and_counted(self):
+        xml = SLIDE_XML + '<a:spcBef val="1000"/>'
+        _, count = probe_harness.apply_patch(xml, self.variant())
+        self.assertEqual(count, 2)
+
+
+class MemberHygieneTest(unittest.TestCase):
+    def test_appledouble_and_dotfile_members_are_flagged(self):
+        flagged = probe_harness.suspicious_members(
+            ["ppt/slides/slide1.xml", "._slide1.xml", ".DS_Store", "ppt/._x.xml"]
+        )
+        self.assertEqual(flagged, ["._slide1.xml", ".DS_Store", "ppt/._x.xml"])
+
+    def test_ordinary_ooxml_members_are_not_flagged(self):
+        names = ["[Content_Types].xml", "_rels/.rels", "ppt/slides/slide1.xml"]
+        self.assertEqual(probe_harness.suspicious_members(names), [])
+
+
+class BuildPackageTest(unittest.TestCase):
+    def test_the_control_preserves_every_member_name_and_byte(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            base = tmp / "base.pptx"
+            write_base_package(base)
+            control = tmp / "control.pptx"
+            probe_harness.build_package(base, control, {})
+            with zipfile.ZipFile(base) as before, zipfile.ZipFile(control) as after:
+                self.assertEqual(before.namelist(), after.namelist())
+                for name in before.namelist():
+                    self.assertEqual(before.read(name), after.read(name))
+
+    def test_a_variant_changes_only_the_patched_part(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            base = tmp / "base.pptx"
+            write_base_package(base)
+            variant = tmp / "variant.pptx"
+            patched = SLIDE_XML.replace('val="1000"', 'val="500"')
+            probe_harness.build_package(
+                base, variant, {"ppt/slides/slide1.xml": patched.encode()}
+            )
+            with zipfile.ZipFile(base) as before, zipfile.ZipFile(variant) as after:
+                self.assertEqual(before.namelist(), after.namelist())
+                self.assertEqual(after.read("ppt/slides/slide1.xml"), patched.encode())
+                for name in before.namelist():
+                    if name != "ppt/slides/slide1.xml":
+                        self.assertEqual(before.read(name), after.read(name))
+
+    def test_an_existing_archive_is_replaced_not_updated(self):
+        # `zip -r` updates an archive in place, so a second variant silently
+        # inherits the first's members; the harness must always write fresh.
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            base = tmp / "base.pptx"
+            write_base_package(base)
+            out = tmp / "out.pptx"
+            with zipfile.ZipFile(out, "w") as stale:
+                stale.writestr("stale/leftover.xml", "<stale/>")
+            probe_harness.build_package(base, out, {})
+            with zipfile.ZipFile(out) as archive:
+                self.assertNotIn("stale/leftover.xml", archive.namelist())
+
+    def test_rebuilding_the_same_package_is_byte_deterministic(self):
+        # The control gate byte-compares exported PDFs; a nondeterministic
+        # repackaging step would turn that gate into noise.
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            base = tmp / "base.pptx"
+            write_base_package(base)
+            first = tmp / "first.pptx"
+            second = tmp / "second.pptx"
+            probe_harness.build_package(base, first, {})
+            probe_harness.build_package(base, second, {})
+            self.assertEqual(first.read_bytes(), second.read_bytes())
+
+
+class ExportTest(unittest.TestCase):
+    def collect_runner(self, pdfs_to_write: dict[str, bytes] | None = None):
+        calls: list[list[str]] = []
+
+        def runner(argv: list[str]) -> subprocess.CompletedProcess:
+            calls.append(list(argv))
+            for name, data in (pdfs_to_write or {}).items():
+                Path(name).write_bytes(data)
+            return completed(argv)
+
+        return calls, runner
+
+    def test_the_office2pdf_backend_converts_each_package(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            pdf_dir = tmp / "pdfs"
+            pdf_dir.mkdir()
+            (tmp / "control.pptx").write_bytes(b"zip")
+            calls = []
+
+            def runner(argv):
+                calls.append(list(argv))
+                Path(argv[3]).write_bytes(b"%PDF")
+                return completed(argv)
+
+            probe_harness.export_all(
+                "office2pdf",
+                [("control", tmp / "control.pptx")],
+                pdf_dir,
+                converter="/tmp/office2pdf",
+                runner=runner,
+            )
+            self.assertEqual(
+                calls,
+                [["/tmp/office2pdf", str(tmp / "control.pptx"), "-o", str(pdf_dir / "control.pdf")]],
+            )
+
+    def test_the_soffice_backend_converts_into_the_pdf_directory(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            pdf_dir = tmp / "pdfs"
+            pdf_dir.mkdir()
+            (tmp / "control.pptx").write_bytes(b"zip")
+            calls = []
+
+            def runner(argv):
+                calls.append(list(argv))
+                (pdf_dir / "control.pdf").write_bytes(b"%PDF")
+                return completed(argv)
+
+            probe_harness.export_all(
+                "soffice", [("control", tmp / "control.pptx")], pdf_dir, runner=runner
+            )
+            self.assertEqual(
+                calls,
+                [
+                    [
+                        "soffice",
+                        "--headless",
+                        "--convert-to",
+                        "pdf",
+                        "--outdir",
+                        str(pdf_dir),
+                        str(tmp / "control.pptx"),
+                    ]
+                ],
+            )
+
+    def test_the_office_backend_batches_one_osascript_call(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            pdf_dir = tmp / "pdfs"
+            pdf_dir.mkdir()
+            (tmp / "base.docx").write_bytes(b"zip")
+            (tmp / "variant-500.docx").write_bytes(b"zip2")
+            calls = []
+
+            def runner(argv):
+                calls.append(list(argv))
+                (pdf_dir / "base.pdf").write_bytes(b"%PDF")
+                (pdf_dir / "variant-500.pdf").write_bytes(b"%PDF")
+                return completed(argv)
+
+            probe_harness.export_all(
+                "office",
+                [("base", tmp / "base.docx"), ("variant-500", tmp / "variant-500.docx")],
+                pdf_dir,
+                runner=runner,
+            )
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0][0], "osascript")
+            self.assertTrue(calls[0][1].endswith("export_word_pdfs.applescript"))
+            self.assertEqual(
+                calls[0][2:],
+                [
+                    str(pdf_dir),
+                    "base",
+                    str(tmp / "base.docx"),
+                    "variant-500",
+                    str(tmp / "variant-500.docx"),
+                ],
+            )
+
+    def test_the_office_backend_picks_the_applescript_by_extension(self):
+        self.assertTrue(str(probe_harness.applescript_for(".docx")).endswith("export_word_pdfs.applescript"))
+        self.assertTrue(str(probe_harness.applescript_for(".pptx")).endswith("export_powerpoint_pdfs.applescript"))
+        self.assertTrue(str(probe_harness.applescript_for(".xlsx")).endswith("export_excel_pdfs.applescript"))
+        with self.assertRaisesRegex(probe_harness.ProbeError, "odt"):
+            probe_harness.applescript_for(".odt")
+
+    def test_the_office_backend_refuses_an_external_volume_stage(self):
+        # The Office sandbox cannot write to external volumes; a save there
+        # hangs with AppleEvent timeout -1712 and produces nothing.
+        calls, runner = self.collect_runner()
+        with self.assertRaisesRegex(probe_harness.ProbeError, "internal disk"):
+            probe_harness.export_all(
+                "office",
+                [("base", Path("/tmp/base.docx"))],
+                Path("/Volumes/FakeDisk/probe/pdfs"),
+                runner=runner,
+            )
+        self.assertEqual(calls, [])
+
+    def test_an_export_failure_propagates_its_stderr(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            pdf_dir = tmp / "pdfs"
+            pdf_dir.mkdir()
+            (tmp / "control.pptx").write_bytes(b"zip")
+
+            def runner(argv):
+                return completed(argv, returncode=1, stderr="conversion exploded")
+
+            with self.assertRaisesRegex(probe_harness.ProbeError, "conversion exploded"):
+                probe_harness.export_all(
+                    "office2pdf", [("control", tmp / "control.pptx")], pdf_dir, runner=runner
+                )
+
+    def test_a_missing_output_pdf_is_an_error(self):
+        # An exporter that reports success but writes nothing (or an empty
+        # file) must not produce a probe row.
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            pdf_dir = tmp / "pdfs"
+            pdf_dir.mkdir()
+            (tmp / "control.pptx").write_bytes(b"zip")
+
+            def runner(argv):
+                return completed(argv)
+
+            with self.assertRaisesRegex(probe_harness.ProbeError, "control"):
+                probe_harness.export_all(
+                    "office2pdf", [("control", tmp / "control.pptx")], pdf_dir, runner=runner
+                )
+
+    def test_excel_sheet_pdfs_are_united_per_job(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            pdf_dir = tmp / "pdfs"
+            pdf_dir.mkdir()
+            (tmp / "base.xlsx").write_bytes(b"zip")
+            calls = []
+
+            def runner(argv):
+                calls.append(list(argv))
+                if argv[0] == "osascript":
+                    (pdf_dir / "base-sheet-01.pdf").write_bytes(b"%PDF1")
+                    (pdf_dir / "base-sheet-02.pdf").write_bytes(b"%PDF2")
+                if argv[0] == "pdfunite":
+                    Path(argv[-1]).write_bytes(b"%PDF12")
+                return completed(argv)
+
+            probe_harness.export_all(
+                "office", [("base", tmp / "base.xlsx")], pdf_dir, runner=runner
+            )
+            self.assertEqual(calls[0][0], "osascript")
+            self.assertTrue(calls[0][1].endswith("export_excel_pdfs.applescript"))
+            self.assertEqual(
+                calls[1],
+                [
+                    "pdfunite",
+                    str(pdf_dir / "base-sheet-01.pdf"),
+                    str(pdf_dir / "base-sheet-02.pdf"),
+                    str(pdf_dir / "base.pdf"),
+                ],
+            )
+
+    def test_a_single_excel_sheet_is_copied_without_pdfunite(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            pdf_dir = tmp / "pdfs"
+            pdf_dir.mkdir()
+            (tmp / "base.xlsx").write_bytes(b"zip")
+            calls = []
+
+            def runner(argv):
+                calls.append(list(argv))
+                (pdf_dir / "base-sheet-01.pdf").write_bytes(b"%PDF1")
+                return completed(argv)
+
+            probe_harness.export_all(
+                "office", [("base", tmp / "base.xlsx")], pdf_dir, runner=runner
+            )
+            self.assertEqual(len(calls), 1)
+            self.assertEqual((pdf_dir / "base.pdf").read_bytes(), b"%PDF1")
+
+
+class DifferTest(unittest.TestCase):
+    def test_the_differ_report_is_parsed_from_json(self):
+        report = differ_report(page_vector())
+
+        def runner(argv):
+            self.assertEqual(argv[0], sys.executable)
+            self.assertTrue(argv[1].endswith("compare_layout.py"))
+            self.assertIn("--json", argv)
+            return completed(argv, stdout=json.dumps(report))
+
+        parsed = probe_harness.run_differ(Path("control.pdf"), Path("variant.pdf"), runner=runner)
+        self.assertEqual(parsed["gt_pages"], 1)
+
+    def test_page_and_noise_floor_are_forwarded(self):
+        seen = []
+
+        def runner(argv):
+            seen.append(list(argv))
+            return completed(argv, stdout=json.dumps(differ_report(page_vector())))
+
+        probe_harness.run_differ(
+            Path("control.pdf"), Path("variant.pdf"), page=2, noise_floor=0.5, runner=runner
+        )
+        self.assertIn("--page", seen[0])
+        self.assertIn("2", seen[0])
+        self.assertIn("--noise-floor", seen[0])
+        self.assertIn("0.5", seen[0])
+
+    def test_a_differ_failure_propagates_instead_of_reading_as_identical(self):
+        # The #810 trap: a differ that parses zero pages once exited 0 with an
+        # empty report, which reads as "variant identical to control" — the
+        # exact answer a one-factor probe is looking for, and exactly wrong.
+        def runner(argv):
+            return completed(
+                argv, returncode=1, stderr="no pages parsed from the GT trace — cannot compare"
+            )
+
+        with self.assertRaisesRegex(probe_harness.ProbeError, "no pages parsed"):
+            probe_harness.run_differ(Path("control.pdf"), Path("variant.pdf"), runner=runner)
+
+    def test_undecodable_differ_output_is_an_error(self):
+        def runner(argv):
+            return completed(argv, stdout="not json")
+
+        with self.assertRaisesRegex(probe_harness.ProbeError, "JSON"):
+            probe_harness.run_differ(Path("control.pdf"), Path("variant.pdf"), runner=runner)
+
+
+class ControlGateTest(unittest.TestCase):
+    def test_byte_identical_pdfs_pass_without_the_differ(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "base.pdf").write_bytes(b"%PDF same")
+            (tmp / "control.pdf").write_bytes(b"%PDF same")
+
+            def runner(argv):
+                raise AssertionError("differ must not run for byte-identical PDFs")
+
+            verdict = probe_harness.verify_control(
+                tmp / "base.pdf", tmp / "control.pdf", runner=runner
+            )
+            self.assertIn("byte-identical", verdict)
+
+    def test_a_layout_identical_control_passes_with_a_note(self):
+        # Native Office stamps timestamps into every export, so byte equality
+        # is unreachable there; a clean differ report is the fallback gate.
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "base.pdf").write_bytes(b"%PDF a")
+            (tmp / "control.pdf").write_bytes(b"%PDF b")
+
+            def runner(argv):
+                return completed(argv, stdout=json.dumps(differ_report(page_vector())))
+
+            verdict = probe_harness.verify_control(
+                tmp / "base.pdf", tmp / "control.pdf", runner=runner
+            )
+            self.assertIn("layout-identical", verdict)
+
+    def test_a_control_deviation_aborts_the_run(self):
+        # A control that differs from the base invalidates every variant row;
+        # nothing downstream can be trusted.
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "base.pdf").write_bytes(b"%PDF a")
+            (tmp / "control.pdf").write_bytes(b"%PDF b")
+
+            def runner(argv):
+                return completed(
+                    argv, stdout=json.dumps(differ_report(page_vector(missing=1)))
+                )
+
+            with self.assertRaisesRegex(probe_harness.ProbeError, "control"):
+                probe_harness.verify_control(tmp / "base.pdf", tmp / "control.pdf", runner=runner)
+
+    def test_a_control_page_count_mismatch_aborts_the_run(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "base.pdf").write_bytes(b"%PDF a")
+            (tmp / "control.pdf").write_bytes(b"%PDF b")
+
+            def runner(argv):
+                return completed(
+                    argv,
+                    stdout=json.dumps(differ_report(page_vector(), gt_pages=2, out_pages=1)),
+                )
+
+            with self.assertRaisesRegex(probe_harness.ProbeError, "page"):
+                probe_harness.verify_control(tmp / "base.pdf", tmp / "control.pdf", runner=runner)
+
+
+class RowTest(unittest.TestCase):
+    def test_multi_page_reports_sum_counts_and_keep_worst_magnitudes(self):
+        report = differ_report(
+            page_vector(matched=10, missing=1, wraps=1, mean_abs_dy=0.2, worst_dy=-0.5, worst_pitch=0.3),
+            page_vector(matched=30, extra=2, deviant=3, mean_abs_dy=0.6, worst_dy=1.4, worst_pitch=0.1, rects=(4, 5)),
+        )
+        row = probe_harness.variant_row("500", 1, report)
+        self.assertEqual(row["value"], "500")
+        self.assertEqual(row["patched"], 1)
+        self.assertEqual(row["pages"], "2/2")
+        self.assertEqual(row["matched"], 40)
+        self.assertEqual(row["missing"], 1)
+        self.assertEqual(row["extra"], 2)
+        self.assertEqual(row["wraps"], 1)
+        self.assertEqual(row["deviant"], 3)
+        self.assertAlmostEqual(row["mean_abs_dy"], (0.2 * 10 + 0.6 * 30) / 40)
+        self.assertAlmostEqual(row["worst_dy"], 1.4)
+        self.assertAlmostEqual(row["worst_pitch"], 0.3)
+        self.assertEqual(row["rects"], "7/8")
+
+
+class TableTest(unittest.TestCase):
+    def test_one_row_per_variant_keyed_by_the_factor_value(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            write_base_package(tmp / "base.pptx")
+            spec = probe_harness.load_spec(write_spec(tmp))
+        rows = [
+            probe_harness.variant_row("500", 1, differ_report(page_vector(worst_dy=-5.0))),
+            probe_harness.variant_row("2000", 1, differ_report(page_vector(worst_dy=20.0))),
+        ]
+        table = probe_harness.render_table(spec, "office2pdf", "byte-identical re-zip", rows)
+        self.assertIn("a:spcAft val", table)
+        self.assertIn("byte-identical re-zip", table)
+        lines = [line for line in table.splitlines() if line.startswith("| ")]
+        self.assertEqual(len(lines), 4)  # header + separator + two variants
+        self.assertIn("| 500 |", table)
+        self.assertIn("| 2000 |", table)
+        self.assertIn("-5.00", table)
+        self.assertIn("+20.00", table)
+
+
+class EndToEndTest(unittest.TestCase):
+    """Full run with a fake exporter that derives PDF bytes from the patched part.
+
+    Base and control carry identical slide XML, so their fake PDFs are
+    byte-identical and the control gate passes without the differ; variants
+    differ and get a differ row each.
+    """
+
+    def fake_runner(self, differ_result=None):
+        def runner(argv):
+            if argv[0] == "fake-office2pdf":
+                with zipfile.ZipFile(argv[1]) as archive:
+                    content = archive.read("ppt/slides/slide1.xml")
+                Path(argv[3]).write_bytes(b"%PDF " + content)
+                return completed(argv)
+            if argv[1].endswith("compare_layout.py"):
+                if differ_result is not None:
+                    return differ_result(argv)
+                return completed(argv, stdout=json.dumps(differ_report(page_vector())))
+            raise AssertionError(f"unexpected command {argv}")
+
+        return runner
+
+    def test_a_probe_run_writes_one_table_with_one_row_per_variant(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            write_base_package(tmp / "base.pptx")
+            spec_path = write_spec(tmp)
+            stage_root = tmp / "stage"
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                report_path = probe_harness.run_probe(
+                    spec_path,
+                    backend="office2pdf",
+                    converter="fake-office2pdf",
+                    stage_root=stage_root,
+                    runner=self.fake_runner(),
+                )
+            report = report_path.read_text()
+            self.assertIn("| 500 |", report)
+            self.assertIn("| 2000 |", report)
+            self.assertIn("byte-identical", report)
+            self.assertEqual(report, stdout.getvalue())
+            packages = stage_root / "spcAft-linearity" / "packages"
+            self.assertTrue((packages / "control.pptx").exists())
+            self.assertTrue((packages / "variant-500.pptx").exists())
+
+    def test_a_differ_failure_fails_the_whole_run(self):
+        def differ_result(argv):
+            return completed(argv, returncode=1, stderr="no pages parsed from the GT trace")
+
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            write_base_package(tmp / "base.pptx")
+            spec_path = write_spec(tmp)
+            with self.assertRaisesRegex(probe_harness.ProbeError, "no pages parsed"):
+                probe_harness.run_probe(
+                    spec_path,
+                    backend="office2pdf",
+                    converter="fake-office2pdf",
+                    stage_root=tmp / "stage",
+                    runner=self.fake_runner(differ_result=differ_result),
+                )
+
+    def test_main_reports_a_probe_error_and_exits_nonzero(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            write_base_package(tmp / "base.pptx")
+            spec_path = write_spec(
+                tmp,
+                {"variants": [{"value": "500", "find": "no-such-text", "replace": "x"}]},
+            )
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                code = probe_harness.main(
+                    [str(spec_path), "--stage-root", str(tmp / "stage")]
+                )
+            self.assertEqual(code, 1)
+            self.assertIn("500", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `scripts/probe_harness.py`: the manual one-factor probe loop (patch one OOXML factor → re-zip → export → measure with the layout differ) as a single command driven by a JSON spec
- a spec names a base fixture, the target part, and a list of one-factor patches (literal or regex, with an optional expected match count); the harness builds one variant package per patch **plus a no-patch re-zip control**, exports the batch, and renders one table per probe — one differ row per variant, keyed by the factor value
- three export backends behind one seam: `office2pdf` (answers "what does our code do", runs anywhere in seconds), `soffice` (headless LibreOffice, the only reference without a Mac), and `office` (native Office via the existing `scripts/macos/export_*_pdfs.applescript`, Excel sheets united with `pdfunite`)
- the traps the manual loop hit are encoded as contracts:
  - archives are always written fresh — `zip -r` updates in place, so a second variant silently inherited the first's members
  - the control is a hard gate: byte-identical exports pass outright; otherwise the differ must report zero deviations, or the run aborts (a repackaging artifact invalidates every row)
  - a differ failure propagates instead of reading as an identical variant — the #810 zero-page trap is exactly the answer a one-factor probe is looking for, and exactly the wrong one
  - the `office` backend refuses to stage under `/Volumes`: the sandboxed Office apps hang there with AppleEvent timeout -1712
- run the harness's test suite in the visual-pr-contract CI job, and document the tool in CLAUDE.md beside the other comparison tooling

## Related issue

Related: #698

End-to-end on a tracked fixture (title `sz="4000"` probed at 2000/6000, office2pdf backend, real differ): the control gate reports `byte-identical re-zip` — our converter is deterministic, so repackaging is provably faithful — and the table shows the symmetric linear response a probe exists to reveal:

```
| title sz | patched | pages | matched | missing | extra | wraps | deviant | mean abs dy (pt) | worst dy (pt) | worst pitch (pt) | worst width (%) | large shifts | rects |
| 2000     | 2       | 1/1   | 3       | 0       | 0     | 0     | 1       | 2.31             | -6.93         | 6.93             | 50.0            | 1            | 1/1   |
| 6000     | 2       | 1/1   | 3       | 0       | 0     | 0     | 1       | 2.31             | +6.93         | 6.93             | 50.0            | 1            | 1/1   |
```

## Testing

- `python3 -m unittest discover -s scripts/tests -p 'test_probe_harness.py'` (37 tests): spec validation, patch application, fresh-archive/determinism contracts, per-backend export command construction with a stubbed runner, the external-volume guard, Excel sheet uniting, differ failure propagation, the control gate, row aggregation, table rendering, and two stubbed end-to-end runs
- all seven script suites run as CI invokes them (`test_check_visual_pr`, `test_compare_layout`, `test_compare_render`, `test_compare_text_layer`, `test_check_gt_integrity`, `test_validate_business_golden_mocks`, `test_probe_harness`): OK
- real end-to-end run against a release binary and real `compare_layout.py`/`mutool` (table above), exit 0
- documentation freshness audit: PASS

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: tooling, tests, CI, and docs only; no converter code is touched.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
