### PR TITLE
feat(ooxml): lossless OPC package and PPTX model for round-trip editing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["crates/office2pdf", "crates/office2pdf-cli"]
+members = [
+    "crates/office2pdf",
+    "crates/office2pdf-cli",
+    "crates/ooxml-package",
+    "crates/pptx-model",
+]
 resolver = "3"
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -207,6 +207,21 @@ Native Rust callers can use the same per-conversion path through
 | PPTX | Supported | Slides, text boxes, shapes, tables, images, masters, gradients, effects |
 | XLSX | Supported | Sheets, formatting, merged cells, column/row sizing, conditional formatting |
 
+## Workspace Crates
+
+| Crate | Published | Purpose |
+|-------|-----------|---------|
+| `office2pdf` | [crates.io](https://crates.io/crates/office2pdf) | Conversion library (this README) |
+| `office2pdf-cli` | [crates.io](https://crates.io/crates/office2pdf-cli) | Command-line interface |
+| `ooxml-package` | not yet | Lossless OPC (OOXML container) model: byte-for-byte round trip, dirty-part tracking, surgical save |
+| `pptx-model` | not yet | Lossless, editable PPTX model over `ooxml-package`: slide enumeration, surgical text-run edits |
+
+`ooxml-package` and `pptx-model` are the foundation for round-trip OOXML
+editing: a load/save cycle preserves every package part — including parts and
+XML they do not model — and saving rewrites only edited entries. The
+`office2pdf` rendering pipeline stays a derived projection for PDF
+preview/export; it is not the editable source of truth.
+
 ## License
 
 Licensed under [Apache License, Version 2.0](LICENSE).

--- a/crates/ooxml-package/Cargo.toml
+++ b/crates/ooxml-package/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ooxml-package"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Lossless OOXML (OPC) package model for round-trip editing"
+# Not published yet: the editing foundation (issue #746) ships behind the
+# converter crates until the editable models stabilize.
+publish = false
+
+[dependencies]
+thiserror = "2"
+tracing = "0.1"
+quick-xml = "0.38"
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
+
+[dev-dependencies]
+# The round-trip tests re-read saved containers with `zip` directly so the
+# crate under test never verifies its own output.
+zip = { version = "0.6", default-features = false, features = ["deflate"] }

--- a/crates/ooxml-package/src/lib.rs
+++ b/crates/ooxml-package/src/lib.rs
@@ -1,0 +1,456 @@
+//! Lossless Open Packaging Conventions (OPC) container model.
+//!
+//! This crate is the package-level foundation for round-trip OOXML editing
+//! (issue #746). The existing rendering pipeline in `office2pdf` flattens
+//! format-specific information into a draw-only intermediate representation,
+//! so it cannot be serialized back into DOCX/PPTX/XLSX without data loss.
+//! [`OpcPackage`] instead preserves the original container: every ZIP part —
+//! including parts and XML this workspace does not understand — survives a
+//! load/save cycle, and untouched part payloads are copied byte-for-byte
+//! (raw compressed entry copy, so even the compression choice is kept).
+//!
+//! Only parts explicitly replaced through [`OpcPackage::set_part_bytes`] are
+//! re-encoded on save; [`OpcPackage::dirty_part_names`] reports exactly which
+//! parts an edit touched. Relationships and content types are parsed on
+//! demand for integrity checks and navigation, always from the authoritative
+//! part bytes — never from a lossy projection.
+
+use std::borrow::Cow;
+use std::fmt;
+use std::io::{Cursor, Read, Write};
+use std::path::Path;
+
+use quick_xml::events::{BytesStart, Event};
+
+/// Errors raised while reading, editing, or saving an OPC package.
+#[derive(Debug, thiserror::Error)]
+pub enum PackageError {
+    /// The container is not a readable ZIP archive.
+    #[error("failed to read package container: {0}")]
+    Container(#[from] zip::result::ZipError),
+    /// The underlying reader failed.
+    #[error("I/O failure while accessing package: {0}")]
+    Io(#[from] std::io::Error),
+    /// A named part does not exist in the package.
+    #[error("package has no part named {0:?}")]
+    MissingPart(String),
+    /// A package part holds XML this crate could not parse.
+    #[error("malformed XML in part {part:?}: {message}")]
+    MalformedXml {
+        /// Part name whose XML failed to parse.
+        part: String,
+        /// Parser diagnostic.
+        message: String,
+    },
+}
+
+/// Whether a relationship points inside or outside the package.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetMode {
+    /// The target is another part in this package.
+    Internal,
+    /// The target is an external resource (for example a hyperlink URL).
+    External,
+}
+
+/// One `<Relationship>` from a `.rels` part.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Relationship {
+    /// The `Id` attribute, unique within its `.rels` part.
+    pub id: String,
+    /// The `Type` attribute (a schema URI).
+    pub relationship_type: String,
+    /// The raw `Target` attribute, unresolved. Use
+    /// [`resolve_relationship_target`] to obtain a part name.
+    pub target: String,
+    /// Internal (default) or External per the `TargetMode` attribute.
+    pub target_mode: TargetMode,
+}
+
+/// Where an entry's payload currently lives.
+enum EntryPayload {
+    /// Still in the source container; copied raw (compressed) on save.
+    Untouched,
+    /// Replaced in memory; re-deflated on save.
+    Modified(Vec<u8>),
+}
+
+/// One ZIP entry of the source container.
+///
+/// Directory entries are kept so the saved container mirrors the source
+/// entry list exactly; they are hidden from the part-level API.
+struct PackageEntry {
+    /// Zip entry name; directory entries keep their trailing `/`.
+    name: String,
+    /// Index of this entry in the source archive.
+    source_index: usize,
+    is_directory: bool,
+    payload: EntryPayload,
+}
+
+/// A lossless in-memory OOXML package.
+///
+/// Invariant: `entries` lists every ZIP entry of the source container in its
+/// original order, and saving writes them back in that order.
+pub struct OpcPackage {
+    source: Vec<u8>,
+    entries: Vec<PackageEntry>,
+}
+
+impl fmt::Debug for OpcPackage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OpcPackage")
+            .field("source_len", &self.source.len())
+            .field("entries", &self.entries.len())
+            .field("dirty", &self.dirty_part_names())
+            .finish()
+    }
+}
+
+impl OpcPackage {
+    /// Load a package from a file on disk.
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self, PackageError> {
+        Self::from_bytes(std::fs::read(path)?)
+    }
+
+    /// Load a package from container bytes.
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, PackageError> {
+        let mut archive: zip::ZipArchive<Cursor<&[u8]>> =
+            zip::ZipArchive::new(Cursor::new(bytes.as_slice()))?;
+        let mut entries: Vec<PackageEntry> = Vec::with_capacity(archive.len());
+        for source_index in 0..archive.len() {
+            // Raw access skips decompression: payloads stay in `source` until
+            // a caller actually reads or replaces them.
+            let file = archive.by_index_raw(source_index)?;
+            entries.push(PackageEntry {
+                name: file.name().to_string(),
+                source_index,
+                is_directory: file.is_dir(),
+                payload: EntryPayload::Untouched,
+            });
+        }
+        drop(archive);
+        tracing::debug!(entry_count = entries.len(), "loaded OPC package");
+        Ok(Self {
+            source: bytes,
+            entries,
+        })
+    }
+
+    /// Names of every part (non-directory ZIP entry), in container order.
+    pub fn part_names(&self) -> Vec<&str> {
+        self.entries
+            .iter()
+            .filter(|entry| !entry.is_directory)
+            .map(|entry| entry.name.as_str())
+            .collect()
+    }
+
+    /// Whether a part with this exact name exists.
+    pub fn has_part(&self, name: &str) -> bool {
+        self.find_part(name).is_some()
+    }
+
+    /// The decompressed payload of a part.
+    pub fn part_bytes(&self, name: &str) -> Result<Cow<'_, [u8]>, PackageError> {
+        let entry: &PackageEntry = self
+            .find_part(name)
+            .ok_or_else(|| PackageError::MissingPart(name.to_string()))?;
+        match &entry.payload {
+            EntryPayload::Modified(bytes) => Ok(Cow::Borrowed(bytes.as_slice())),
+            EntryPayload::Untouched => {
+                let mut archive: zip::ZipArchive<Cursor<&[u8]>> =
+                    zip::ZipArchive::new(Cursor::new(self.source.as_slice()))?;
+                let mut file = archive.by_index(entry.source_index)?;
+                let mut payload: Vec<u8> = Vec::with_capacity(file.size() as usize);
+                file.read_to_end(&mut payload)?;
+                Ok(Cow::Owned(payload))
+            }
+        }
+    }
+
+    /// Replace the payload of an existing part, marking it dirty.
+    pub fn set_part_bytes(&mut self, name: &str, bytes: Vec<u8>) -> Result<(), PackageError> {
+        let entry: &mut PackageEntry = self
+            .entries
+            .iter_mut()
+            .find(|entry| !entry.is_directory && entry.name == name)
+            .ok_or_else(|| PackageError::MissingPart(name.to_string()))?;
+        tracing::debug!(
+            part = name,
+            byte_count = bytes.len(),
+            "replacing part payload"
+        );
+        entry.payload = EntryPayload::Modified(bytes);
+        Ok(())
+    }
+
+    /// Names of parts whose payload was replaced since load, in container order.
+    pub fn dirty_part_names(&self) -> Vec<&str> {
+        self.entries
+            .iter()
+            .filter(|entry| matches!(entry.payload, EntryPayload::Modified(_)))
+            .map(|entry| entry.name.as_str())
+            .collect()
+    }
+
+    /// Relationships of the package root (`None`) or of a part (`Some`).
+    ///
+    /// Returns an empty list when the corresponding `.rels` part is absent.
+    pub fn relationships(
+        &self,
+        source_part: Option<&str>,
+    ) -> Result<Vec<Relationship>, PackageError> {
+        let rels_part: String = relationships_part_name(source_part);
+        if !self.has_part(&rels_part) {
+            return Ok(Vec::new());
+        }
+        let xml: Cow<'_, [u8]> = self.part_bytes(&rels_part)?;
+        parse_relationships(&xml, &rels_part)
+    }
+
+    /// The declared content type of a part, from `[Content_Types].xml`.
+    ///
+    /// Override declarations win over extension defaults. Returns `None` when
+    /// neither declares the part.
+    pub fn content_type_of(&self, part_name: &str) -> Result<Option<String>, PackageError> {
+        const CONTENT_TYPES_PART: &str = "[Content_Types].xml";
+        if !self.has_part(CONTENT_TYPES_PART) {
+            return Ok(None);
+        }
+        let xml: Cow<'_, [u8]> = self.part_bytes(CONTENT_TYPES_PART)?;
+        let content_types: ContentTypes = parse_content_types(&xml, CONTENT_TYPES_PART)?;
+
+        let absolute_name: String = format!("/{part_name}");
+        if let Some(declared) = content_types
+            .overrides
+            .iter()
+            .find(|(name, _)| *name == absolute_name)
+        {
+            return Ok(Some(declared.1.clone()));
+        }
+        let extension: Option<&str> = part_name.rsplit_once('.').map(|(_, ext)| ext);
+        Ok(extension.and_then(|extension| {
+            content_types
+                .defaults
+                .iter()
+                // OPC compares extensions case-insensitively.
+                .find(|(declared, _)| declared.eq_ignore_ascii_case(extension))
+                .map(|(_, content_type)| content_type.clone())
+        }))
+    }
+
+    /// Serialize the package back into container bytes.
+    ///
+    /// Untouched entries are copied raw (byte-for-byte compressed payload,
+    /// preserving compression method and timestamps); dirty parts are
+    /// re-deflated. Entry order is the source container's order.
+    pub fn save_to_bytes(&self) -> Result<Vec<u8>, PackageError> {
+        let mut source_archive: zip::ZipArchive<Cursor<&[u8]>> =
+            zip::ZipArchive::new(Cursor::new(self.source.as_slice()))?;
+        let mut writer: zip::ZipWriter<Cursor<Vec<u8>>> =
+            zip::ZipWriter::new(Cursor::new(Vec::new()));
+        let mut rewritten: usize = 0;
+        for entry in &self.entries {
+            match &entry.payload {
+                EntryPayload::Untouched => {
+                    let file = source_archive.by_index_raw(entry.source_index)?;
+                    writer.raw_copy_file(file)?;
+                }
+                EntryPayload::Modified(bytes) => {
+                    // Mirror the source entry's metadata so the rewrite is
+                    // confined to the payload itself.
+                    let source_file = source_archive.by_index_raw(entry.source_index)?;
+                    let mut options: zip::write::FileOptions = zip::write::FileOptions::default()
+                        .compression_method(source_file.compression())
+                        .last_modified_time(source_file.last_modified());
+                    if let Some(mode) = source_file.unix_mode() {
+                        options = options.unix_permissions(mode);
+                    }
+                    drop(source_file);
+                    writer.start_file(entry.name.as_str(), options)?;
+                    writer.write_all(bytes)?;
+                    rewritten += 1;
+                }
+            }
+        }
+        let cursor: Cursor<Vec<u8>> = writer.finish()?;
+        tracing::debug!(
+            entry_count = self.entries.len(),
+            rewritten_count = rewritten,
+            "saved OPC package"
+        );
+        Ok(cursor.into_inner())
+    }
+
+    fn find_part(&self, name: &str) -> Option<&PackageEntry> {
+        self.entries
+            .iter()
+            .find(|entry| !entry.is_directory && entry.name == name)
+    }
+}
+
+/// The `.rels` part name that holds relationships for `source_part`
+/// (`None` addresses the package root).
+pub fn relationships_part_name(source_part: Option<&str>) -> String {
+    match source_part {
+        None => "_rels/.rels".to_string(),
+        Some(part) => match part.rsplit_once('/') {
+            Some((directory, file_name)) => format!("{directory}/_rels/{file_name}.rels"),
+            None => format!("_rels/{part}.rels"),
+        },
+    }
+}
+
+/// Resolve a relationship `Target` against its source part into a part name.
+///
+/// Handles targets relative to the source part's directory, `../` traversal,
+/// and absolute (`/`-prefixed) targets. The result carries no leading slash,
+/// matching ZIP entry names.
+pub fn resolve_relationship_target(source_part: Option<&str>, target: &str) -> String {
+    let mut segments: Vec<&str> = Vec::new();
+    if !target.starts_with('/')
+        && let Some((directory, _)) = source_part.and_then(|part| part.rsplit_once('/'))
+    {
+        segments.extend(directory.split('/'));
+    }
+    for segment in target.trim_start_matches('/').split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                segments.pop();
+            }
+            other => segments.push(other),
+        }
+    }
+    segments.join("/")
+}
+
+/// Parsed `[Content_Types].xml`: extension defaults and part-name overrides.
+struct ContentTypes {
+    /// `(extension, content type)` from `<Default>` elements.
+    defaults: Vec<(String, String)>,
+    /// `(absolute part name, content type)` from `<Override>` elements.
+    overrides: Vec<(String, String)>,
+}
+
+fn parse_relationships(xml: &[u8], part: &str) -> Result<Vec<Relationship>, PackageError> {
+    let mut reader: quick_xml::Reader<&[u8]> = quick_xml::Reader::from_reader(xml);
+    let mut relationships: Vec<Relationship> = Vec::new();
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element)) | Ok(Event::Empty(element))
+                if element.name().local_name().as_ref() == b"Relationship" =>
+            {
+                relationships.push(parse_relationship_element(&element, part)?);
+            }
+            Ok(Event::Eof) => break,
+            Ok(_) => {}
+            Err(error) => {
+                return Err(PackageError::MalformedXml {
+                    part: part.to_string(),
+                    message: error.to_string(),
+                });
+            }
+        }
+    }
+    Ok(relationships)
+}
+
+fn parse_relationship_element(
+    element: &BytesStart<'_>,
+    part: &str,
+) -> Result<Relationship, PackageError> {
+    let mut id: Option<String> = None;
+    let mut relationship_type: Option<String> = None;
+    let mut target: Option<String> = None;
+    let mut target_mode: TargetMode = TargetMode::Internal;
+    for attribute in element.attributes() {
+        let attribute = attribute.map_err(|error| PackageError::MalformedXml {
+            part: part.to_string(),
+            message: error.to_string(),
+        })?;
+        let value: String = attribute
+            .unescape_value()
+            .map_err(|error| PackageError::MalformedXml {
+                part: part.to_string(),
+                message: error.to_string(),
+            })?
+            .into_owned();
+        match attribute.key.local_name().as_ref() {
+            b"Id" => id = Some(value),
+            b"Type" => relationship_type = Some(value),
+            b"Target" => target = Some(value),
+            b"TargetMode" if value == "External" => target_mode = TargetMode::External,
+            _ => {}
+        }
+    }
+    match (id, relationship_type, target) {
+        (Some(id), Some(relationship_type), Some(target)) => Ok(Relationship {
+            id,
+            relationship_type,
+            target,
+            target_mode,
+        }),
+        _ => Err(PackageError::MalformedXml {
+            part: part.to_string(),
+            message: "Relationship element lacks Id, Type, or Target".to_string(),
+        }),
+    }
+}
+
+fn parse_content_types(xml: &[u8], part: &str) -> Result<ContentTypes, PackageError> {
+    let mut reader: quick_xml::Reader<&[u8]> = quick_xml::Reader::from_reader(xml);
+    let mut content_types: ContentTypes = ContentTypes {
+        defaults: Vec::new(),
+        overrides: Vec::new(),
+    };
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element)) | Ok(Event::Empty(element)) => {
+                let is_default: bool = match element.name().local_name().as_ref() {
+                    b"Default" => true,
+                    b"Override" => false,
+                    _ => continue,
+                };
+                let mut key: Option<String> = None;
+                let mut content_type: Option<String> = None;
+                for attribute in element.attributes() {
+                    let attribute = attribute.map_err(|error| PackageError::MalformedXml {
+                        part: part.to_string(),
+                        message: error.to_string(),
+                    })?;
+                    let value: String = attribute
+                        .unescape_value()
+                        .map_err(|error| PackageError::MalformedXml {
+                            part: part.to_string(),
+                            message: error.to_string(),
+                        })?
+                        .into_owned();
+                    match attribute.key.local_name().as_ref() {
+                        b"Extension" | b"PartName" => key = Some(value),
+                        b"ContentType" => content_type = Some(value),
+                        _ => {}
+                    }
+                }
+                if let (Some(key), Some(content_type)) = (key, content_type) {
+                    if is_default {
+                        content_types.defaults.push((key, content_type));
+                    } else {
+                        content_types.overrides.push((key, content_type));
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Ok(_) => {}
+            Err(error) => {
+                return Err(PackageError::MalformedXml {
+                    part: part.to_string(),
+                    message: error.to_string(),
+                });
+            }
+        }
+    }
+    Ok(content_types)
+}

--- a/crates/ooxml-package/tests/package_roundtrip.rs
+++ b/crates/ooxml-package/tests/package_roundtrip.rs
@@ -1,0 +1,355 @@
+//! Lossless round-trip tests for the OPC package model (issue #746).
+//!
+//! Every assertion here reads the saved container back with the `zip` crate
+//! directly, so the crate under test never verifies itself.
+
+use std::io::{Cursor, Read, Write};
+use std::path::PathBuf;
+
+use ooxml_package::{OpcPackage, PackageError, TargetMode, resolve_relationship_target};
+
+/// OPC is format-agnostic: the round-trip guarantees must hold for all three
+/// OOXML flavors, not just the PPTX milestone target.
+const ROUND_TRIP_FIXTURES: [&str; 4] = [
+    "pptx/minimal.pptx",
+    "pptx/WithMaster.pptx",
+    "docx/unit_test_headers.docx",
+    "xlsx/temperature.xlsx",
+];
+
+fn fixture_path(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures")
+        .join(relative)
+}
+
+fn fixture_bytes(relative: &str) -> Vec<u8> {
+    std::fs::read(fixture_path(relative)).expect("fixture should be readable")
+}
+
+/// `(name, decompressed payload)` for every non-directory entry, in order.
+fn zip_entries(bytes: &[u8]) -> Vec<(String, Vec<u8>)> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).expect("container should open");
+    let mut entries: Vec<(String, Vec<u8>)> = Vec::new();
+    for index in 0..archive.len() {
+        let mut file = archive.by_index(index).expect("entry should open");
+        if file.is_dir() {
+            continue;
+        }
+        let mut payload: Vec<u8> = Vec::new();
+        file.read_to_end(&mut payload)
+            .expect("entry should decompress");
+        entries.push((file.name().to_string(), payload));
+    }
+    entries
+}
+
+/// `(name, raw compressed payload)` for every non-directory entry, in order.
+fn raw_zip_entries(bytes: &[u8]) -> Vec<(String, Vec<u8>)> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).expect("container should open");
+    let mut entries: Vec<(String, Vec<u8>)> = Vec::new();
+    for index in 0..archive.len() {
+        let mut file = archive.by_index_raw(index).expect("raw entry should open");
+        if file.is_dir() {
+            continue;
+        }
+        let mut payload: Vec<u8> = Vec::new();
+        file.read_to_end(&mut payload)
+            .expect("raw entry should read");
+        entries.push((file.name().to_string(), payload));
+    }
+    entries
+}
+
+/// Rebuild `original` with extra entries appended, using the `zip` crate only.
+fn with_extra_entries(original: &[u8], extras: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(original)).expect("container should open");
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    for index in 0..archive.len() {
+        let file = archive.by_index_raw(index).expect("raw entry should open");
+        writer.raw_copy_file(file).expect("raw copy should succeed");
+    }
+    for (name, payload) in extras {
+        writer
+            .start_file(*name, zip::write::FileOptions::default())
+            .expect("extra entry should start");
+        writer.write_all(payload).expect("extra entry should write");
+    }
+    writer
+        .finish()
+        .expect("container should finish")
+        .into_inner()
+}
+
+#[test]
+fn no_op_round_trip_preserves_every_part_payload_and_order() {
+    for fixture in ROUND_TRIP_FIXTURES {
+        let original: Vec<u8> = fixture_bytes(fixture);
+        let package = OpcPackage::from_bytes(original.clone())
+            .unwrap_or_else(|error| panic!("{fixture} should load: {error}"));
+        let saved: Vec<u8> = package
+            .save_to_bytes()
+            .unwrap_or_else(|error| panic!("{fixture} should save: {error}"));
+        assert_eq!(
+            zip_entries(&original),
+            zip_entries(&saved),
+            "{fixture}: part names, order, or payloads changed across a no-op round trip"
+        );
+    }
+}
+
+#[test]
+fn untouched_part_payloads_are_copied_byte_for_byte_compressed() {
+    for fixture in ROUND_TRIP_FIXTURES {
+        let original: Vec<u8> = fixture_bytes(fixture);
+        let package = OpcPackage::from_bytes(original.clone()).expect("fixture should load");
+        let saved: Vec<u8> = package.save_to_bytes().expect("package should save");
+        assert_eq!(
+            raw_zip_entries(&original),
+            raw_zip_entries(&saved),
+            "{fixture}: untouched entries should keep their exact compressed payload"
+        );
+    }
+}
+
+#[test]
+fn part_bytes_returns_the_decompressed_payload() {
+    let original: Vec<u8> = fixture_bytes("pptx/WithMaster.pptx");
+    let package = OpcPackage::from_bytes(original.clone()).expect("fixture should load");
+    let expected: Vec<(String, Vec<u8>)> = zip_entries(&original);
+    for (name, payload) in &expected {
+        let actual = package.part_bytes(name).expect("part should be readable");
+        assert_eq!(
+            actual.as_ref(),
+            payload.as_slice(),
+            "part {name} should decompress to the original payload"
+        );
+    }
+    assert_eq!(
+        package.part_names(),
+        expected
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect::<Vec<&str>>(),
+        "part_names should list every part in container order"
+    );
+}
+
+#[test]
+fn unknown_parts_survive_a_round_trip() {
+    let opaque_payload: Vec<u8> = (0u8..=255).cycle().take(1024).collect();
+    let extras: [(&str, &[u8]); 2] = [
+        (
+            "customXml/unknown-tool-data.xml",
+            b"<unknownTool><keep everything=\"intact\"/></unknownTool>".as_slice(),
+        ),
+        ("ppt/media/opaque-blob.bin", opaque_payload.as_slice()),
+    ];
+    let with_unknown: Vec<u8> = with_extra_entries(&fixture_bytes("pptx/WithMaster.pptx"), &extras);
+
+    let package = OpcPackage::from_bytes(with_unknown.clone()).expect("package should load");
+    for (name, payload) in &extras {
+        assert!(
+            package.has_part(name),
+            "unknown part {name} should be visible"
+        );
+        assert_eq!(
+            package
+                .part_bytes(name)
+                .expect("unknown part should read")
+                .as_ref(),
+            *payload,
+            "unknown part {name} should keep its payload in memory"
+        );
+    }
+
+    let saved: Vec<u8> = package.save_to_bytes().expect("package should save");
+    assert_eq!(
+        zip_entries(&with_unknown),
+        zip_entries(&saved),
+        "unknown parts must survive a no-op round trip untouched"
+    );
+}
+
+#[test]
+fn modifying_one_part_rewrites_only_that_entry() {
+    let original: Vec<u8> = fixture_bytes("pptx/WithMaster.pptx");
+    let target_part: &str = "ppt/slides/slide2.xml";
+
+    let mut package = OpcPackage::from_bytes(original.clone()).expect("fixture should load");
+    let original_slide: Vec<u8> = package
+        .part_bytes(target_part)
+        .expect("slide should be readable")
+        .into_owned();
+    let modified_slide: Vec<u8> = String::from_utf8(original_slide.clone())
+        .expect("slide XML should be UTF-8")
+        .replace("subtitle", "caption")
+        .into_bytes();
+    assert_ne!(
+        original_slide, modified_slide,
+        "the edit should change the slide"
+    );
+
+    package
+        .set_part_bytes(target_part, modified_slide.clone())
+        .expect("existing part should accept new bytes");
+    assert_eq!(
+        package.dirty_part_names(),
+        vec![target_part],
+        "exactly the edited part should be dirty"
+    );
+
+    let saved: Vec<u8> = package.save_to_bytes().expect("package should save");
+    let original_raw: Vec<(String, Vec<u8>)> = raw_zip_entries(&original);
+    let saved_raw: Vec<(String, Vec<u8>)> = raw_zip_entries(&saved);
+    assert_eq!(
+        original_raw
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect::<Vec<&str>>(),
+        saved_raw
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect::<Vec<&str>>(),
+        "entry names and order should be preserved"
+    );
+    for ((name, original_payload), (_, saved_payload)) in original_raw.iter().zip(saved_raw.iter())
+    {
+        if name == target_part {
+            continue;
+        }
+        assert_eq!(
+            original_payload, saved_payload,
+            "untouched entry {name} should keep its exact compressed payload"
+        );
+    }
+    assert_eq!(
+        zip_entries(&saved)
+            .into_iter()
+            .find(|(name, _)| name == target_part)
+            .expect("edited part should exist")
+            .1,
+        modified_slide,
+        "the edited part should carry the replacement payload"
+    );
+}
+
+#[test]
+fn relationships_resolve_to_existing_parts_before_and_after_round_trip() {
+    for fixture in ROUND_TRIP_FIXTURES {
+        let package = OpcPackage::from_bytes(fixture_bytes(fixture)).expect("fixture should load");
+        assert_relationships_resolve(&package, fixture);
+
+        let reloaded =
+            OpcPackage::from_bytes(package.save_to_bytes().expect("package should save"))
+                .expect("saved container should reload");
+        assert_relationships_resolve(&reloaded, fixture);
+    }
+}
+
+fn assert_relationships_resolve(package: &OpcPackage, fixture: &str) {
+    let root_relationships: Vec<ooxml_package::Relationship> = package
+        .relationships(None)
+        .expect("root relationships should parse");
+    let office_document = root_relationships
+        .iter()
+        .find(|relationship| relationship.relationship_type.ends_with("/officeDocument"))
+        .unwrap_or_else(|| panic!("{fixture} should declare an officeDocument relationship"));
+    assert!(
+        package.has_part(&resolve_relationship_target(None, &office_document.target)),
+        "{fixture}: officeDocument target should exist"
+    );
+
+    let part_names: Vec<String> = package
+        .part_names()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    for part_name in &part_names {
+        let relationships = package
+            .relationships(Some(part_name))
+            .expect("part relationships should parse");
+        for relationship in relationships {
+            if relationship.target_mode == TargetMode::External {
+                continue;
+            }
+            let resolved: String =
+                resolve_relationship_target(Some(part_name), &relationship.target);
+            assert!(
+                package.has_part(&resolved),
+                "{fixture}: relationship {id} of {part_name} targets missing part {resolved}",
+                id = relationship.id,
+            );
+        }
+    }
+}
+
+#[test]
+fn content_types_cover_every_part() {
+    for fixture in ROUND_TRIP_FIXTURES {
+        let package = OpcPackage::from_bytes(fixture_bytes(fixture)).expect("fixture should load");
+        for part_name in package.part_names() {
+            if part_name == "[Content_Types].xml" {
+                continue;
+            }
+            let content_type: Option<String> = package
+                .content_type_of(part_name)
+                .expect("content types should parse");
+            assert!(
+                content_type.is_some_and(|declared| !declared.is_empty()),
+                "{fixture}: part {part_name} should have a declared content type"
+            );
+        }
+    }
+}
+
+#[test]
+fn from_bytes_rejects_bytes_that_are_not_a_zip_container() {
+    let error: PackageError =
+        OpcPackage::from_bytes(b"this is not a zip container".to_vec()).unwrap_err();
+    assert!(
+        matches!(error, PackageError::Container(_)),
+        "expected a container error, got: {error}"
+    );
+}
+
+#[test]
+fn missing_parts_are_reported_by_name() {
+    let mut package =
+        OpcPackage::from_bytes(fixture_bytes("pptx/minimal.pptx")).expect("fixture should load");
+    let read_error: PackageError = package.part_bytes("ppt/absent.xml").unwrap_err();
+    assert!(
+        matches!(&read_error, PackageError::MissingPart(name) if name == "ppt/absent.xml"),
+        "expected MissingPart, got: {read_error}"
+    );
+    let write_error: PackageError = package
+        .set_part_bytes("ppt/absent.xml", vec![1, 2, 3])
+        .unwrap_err();
+    assert!(
+        matches!(&write_error, PackageError::MissingPart(name) if name == "ppt/absent.xml"),
+        "expected MissingPart, got: {write_error}"
+    );
+}
+
+#[test]
+fn relationship_targets_resolve_relative_to_their_source_part() {
+    assert_eq!(
+        resolve_relationship_target(None, "ppt/presentation.xml"),
+        "ppt/presentation.xml"
+    );
+    assert_eq!(
+        resolve_relationship_target(Some("ppt/presentation.xml"), "slides/slide1.xml"),
+        "ppt/slides/slide1.xml"
+    );
+    assert_eq!(
+        resolve_relationship_target(
+            Some("ppt/slideLayouts/slideLayout1.xml"),
+            "../slideMasters/slideMaster1.xml"
+        ),
+        "ppt/slideMasters/slideMaster1.xml"
+    );
+    assert_eq!(
+        resolve_relationship_target(Some("ppt/presentation.xml"), "/docProps/core.xml"),
+        "docProps/core.xml"
+    );
+}

--- a/crates/pptx-model/Cargo.toml
+++ b/crates/pptx-model/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "pptx-model"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Lossless, editable PPTX document model over ooxml-package"
+# Not published yet: the editing foundation (issue #746) ships behind the
+# converter crates until the editable models stabilize.
+publish = false
+
+[dependencies]
+ooxml-package = { path = "../ooxml-package" }
+thiserror = "2"
+tracing = "0.1"
+quick-xml = "0.38"
+
+[dev-dependencies]
+# Projection tests render the round-tripped package through the existing
+# converter pipeline and inspect the resulting PDF.
+office2pdf = { path = "../office2pdf" }
+pdf-extract = "0.10"
+# Saved containers are re-read with `zip` directly so the model under test
+# never verifies its own output.
+zip = { version = "0.6", default-features = false, features = ["deflate"] }

--- a/crates/pptx-model/src/lib.rs
+++ b/crates/pptx-model/src/lib.rs
@@ -1,0 +1,435 @@
+//! Lossless, editable PPTX document model (issue #746).
+//!
+//! [`PptxDocument`] wraps [`ooxml_package::OpcPackage`] so every part of the
+//! original file — including parts and XML this crate does not model —
+//! survives load, edit, and save. Edits are surgical: replacing a text run
+//! splices only that run's character data inside its slide part and leaves
+//! every other byte of the package untouched.
+//!
+//! The rendering pipeline in `office2pdf` stays a derived projection: saving
+//! this model yields a standard `.pptx` container that the existing
+//! converter (and PowerPoint) can open, so PDF preview is always available
+//! without this model ever becoming lossy.
+
+use std::borrow::Cow;
+
+use ooxml_package::{OpcPackage, resolve_relationship_target};
+use quick_xml::NsReader;
+use quick_xml::events::{BytesRef, BytesStart, Event};
+use quick_xml::name::{Namespace, QName, ResolveResult};
+
+const DRAWINGML_NAMESPACE: &[u8] = b"http://schemas.openxmlformats.org/drawingml/2006/main";
+const PRESENTATIONML_NAMESPACE: &[u8] =
+    b"http://schemas.openxmlformats.org/presentationml/2006/main";
+const RELATIONSHIPS_NAMESPACE: &[u8] =
+    b"http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+/// Prefix shared by every PresentationML main-part content type
+/// (presentation, slideshow, template, and their macro-enabled variants).
+const PRESENTATION_CONTENT_TYPE_PREFIX: &str =
+    "application/vnd.openxmlformats-officedocument.presentationml";
+
+/// Errors raised while loading or editing a PPTX document.
+#[derive(Debug, thiserror::Error)]
+pub enum PptxError {
+    /// The underlying OPC package failed to load, read, or save.
+    #[error(transparent)]
+    Package(#[from] ooxml_package::PackageError),
+    /// The package is a valid OPC container but not a PowerPoint presentation.
+    #[error("package is not a PowerPoint presentation: {0}")]
+    NotAPresentation(String),
+    /// A slide part holds XML this crate could not parse.
+    #[error("malformed XML in part {part:?}: {message}")]
+    MalformedXml {
+        /// Part name whose XML failed to parse.
+        part: String,
+        /// Parser diagnostic.
+        message: String,
+    },
+    /// A slide index is out of range.
+    #[error("slide index {index} out of range: the presentation has {slide_count} slides")]
+    SlideIndexOutOfRange {
+        /// The requested zero-based slide index.
+        index: usize,
+        /// Number of slides in the presentation.
+        slide_count: usize,
+    },
+    /// A text-run index is out of range for the addressed slide.
+    #[error("text run index {index} out of range: slide part {part:?} has {run_count} runs")]
+    TextRunIndexOutOfRange {
+        /// Slide part name.
+        part: String,
+        /// The requested zero-based run index.
+        index: usize,
+        /// Number of text runs on that slide.
+        run_count: usize,
+    },
+}
+
+/// A lossless, editable PowerPoint presentation.
+#[derive(Debug)]
+pub struct PptxDocument {
+    package: OpcPackage,
+    /// Slide part names in presentation (slide show) order, resolved from
+    /// `p:sldIdLst` through the presentation part's relationships.
+    slide_part_names: Vec<String>,
+}
+
+impl PptxDocument {
+    /// Load a presentation from `.pptx` container bytes.
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, PptxError> {
+        let package: OpcPackage = OpcPackage::from_bytes(bytes)?;
+
+        let root_relationships: Vec<ooxml_package::Relationship> = package.relationships(None)?;
+        let office_document: &ooxml_package::Relationship = root_relationships
+            .iter()
+            .find(|relationship| {
+                relationship.target_mode == ooxml_package::TargetMode::Internal
+                    && relationship.relationship_type.ends_with("/officeDocument")
+            })
+            .ok_or_else(|| {
+                PptxError::NotAPresentation(
+                    "the package declares no officeDocument relationship".to_string(),
+                )
+            })?;
+        let presentation_part: String = resolve_relationship_target(None, &office_document.target);
+        if !package.has_part(&presentation_part) {
+            return Err(PptxError::NotAPresentation(format!(
+                "main part {presentation_part:?} is missing"
+            )));
+        }
+        let content_type: Option<String> = package.content_type_of(&presentation_part)?;
+        if !content_type
+            .as_deref()
+            .is_some_and(|declared| declared.starts_with(PRESENTATION_CONTENT_TYPE_PREFIX))
+        {
+            return Err(PptxError::NotAPresentation(format!(
+                "main part content type {content_type:?} is not PresentationML"
+            )));
+        }
+
+        let presentation_xml: Cow<'_, [u8]> = package.part_bytes(&presentation_part)?;
+        let slide_relationship_ids: Vec<String> =
+            parse_slide_relationship_ids(&presentation_xml, &presentation_part)?;
+        drop(presentation_xml);
+
+        let presentation_relationships: Vec<ooxml_package::Relationship> =
+            package.relationships(Some(&presentation_part))?;
+        let mut slide_part_names: Vec<String> = Vec::with_capacity(slide_relationship_ids.len());
+        for relationship_id in &slide_relationship_ids {
+            let relationship = presentation_relationships
+                .iter()
+                .find(|relationship| relationship.id == *relationship_id)
+                .ok_or_else(|| {
+                    PptxError::NotAPresentation(format!(
+                        "sldIdLst references undeclared relationship {relationship_id:?}"
+                    ))
+                })?;
+            let slide_part: String =
+                resolve_relationship_target(Some(&presentation_part), &relationship.target);
+            if !package.has_part(&slide_part) {
+                return Err(PptxError::NotAPresentation(format!(
+                    "slide part {slide_part:?} is missing"
+                )));
+            }
+            slide_part_names.push(slide_part);
+        }
+        tracing::debug!(
+            slide_count = slide_part_names.len(),
+            presentation_part,
+            "loaded PPTX document"
+        );
+
+        Ok(Self {
+            package,
+            slide_part_names,
+        })
+    }
+
+    /// Load a presentation from a file on disk.
+    pub fn from_path(path: impl AsRef<std::path::Path>) -> Result<Self, PptxError> {
+        Self::from_bytes(std::fs::read(path).map_err(ooxml_package::PackageError::from)?)
+    }
+
+    /// Slide part names in presentation (slide show) order.
+    pub fn slide_part_names(&self) -> &[String] {
+        &self.slide_part_names
+    }
+
+    /// Number of slides in the presentation.
+    pub fn slide_count(&self) -> usize {
+        self.slide_part_names.len()
+    }
+
+    /// The text of every `a:t` run on a slide, in document order.
+    pub fn slide_text_runs(&self, slide_index: usize) -> Result<Vec<String>, PptxError> {
+        let slide_part: &str = self.slide_part_name_at(slide_index)?;
+        let xml: Cow<'_, [u8]> = self.package.part_bytes(slide_part)?;
+        let spans: Vec<TextRunSpan> = scan_text_runs(&xml, slide_part)?;
+        Ok(spans.into_iter().map(|span| span.text).collect())
+    }
+
+    /// Replace the text of one run on one slide.
+    ///
+    /// Only the addressed slide part is rewritten; every other package part
+    /// keeps its exact original bytes.
+    pub fn set_slide_text_run(
+        &mut self,
+        slide_index: usize,
+        run_index: usize,
+        new_text: &str,
+    ) -> Result<(), PptxError> {
+        let slide_part: String = self.slide_part_name_at(slide_index)?.to_string();
+        let xml: Vec<u8> = self.package.part_bytes(&slide_part)?.into_owned();
+        let spans: Vec<TextRunSpan> = scan_text_runs(&xml, &slide_part)?;
+        let span: &TextRunSpan =
+            spans
+                .get(run_index)
+                .ok_or_else(|| PptxError::TextRunIndexOutOfRange {
+                    part: slide_part.clone(),
+                    index: run_index,
+                    run_count: spans.len(),
+                })?;
+        let spliced: Vec<u8> = splice_text_run(&xml, span, new_text);
+        tracing::debug!(
+            slide_part,
+            run_index,
+            new_text_len = new_text.len(),
+            "replacing slide text run"
+        );
+        self.package.set_part_bytes(&slide_part, spliced)?;
+        Ok(())
+    }
+
+    /// The underlying lossless package (for example to inspect dirty parts).
+    pub fn package(&self) -> &OpcPackage {
+        &self.package
+    }
+
+    /// Serialize the presentation back into `.pptx` container bytes.
+    pub fn save_to_bytes(&self) -> Result<Vec<u8>, PptxError> {
+        Ok(self.package.save_to_bytes()?)
+    }
+
+    fn slide_part_name_at(&self, slide_index: usize) -> Result<&str, PptxError> {
+        self.slide_part_names
+            .get(slide_index)
+            .map(String::as_str)
+            .ok_or(PptxError::SlideIndexOutOfRange {
+                index: slide_index,
+                slide_count: self.slide_part_names.len(),
+            })
+    }
+}
+
+/// One `a:t` element found in a slide part.
+struct TextRunSpan {
+    /// Unescaped character data currently in the run.
+    text: String,
+    /// Where the run's bytes live, for surgical replacement.
+    location: TextRunLocation,
+}
+
+enum TextRunLocation {
+    /// `<a:t>…</a:t>`: replace the bytes between the tags.
+    Element {
+        content_start: usize,
+        content_end: usize,
+    },
+    /// `<a:t/>`: replace the whole tag with an open/content/close triple.
+    EmptyTag {
+        tag_start: usize,
+        tag_end: usize,
+        /// The tag name as written (usually `a:t`), reused when rebuilding.
+        qualified_name: Vec<u8>,
+    },
+}
+
+fn malformed(part: &str, message: impl ToString) -> PptxError {
+    PptxError::MalformedXml {
+        part: part.to_string(),
+        message: message.to_string(),
+    }
+}
+
+fn is_in_namespace<R>(
+    reader: &NsReader<R>,
+    name: QName<'_>,
+    namespace: &[u8],
+    local: &[u8],
+) -> bool {
+    let (resolve_result, local_name) = reader.resolve_element(name);
+    matches!(resolve_result, ResolveResult::Bound(Namespace(bound)) if bound == namespace)
+        && local_name.as_ref() == local
+}
+
+/// The `r:id` of every `p:sldId` in the presentation part, in `sldIdLst`
+/// (slide show) order.
+fn parse_slide_relationship_ids(xml: &[u8], part: &str) -> Result<Vec<String>, PptxError> {
+    let mut reader: NsReader<&[u8]> = NsReader::from_reader(xml);
+    let mut relationship_ids: Vec<String> = Vec::new();
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element)) | Ok(Event::Empty(element))
+                if is_in_namespace(&reader, element.name(), PRESENTATIONML_NAMESPACE, b"sldId") =>
+            {
+                relationship_ids.push(slide_relationship_id(&reader, &element, part)?);
+            }
+            Ok(Event::Eof) => break,
+            Ok(_) => {}
+            Err(error) => return Err(malformed(part, error)),
+        }
+    }
+    Ok(relationship_ids)
+}
+
+fn slide_relationship_id(
+    reader: &NsReader<&[u8]>,
+    element: &BytesStart<'_>,
+    part: &str,
+) -> Result<String, PptxError> {
+    for attribute in element.attributes() {
+        let attribute = attribute.map_err(|error| malformed(part, error))?;
+        let (resolve_result, local_name) = reader.resolve_attribute(attribute.key);
+        let is_relationship_id: bool = matches!(
+            resolve_result,
+            ResolveResult::Bound(Namespace(bound)) if bound == RELATIONSHIPS_NAMESPACE
+        ) && local_name.as_ref() == b"id";
+        if is_relationship_id {
+            return Ok(attribute
+                .unescape_value()
+                .map_err(|error| malformed(part, error))?
+                .into_owned());
+        }
+    }
+    Err(malformed(part, "sldId element lacks an r:id attribute"))
+}
+
+/// Every `a:t` element in a slide part, in document order, with the byte
+/// spans needed to splice replacement text.
+fn scan_text_runs(xml: &[u8], part: &str) -> Result<Vec<TextRunSpan>, PptxError> {
+    let mut reader: NsReader<&[u8]> = NsReader::from_reader(xml);
+    let mut spans: Vec<TextRunSpan> = Vec::new();
+    // `(content_start, accumulated text)` of an open `<a:t>` element. The
+    // schema forbids nested `a:t`, so one pending slot suffices.
+    let mut pending: Option<(usize, String)> = None;
+    loop {
+        let event_start: usize = reader.buffer_position() as usize;
+        let event: Event<'_> = reader
+            .read_event()
+            .map_err(|error| malformed(part, error))?;
+        let event_end: usize = reader.buffer_position() as usize;
+        match event {
+            Event::Start(element)
+                if is_in_namespace(&reader, element.name(), DRAWINGML_NAMESPACE, b"t") =>
+            {
+                pending = Some((event_end, String::new()));
+            }
+            Event::Empty(element)
+                if is_in_namespace(&reader, element.name(), DRAWINGML_NAMESPACE, b"t") =>
+            {
+                spans.push(TextRunSpan {
+                    text: String::new(),
+                    location: TextRunLocation::EmptyTag {
+                        tag_start: event_start,
+                        tag_end: event_end,
+                        qualified_name: element.name().as_ref().to_vec(),
+                    },
+                });
+            }
+            Event::End(element)
+                if pending.is_some()
+                    && is_in_namespace(&reader, element.name(), DRAWINGML_NAMESPACE, b"t") =>
+            {
+                let (content_start, text) = pending.take().expect("pending run is present");
+                spans.push(TextRunSpan {
+                    text,
+                    location: TextRunLocation::Element {
+                        content_start,
+                        content_end: event_start,
+                    },
+                });
+            }
+            Event::Text(text) => {
+                if let Some((_, accumulated)) = pending.as_mut() {
+                    let decoded: Cow<'_, str> =
+                        text.decode().map_err(|error| malformed(part, error))?;
+                    let unescaped: Cow<'_, str> = quick_xml::escape::unescape(decoded.as_ref())
+                        .map_err(|error| malformed(part, error))?;
+                    accumulated.push_str(&unescaped);
+                }
+            }
+            Event::CData(cdata) => {
+                if let Some((_, accumulated)) = pending.as_mut() {
+                    accumulated.push_str(&String::from_utf8_lossy(&cdata.into_inner()));
+                }
+            }
+            Event::GeneralRef(reference) => {
+                if let Some((_, accumulated)) = pending.as_mut() {
+                    accumulated.push_str(&resolve_general_reference(&reference, part)?);
+                }
+            }
+            Event::Eof => {
+                if pending.is_some() {
+                    return Err(malformed(part, "unterminated a:t element"));
+                }
+                break;
+            }
+            _ => {}
+        }
+    }
+    Ok(spans)
+}
+
+/// Resolve a general entity reference occurring inside run text.
+///
+/// OOXML documents carry no DTD, so only character references and the five
+/// predefined XML entities can appear; `unescape` rejects anything else.
+fn resolve_general_reference(reference: &BytesRef<'_>, part: &str) -> Result<String, PptxError> {
+    let decoded: Cow<'_, str> = reference.decode().map_err(|error| malformed(part, error))?;
+    let wrapped: String = format!("&{};", decoded.as_ref());
+    let unescaped: Cow<'_, str> =
+        quick_xml::escape::unescape(&wrapped).map_err(|error| malformed(part, error))?;
+    Ok(unescaped.into_owned())
+}
+
+/// Rebuild the slide XML with one run's character data replaced.
+///
+/// Everything outside the addressed span is copied byte-for-byte.
+fn splice_text_run(xml: &[u8], span: &TextRunSpan, new_text: &str) -> Vec<u8> {
+    let escaped: Cow<'_, str> = quick_xml::escape::partial_escape(new_text);
+    match &span.location {
+        TextRunLocation::Element {
+            content_start,
+            content_end,
+        } => {
+            let mut spliced: Vec<u8> =
+                Vec::with_capacity(xml.len() - (content_end - content_start) + escaped.len());
+            spliced.extend_from_slice(&xml[..*content_start]);
+            spliced.extend_from_slice(escaped.as_bytes());
+            spliced.extend_from_slice(&xml[*content_end..]);
+            spliced
+        }
+        TextRunLocation::EmptyTag {
+            tag_start,
+            tag_end,
+            qualified_name,
+        } => {
+            // `<a:t ... />` becomes `<a:t ...>new text</a:t>`, keeping any
+            // attributes the original tag carried.
+            let raw_tag: &[u8] = &xml[*tag_start..*tag_end];
+            let open_tag: &[u8] = raw_tag
+                .strip_suffix(b"/>")
+                .expect("an empty-element tag ends with />");
+            let mut spliced: Vec<u8> = Vec::with_capacity(xml.len() + escaped.len() + 16);
+            spliced.extend_from_slice(&xml[..*tag_start]);
+            spliced.extend_from_slice(open_tag);
+            spliced.push(b'>');
+            spliced.extend_from_slice(escaped.as_bytes());
+            spliced.extend_from_slice(b"</");
+            spliced.extend_from_slice(qualified_name);
+            spliced.push(b'>');
+            spliced.extend_from_slice(&xml[*tag_end..]);
+            spliced
+        }
+    }
+}

--- a/crates/pptx-model/tests/pptx_roundtrip.rs
+++ b/crates/pptx-model/tests/pptx_roundtrip.rs
@@ -304,16 +304,22 @@ fn write_powerpoint_verification_artifacts() {
 
     let no_op = PptxDocument::from_bytes(original.clone()).expect("should load");
     let no_op_path: PathBuf = output_dir.join("withmaster-no-op-roundtrip.pptx");
-    std::fs::write(&no_op_path, no_op.save_to_bytes().expect("save should succeed"))
-        .expect("artifact should write");
+    std::fs::write(
+        &no_op_path,
+        no_op.save_to_bytes().expect("save should succeed"),
+    )
+    .expect("artifact should write");
 
     let mut edited = PptxDocument::from_bytes(original).expect("should load");
     edited
         .set_slide_text_run(0, 0, "Edited page title")
         .expect("edit should succeed");
     let edited_path: PathBuf = output_dir.join("withmaster-edited-roundtrip.pptx");
-    std::fs::write(&edited_path, edited.save_to_bytes().expect("save should succeed"))
-        .expect("artifact should write");
+    std::fs::write(
+        &edited_path,
+        edited.save_to_bytes().expect("save should succeed"),
+    )
+    .expect("artifact should write");
 
     println!("no-op artifact:  {}", no_op_path.display());
     println!("edited artifact: {}", edited_path.display());

--- a/crates/pptx-model/tests/pptx_roundtrip.rs
+++ b/crates/pptx-model/tests/pptx_roundtrip.rs
@@ -1,0 +1,320 @@
+//! Round-trip and surgical-edit tests for the lossless PPTX model
+//! (issue #746).
+//!
+//! Saved containers are re-read with the `zip` crate and rendered through the
+//! existing `office2pdf` pipeline, so the model under test never verifies its
+//! own output.
+
+use std::io::{Cursor, Read};
+use std::path::PathBuf;
+
+use pptx_model::{PptxDocument, PptxError};
+
+fn fixture_bytes(relative: &str) -> Vec<u8> {
+    let path: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures")
+        .join(relative);
+    std::fs::read(path).expect("fixture should be readable")
+}
+
+/// `(name, raw compressed payload)` for every non-directory entry, in order.
+fn raw_zip_entries(bytes: &[u8]) -> Vec<(String, Vec<u8>)> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).expect("container should open");
+    let mut entries: Vec<(String, Vec<u8>)> = Vec::new();
+    for index in 0..archive.len() {
+        let mut file = archive.by_index_raw(index).expect("raw entry should open");
+        if file.is_dir() {
+            continue;
+        }
+        let mut payload: Vec<u8> = Vec::new();
+        file.read_to_end(&mut payload)
+            .expect("raw entry should read");
+        entries.push((file.name().to_string(), payload));
+    }
+    entries
+}
+
+fn zip_entry(bytes: &[u8], name: &str) -> Vec<u8> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).expect("container should open");
+    let mut file = archive.by_name(name).expect("entry should exist");
+    let mut payload: Vec<u8> = Vec::new();
+    file.read_to_end(&mut payload)
+        .expect("entry should decompress");
+    payload
+}
+
+fn convert_to_pdf(container: &[u8]) -> Vec<u8> {
+    office2pdf::convert_bytes(
+        container,
+        office2pdf::config::Format::Pptx,
+        &office2pdf::config::ConvertOptions::default(),
+    )
+    .expect("conversion should succeed")
+    .pdf
+}
+
+#[test]
+fn slides_enumerate_in_presentation_order() {
+    let two_slides =
+        PptxDocument::from_bytes(fixture_bytes("pptx/WithMaster.pptx")).expect("should load");
+    assert_eq!(two_slides.slide_count(), 2);
+    assert_eq!(
+        two_slides.slide_part_names(),
+        ["ppt/slides/slide1.xml", "ppt/slides/slide2.xml"]
+    );
+
+    // The rels part of this fixture lists relationships out of order, so the
+    // expected sequence can only come from the sldIdLst -> rels mapping.
+    let ten_slides =
+        PptxDocument::from_bytes(fixture_bytes("pptx/10-slides.pptx")).expect("should load");
+    let expected: Vec<String> = (1..=10)
+        .map(|number| format!("ppt/slides/slide{number}.xml"))
+        .collect();
+    assert_eq!(ten_slides.slide_part_names(), expected.as_slice());
+
+    let empty =
+        PptxDocument::from_bytes(fixture_bytes("pptx/no-slides.pptx")).expect("should load");
+    assert_eq!(empty.slide_count(), 0);
+}
+
+#[test]
+fn text_runs_are_listed_in_document_order() {
+    let document =
+        PptxDocument::from_bytes(fixture_bytes("pptx/WithMaster.pptx")).expect("should load");
+    assert_eq!(
+        document.slide_text_runs(0).expect("slide 1 should parse"),
+        ["First page title", "First page subtitle"]
+    );
+    assert_eq!(
+        document.slide_text_runs(1).expect("slide 2 should parse"),
+        ["2", "nd", " page subtitle", "Footer from the master slide"]
+    );
+}
+
+#[test]
+fn editing_one_text_run_touches_only_that_slide_part() {
+    let original: Vec<u8> = fixture_bytes("pptx/WithMaster.pptx");
+    let mut document = PptxDocument::from_bytes(original.clone()).expect("should load");
+    document
+        .set_slide_text_run(0, 0, "Edited page title")
+        .expect("edit should succeed");
+    assert_eq!(
+        document.package().dirty_part_names(),
+        ["ppt/slides/slide1.xml"],
+        "exactly the edited slide part should be dirty"
+    );
+
+    let saved: Vec<u8> = document.save_to_bytes().expect("save should succeed");
+
+    // The edited slide differs only in the spliced character data.
+    let expected_slide: Vec<u8> = String::from_utf8(zip_entry(&original, "ppt/slides/slide1.xml"))
+        .expect("slide XML should be UTF-8")
+        .replace("First page title", "Edited page title")
+        .into_bytes();
+    assert_eq!(
+        zip_entry(&saved, "ppt/slides/slide1.xml"),
+        expected_slide,
+        "the edit should splice character data and leave the rest of the slide byte-identical"
+    );
+
+    // Every other package part keeps its exact compressed payload.
+    for ((name, original_payload), (saved_name, saved_payload)) in raw_zip_entries(&original)
+        .iter()
+        .zip(raw_zip_entries(&saved).iter())
+    {
+        assert_eq!(name, saved_name, "entry order should be preserved");
+        if name != "ppt/slides/slide1.xml" {
+            assert_eq!(
+                original_payload, saved_payload,
+                "untouched entry {name} should keep its exact compressed payload"
+            );
+        }
+    }
+
+    // The saved file reopens in this model with the edit applied.
+    let reloaded = PptxDocument::from_bytes(saved).expect("saved file should reload");
+    assert_eq!(
+        reloaded.slide_text_runs(0).expect("slide 1 should parse"),
+        ["Edited page title", "First page subtitle"]
+    );
+}
+
+#[test]
+fn replacement_text_is_escaped_and_survives_reload() {
+    let mut document =
+        PptxDocument::from_bytes(fixture_bytes("pptx/WithMaster.pptx")).expect("should load");
+    let replacement: &str = "Q3 <Sales & \"Profit\">";
+    document
+        .set_slide_text_run(0, 1, replacement)
+        .expect("edit should succeed");
+
+    let saved: Vec<u8> = document.save_to_bytes().expect("save should succeed");
+    let slide_xml: String = String::from_utf8(zip_entry(&saved, "ppt/slides/slide1.xml"))
+        .expect("slide XML should be UTF-8");
+    assert!(
+        !slide_xml.contains("<Sales"),
+        "markup characters must be escaped in the stored XML"
+    );
+
+    let reloaded = PptxDocument::from_bytes(saved).expect("saved file should reload");
+    assert_eq!(
+        reloaded.slide_text_runs(0).expect("slide 1 should parse"),
+        ["First page title", replacement]
+    );
+}
+
+#[test]
+fn empty_text_runs_can_be_read_and_edited() {
+    // No committed fixture carries a self-closing <a:t/>, so craft one from
+    // WithMaster.pptx through the package layer.
+    let mut package = ooxml_package::OpcPackage::from_bytes(fixture_bytes("pptx/WithMaster.pptx"))
+        .expect("package should load");
+    let slide_xml: String = String::from_utf8(
+        package
+            .part_bytes("ppt/slides/slide1.xml")
+            .expect("slide should read")
+            .into_owned(),
+    )
+    .expect("slide XML should be UTF-8");
+    package
+        .set_part_bytes(
+            "ppt/slides/slide1.xml",
+            slide_xml
+                .replace("<a:t>First page title</a:t>", "<a:t/>")
+                .into_bytes(),
+        )
+        .expect("slide should accept the crafted XML");
+    let crafted: Vec<u8> = package.save_to_bytes().expect("package should save");
+
+    let mut document = PptxDocument::from_bytes(crafted).expect("crafted file should load");
+    assert_eq!(
+        document.slide_text_runs(0).expect("slide 1 should parse"),
+        ["", "First page subtitle"],
+        "a self-closing a:t is an empty run"
+    );
+
+    document
+        .set_slide_text_run(0, 0, "Restored title")
+        .expect("empty run should accept text");
+    let reloaded = PptxDocument::from_bytes(document.save_to_bytes().expect("save should succeed"))
+        .expect("saved file should reload");
+    assert_eq!(
+        reloaded.slide_text_runs(0).expect("slide 1 should parse"),
+        ["Restored title", "First page subtitle"]
+    );
+}
+
+#[test]
+fn no_op_round_trip_projects_to_an_identical_pdf() {
+    let original: Vec<u8> = fixture_bytes("pptx/WithMaster.pptx");
+    let document = PptxDocument::from_bytes(original.clone()).expect("should load");
+    let saved: Vec<u8> = document.save_to_bytes().expect("save should succeed");
+
+    let original_pdf: Vec<u8> = convert_to_pdf(&original);
+    let round_trip_pdf: Vec<u8> = convert_to_pdf(&saved);
+    assert_eq!(
+        original_pdf, round_trip_pdf,
+        "a no-op round trip must not change the rendered PDF"
+    );
+}
+
+#[test]
+fn edited_presentation_projects_the_new_text_into_the_pdf() {
+    let mut document =
+        PptxDocument::from_bytes(fixture_bytes("pptx/WithMaster.pptx")).expect("should load");
+    document
+        .set_slide_text_run(0, 0, "Quarterly Review 2026")
+        .expect("edit should succeed");
+    let saved: Vec<u8> = document.save_to_bytes().expect("save should succeed");
+
+    let pdf_text: String = pdf_extract::extract_text_from_mem(&convert_to_pdf(&saved))
+        .expect("PDF text should extract");
+    // pdf-extract pads inter-word gaps with variable spacing; compare on
+    // whitespace-normalized text.
+    let normalized: String = pdf_text.split_whitespace().collect::<Vec<&str>>().join(" ");
+    assert!(
+        normalized.contains("Quarterly Review 2026"),
+        "edited text should reach the rendered PDF, got: {normalized:?}"
+    );
+    assert!(
+        !normalized.contains("First page title"),
+        "replaced text should no longer render"
+    );
+}
+
+#[test]
+fn non_presentation_input_is_rejected() {
+    let docx_error: PptxError =
+        PptxDocument::from_bytes(fixture_bytes("docx/unit_test_headers.docx")).unwrap_err();
+    assert!(
+        matches!(docx_error, PptxError::NotAPresentation(_)),
+        "a DOCX container must be rejected as not-a-presentation, got: {docx_error}"
+    );
+
+    let garbage_error: PptxError =
+        PptxDocument::from_bytes(b"not an OPC container".to_vec()).unwrap_err();
+    assert!(
+        matches!(garbage_error, PptxError::Package(_)),
+        "garbage bytes must surface the package error, got: {garbage_error}"
+    );
+}
+
+#[test]
+fn out_of_range_indices_are_reported() {
+    let mut document =
+        PptxDocument::from_bytes(fixture_bytes("pptx/WithMaster.pptx")).expect("should load");
+
+    let slide_error: PptxError = document.slide_text_runs(5).unwrap_err();
+    assert!(
+        matches!(
+            slide_error,
+            PptxError::SlideIndexOutOfRange {
+                index: 5,
+                slide_count: 2,
+            }
+        ),
+        "expected SlideIndexOutOfRange, got: {slide_error}"
+    );
+
+    let run_error: PptxError = document.set_slide_text_run(0, 99, "text").unwrap_err();
+    assert!(
+        matches!(
+            &run_error,
+            PptxError::TextRunIndexOutOfRange {
+                index: 99,
+                run_count: 2,
+                ..
+            }
+        ),
+        "expected TextRunIndexOutOfRange, got: {run_error}"
+    );
+}
+
+/// Writes round-trip artifacts for the manual acceptance check of issue #746:
+/// open both files in Microsoft PowerPoint and confirm neither raises a
+/// repair prompt. Set `PPTX_MODEL_ARTIFACT_DIR` to choose the output
+/// directory (defaults to the system temp directory).
+#[test]
+#[ignore = "writes local artifacts for the manual PowerPoint acceptance check"]
+fn write_powerpoint_verification_artifacts() {
+    let output_dir: PathBuf = std::env::var_os("PPTX_MODEL_ARTIFACT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
+    let original: Vec<u8> = fixture_bytes("pptx/WithMaster.pptx");
+
+    let no_op = PptxDocument::from_bytes(original.clone()).expect("should load");
+    let no_op_path: PathBuf = output_dir.join("withmaster-no-op-roundtrip.pptx");
+    std::fs::write(&no_op_path, no_op.save_to_bytes().expect("save should succeed"))
+        .expect("artifact should write");
+
+    let mut edited = PptxDocument::from_bytes(original).expect("should load");
+    edited
+        .set_slide_text_run(0, 0, "Edited page title")
+        .expect("edit should succeed");
+    let edited_path: PathBuf = output_dir.join("withmaster-edited-roundtrip.pptx");
+    std::fs::write(&edited_path, edited.save_to_bytes().expect("save should succeed"))
+        .expect("artifact should write");
+
+    println!("no-op artifact:  {}", no_op_path.display());
+    println!("edited artifact: {}", edited_path.display());
+}

--- a/scripts/macos/verify_powerpoint_roundtrip.applescript
+++ b/scripts/macos/verify_powerpoint_roundtrip.applescript
@@ -1,0 +1,51 @@
+-- Acceptance probe for lossless round-trip artifacts (issue #746): open each
+-- file in Microsoft PowerPoint and report its slide count. A file that
+-- triggers a repair prompt blocks `open` until the timeout, which is recorded
+-- as a failure — so a clean report means PowerPoint accepted the file as-is.
+--
+-- usage: osascript verify_powerpoint_roundtrip.applescript input.pptx [more.pptx ...]
+on run argv
+    if (count argv) < 1 then error "usage: input-path [input-path ...]"
+
+    set failures to {}
+    set reportLines to {}
+
+    tell application "Microsoft PowerPoint"
+        launch
+        repeat with inputIndex from 1 to (count argv)
+            set inputPath to item inputIndex of argv
+            set openedPresentation to missing value
+            try
+                with timeout of 60 seconds
+                    open my posixFile(inputPath)
+                    set openedPresentation to active presentation
+                    set slideCount to count of slides of openedPresentation
+                    close openedPresentation saving no
+                    set end of reportLines to inputPath & ": opened cleanly, " & slideCount & " slides"
+                end timeout
+            on error errorMessage number errorNumber
+                if openedPresentation is not missing value then
+                    try
+                        close openedPresentation saving no
+                    end try
+                end if
+                set end of failures to inputPath & ": " & errorMessage & " (" & errorNumber & ")"
+            end try
+        end repeat
+        quit
+    end tell
+
+    if (count failures) > 0 then error my joinLines(failures)
+    return my joinLines(reportLines)
+end run
+
+on posixFile(inputPath)
+    return inputPath as POSIX file
+end posixFile
+
+on joinLines(values)
+    set AppleScript's text item delimiters to linefeed
+    set joined to values as text
+    set AppleScript's text item delimiters to ""
+    return joined
+end joinLines


### PR DESCRIPTION
## Summary

Lays the architectural foundation for round-trip OOXML editing (issue #746, first milestone): two new unpublished workspace crates that hold a package losslessly and edit it surgically, while the existing rendering pipeline stays a derived projection — never the editable source of truth.

- **`ooxml-package`** — a lossless OPC container model. Loading records every ZIP entry in container order; on save, untouched entries are copied as raw compressed payloads (byte-for-byte, preserving compression method, timestamps, and permissions), so parts and XML the workspace does not understand survive unchanged. `set_part_bytes` marks a part dirty, `dirty_part_names` reports exactly what an edit touched, and relationships / `[Content_Types].xml` parse on demand — always from the authoritative part bytes.
- **`pptx-model`** — a lossless, editable PPTX model over `ooxml-package`. Slides enumerate in `p:sldIdLst` (slide show) order resolved through the presentation part's relationships; `a:t` runs list in document order; `set_slide_text_run` splices only that run's character data inside its slide part, leaving every other byte of the package untouched.

**First-milestone acceptance criteria from #746, and where each is verified:**

- No-op load/save preserves every part payload byte-identical, in order — `no_op_round_trip_preserves_every_part_payload_and_order` and `untouched_part_payloads_are_copied_byte_for_byte_compressed`, asserted on PPTX, DOCX, and XLSX fixtures (OPC is format-agnostic).
- Unsupported parts and XML survive a no-op round trip — `unknown_parts_survive_a_round_trip` (injected `customXml/` part + opaque binary part).
- Editing one text run changes only the intended slide part — `editing_one_text_run_touches_only_that_slide_part` (every other entry keeps its exact compressed payload; the slide XML differs only in the spliced character data).
- The saved file reopens in office2pdf — reload + `convert_bytes` assertions in the model tests.
- No-op projection produces the same PDF — `no_op_round_trip_projects_to_an_identical_pdf` asserts **byte-identical** PDF output through the existing pipeline (stronger than the tolerance the issue allows).
- Opens in Microsoft PowerPoint without a repair prompt — verified locally with the new probe `scripts/macos/verify_powerpoint_roundtrip.applescript` on the no-op and edited artifacts (see Testing).
- Automated tests cover no-op preservation, single-edit isolation, relationship integrity (`relationships_resolve_to_existing_parts_before_and_after_round_trip`), and unknown-part preservation.

Deferred to later milestones per the issue's own sequencing: property provenance (`Explicit`/`Inherited`/`Default`), transactional edit commands, further mutation kinds (geometry, styles, images, slide insertion/reordering, masters/layouts), and the XLSX/DOCX editable models.

## Related issue

Related: #746

## Testing

- `OFFICE2PDF_VALIDATE_PDF=1 cargo test --workspace` — green (adds 10 `ooxml-package` + 9 `pptx-model` tests; every fixture they read is already tracked in git).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean on stable and on 1.97.
- `cargo fmt --all -- --check` — clean.
- `cargo +1.89.0 check --workspace` — MSRV clean.
- PowerPoint probe: `cargo test -p pptx-model --test pptx_roundtrip write_powerpoint_verification_artifacts -- --ignored`, then `osascript scripts/macos/verify_powerpoint_roundtrip.applescript` on both artifacts — both reported `opened cleanly, 2 slides` in Microsoft PowerPoint for Mac; a repair prompt would have blocked the probe into its timeout failure path.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Adds two new unpublished crates, tests, and a macOS probe script; the converter pipeline is untouched, and the new no-op projection test asserts byte-identical PDF output.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
