### PR TITLE
fix(tooling): stage office-backend probes in the app's sandbox container

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,8 +268,17 @@ deviates from the base's, the run aborts, because repackaging (not the factor)
 changed the output. Differ failures abort likewise, never an empty row.
 Backend `office2pdf` answers "what does our code do" anywhere in seconds
 (`--converter` names the binary); `office` drives the native AppleScripts and
-answers "what does Office do" — its stage must sit on the internal disk (the
-Office sandbox cannot write to `/Volumes`; the harness enforces this).
+answers "what does Office do".
+
+The `office` stage is constrained by the app sandbox on both sides. It defaults
+into the driven app's own container — `~/Library/Containers/com.microsoft.Word`,
+`.Powerpoint` or `.Excel` under `Data/probes/`, matched to the fixture's format
+— and the report and PDFs are copied back to `target/probes/` afterwards.
+Anywhere else, including another Office app's container, costs a per-file
+"Grant Access" dialog that stalls an unattended run. An explicit `--stage-root`
+overrides that and must still sit on the internal disk: the sandbox cannot
+write to `/Volumes` at all (AppleEvent timeout -1712), which the harness
+enforces.
 
 ### Fine-detail analysis (thin and small elements)
 

--- a/scripts/probe_harness.py
+++ b/scripts/probe_harness.py
@@ -20,9 +20,17 @@ Backends:
   Mac.
 - ``office`` — native Office via ``scripts/macos/export_*_pdfs.applescript``
   (picked by the base fixture's extension). Answers "what does Office do".
-  The Office apps are sandboxed and cannot write to external volumes (a save
-  under ``/Volumes`` hangs with AppleEvent timeout -1712), so the stage must
-  sit on the internal disk.
+
+  The Office apps are sandboxed, which constrains the stage twice over. A file
+  outside the driven app's own container needs per-file consent, and the
+  "Grant Access" dialog stalls an unattended run, so this backend stages under
+  ``~/Library/Containers/<bundle id>/Data/probes/`` — ``com.microsoft.Word``,
+  ``com.microsoft.Powerpoint`` or ``com.microsoft.Excel``, matched to the
+  format, since another app's container prompts just the same — and copies the
+  report and the PDFs back out to ``target/probes/`` when the run finishes
+  (#1051). And the sandbox cannot write to external volumes at all (a save
+  under ``/Volumes`` hangs with AppleEvent timeout -1712), so an explicit
+  ``--stage-root`` must still sit on the internal disk.
 
 A differ failure always propagates: a probe row built from a differ that
 silently reported nothing would show the variant as identical to the control,
@@ -70,6 +78,13 @@ APPLESCRIPT_BY_EXTENSION = {
     ".pptx": SCRIPTS_DIR / "macos" / "export_powerpoint_pdfs.applescript",
     ".xlsx": SCRIPTS_DIR / "macos" / "export_excel_pdfs.applescript",
 }
+OFFICE_BUNDLE_ID_BY_EXTENSION = {
+    ".docx": "com.microsoft.Word",
+    ".pptx": "com.microsoft.Powerpoint",
+    ".xlsx": "com.microsoft.Excel",
+}
+CONTAINERS_ROOT = Path.home() / "Library" / "Containers"
+RESULTS_ROOT = REPO_ROOT / "target" / "probes"
 
 SPEC_KEYS = {"name", "base", "part", "factor", "page", "noise_floor", "variants"}
 SPEC_REQUIRED_KEYS = ("name", "base", "part", "variants")
@@ -220,6 +235,39 @@ def ensure_internal_disk(path: Path) -> None:
             f"{path} sits on an external volume; the Office sandbox cannot write there "
             "(AppleEvent timeout -1712) — stage on the internal disk"
         )
+
+
+def default_stage_root(backend: str, extension: str) -> Path:
+    """Where a run stages packages and PDFs when ``--stage-root`` is not given.
+
+    The Office apps are sandboxed: opening a package from, or saving a PDF to,
+    anywhere outside the app's own container raises a per-file "Grant Access"
+    dialog, and an unattended run stalls on the first one (#1051). Inside the
+    container nothing is asked, so the office backend stages there — in the
+    container of the app this fixture's format drives, because reaching into
+    another app's container prompts just the same.
+    """
+    if backend != "office":
+        return RESULTS_ROOT
+    bundle_id = OFFICE_BUNDLE_ID_BY_EXTENSION.get(extension.lower())
+    if bundle_id is None:
+        raise ProbeError(f"no Office app container for '{extension.lstrip('.')}' fixtures")
+    return CONTAINERS_ROOT / bundle_id / "Data" / "probes"
+
+
+def mirror_results(stage: Path, destination: Path) -> Path:
+    """Copy a container-staged run's report and PDFs out; return the report path.
+
+    The variant packages stay behind: they rebuild deterministically from the
+    spec, while the report and the exported PDFs are what the run produced and
+    what the caller came for.
+    """
+    (destination / "pdfs").mkdir(parents=True, exist_ok=True)
+    for pdf in sorted((stage / "pdfs").glob("*.pdf")):
+        shutil.copyfile(pdf, destination / "pdfs" / pdf.name)
+    report = destination / "report.md"
+    shutil.copyfile(stage / "report.md", report)
+    return report
 
 
 def applescript_for(extension: str) -> Path:
@@ -465,17 +513,21 @@ def run_probe(
 ) -> Path:
     """Run one probe spec end to end; return the written report path."""
     spec = load_spec(spec_path)
-    stage = (stage_root or REPO_ROOT / "target" / "probes") / spec.name
+    if not spec.base.is_file():
+        raise ProbeError(f"base fixture not found: {spec.base}")
+    extension = spec.base.suffix.lower()
+
+    staged_in_container = stage_root is None and backend == "office"
+    stage = (stage_root or default_stage_root(backend, extension)) / spec.name
     if backend == "office":
         ensure_internal_disk(stage)
     packages_dir = stage / "packages"
     pdf_dir = stage / "pdfs"
     packages_dir.mkdir(parents=True, exist_ok=True)
     pdf_dir.mkdir(parents=True, exist_ok=True)
+    if staged_in_container:
+        print(f"[{spec.name}] staging inside the app sandbox container: {stage}", file=sys.stderr)
 
-    if not spec.base.is_file():
-        raise ProbeError(f"base fixture not found: {spec.base}")
-    extension = spec.base.suffix.lower()
     with zipfile.ZipFile(spec.base) as archive:
         names = archive.namelist()
         if spec.part not in names:
@@ -537,6 +589,9 @@ def run_probe(
     report_path = stage / "report.md"
     report_path.write_text(report, encoding="utf-8")
     sys.stdout.write(report)
+    if staged_in_container:
+        report_path = mirror_results(stage, RESULTS_ROOT / spec.name)
+        print(f"[{spec.name}] results copied out to {report_path.parent}", file=sys.stderr)
     return report_path
 
 
@@ -558,7 +613,11 @@ def main(argv: list[str] | None = None) -> int:
         "--stage-root",
         type=Path,
         default=None,
-        help="directory to stage packages/PDFs/reports under (default: target/probes)",
+        help=(
+            "directory to stage packages/PDFs/reports under (default: target/probes; "
+            "--backend office defaults into the driven app's sandbox container and "
+            "copies the results back to target/probes)"
+        ),
     )
     args = parser.parse_args(argv)
 

--- a/scripts/tests/test_probe_harness.py
+++ b/scripts/tests/test_probe_harness.py
@@ -20,6 +20,7 @@ import zipfile
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -475,6 +476,59 @@ class ExportTest(unittest.TestCase):
             self.assertEqual((pdf_dir / "base.pdf").read_bytes(), b"%PDF1")
 
 
+class StageRootTest(unittest.TestCase):
+    """Where a run stages when --stage-root is not given (#1051)."""
+
+    def test_the_office_backend_stages_in_the_driven_apps_own_container(self):
+        # Anywhere outside the sandbox container raises a per-file "Grant
+        # Access" dialog, which stalls an unattended run; a cross-app
+        # container prompts too, so each format goes to its own app's.
+        for extension, bundle_id in (
+            (".docx", "com.microsoft.Word"),
+            (".pptx", "com.microsoft.Powerpoint"),
+            (".xlsx", "com.microsoft.Excel"),
+        ):
+            with self.subTest(extension=extension):
+                self.assertEqual(
+                    probe_harness.default_stage_root("office", extension),
+                    probe_harness.CONTAINERS_ROOT / bundle_id / "Data" / "probes",
+                )
+
+    def test_an_extension_no_office_app_opens_is_an_error(self):
+        with self.assertRaisesRegex(probe_harness.ProbeError, "odt"):
+            probe_harness.default_stage_root("office", ".odt")
+
+    def test_the_other_backends_stage_under_the_repo_results_root(self):
+        # Only the sandboxed apps need the container; our converter and
+        # LibreOffice read and write anywhere.
+        for backend in ("office2pdf", "soffice"):
+            with self.subTest(backend=backend):
+                self.assertEqual(
+                    probe_harness.default_stage_root(backend, ".pptx"),
+                    probe_harness.RESULTS_ROOT,
+                )
+
+    def test_results_are_copied_out_of_the_container(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            stage = tmp / "container" / "spcAft"
+            (stage / "pdfs").mkdir(parents=True)
+            (stage / "packages").mkdir()
+            (stage / "report.md").write_text("# Probe: spcAft\n")
+            (stage / "pdfs" / "base.pdf").write_bytes(b"%PDF base")
+            (stage / "pdfs" / "variant-500.pdf").write_bytes(b"%PDF 500")
+            destination = tmp / "target" / "probes" / "spcAft"
+
+            report_path = probe_harness.mirror_results(stage, destination)
+
+            self.assertEqual(report_path, destination / "report.md")
+            self.assertEqual(report_path.read_text(), "# Probe: spcAft\n")
+            self.assertEqual(
+                (destination / "pdfs" / "variant-500.pdf").read_bytes(), b"%PDF 500"
+            )
+            self.assertEqual((destination / "pdfs" / "base.pdf").read_bytes(), b"%PDF base")
+
+
 class DifferTest(unittest.TestCase):
     def test_the_differ_report_is_parsed_from_json(self):
         report = differ_report(page_vector())
@@ -674,6 +728,80 @@ class EndToEndTest(unittest.TestCase):
             packages = stage_root / "spcAft-linearity" / "packages"
             self.assertTrue((packages / "control.pptx").exists())
             self.assertTrue((packages / "variant-500.pptx").exists())
+
+    def office_runner(self):
+        """A fake `osascript` export deriving each PDF from its package's part."""
+        calls: list[list[str]] = []
+
+        def runner(argv):
+            calls.append(list(argv))
+            if argv[0] == "osascript":
+                pdf_dir = Path(argv[2])
+                for index in range(3, len(argv), 2):
+                    job_id, package = argv[index], argv[index + 1]
+                    with zipfile.ZipFile(package) as archive:
+                        content = archive.read("ppt/slides/slide1.xml")
+                    (pdf_dir / f"{job_id}.pdf").write_bytes(b"%PDF " + content)
+                return completed(argv)
+            if argv[1].endswith("compare_layout.py"):
+                return completed(argv, stdout=json.dumps(differ_report(page_vector())))
+            raise AssertionError(f"unexpected command {argv}")
+
+        return calls, runner
+
+    def test_an_office_run_stages_in_the_container_and_copies_results_out(self):
+        # Every path PowerPoint is handed must sit inside its own container,
+        # or the sandbox raises a Grant Access dialog per file (#1051); the
+        # results still have to land where the caller looks for them.
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            write_base_package(tmp / "base.pptx")
+            spec_path = write_spec(tmp)
+            containers = tmp / "Containers"
+            results = tmp / "target" / "probes"
+            calls, runner = self.office_runner()
+            with patch.object(probe_harness, "CONTAINERS_ROOT", containers), patch.object(
+                probe_harness, "RESULTS_ROOT", results
+            ), redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                report_path = probe_harness.run_probe(
+                    spec_path, backend="office", runner=runner
+                )
+
+            stage = containers / "com.microsoft.Powerpoint" / "Data" / "probes" / "spcAft-linearity"
+            exports = [argv for argv in calls if argv[0] == "osascript"]
+            self.assertEqual(len(exports), 1)
+            for argument in exports[0][2:]:
+                if "/" in argument:
+                    self.assertTrue(
+                        Path(argument).is_relative_to(stage),
+                        f"{argument} is outside the app container",
+                    )
+            self.assertEqual(report_path, results / "spcAft-linearity" / "report.md")
+            self.assertIn("| 500 |", report_path.read_text())
+            self.assertEqual(
+                (results / "spcAft-linearity" / "pdfs" / "variant-500.pdf").read_bytes(),
+                (stage / "pdfs" / "variant-500.pdf").read_bytes(),
+            )
+
+    def test_an_explicit_stage_root_is_honoured_and_still_guarded(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            write_base_package(tmp / "base.pptx")
+            spec_path = write_spec(tmp)
+            _, runner = self.office_runner()
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                report_path = probe_harness.run_probe(
+                    spec_path, backend="office", stage_root=tmp / "explicit", runner=runner
+                )
+            self.assertEqual(report_path, tmp / "explicit" / "spcAft-linearity" / "report.md")
+
+            with self.assertRaisesRegex(probe_harness.ProbeError, "internal disk"):
+                probe_harness.run_probe(
+                    spec_path,
+                    backend="office",
+                    stage_root=Path("/Volumes/FakeDisk/probes"),
+                    runner=runner,
+                )
 
     def test_a_differ_failure_fails_the_whole_run(self):
         def differ_result(argv):


### PR DESCRIPTION
## Summary

`scripts/probe_harness.py --backend office` staged its packages and PDFs under `target/probes`, outside the sandboxed Office app's container. macOS charges consent per file there: every workbook the app opens and every PDF it saves raises a "Grant Access" dialog, and an unattended run stops at the first one. The harness already guarded the sandbox's *other* staging trap — a save under `/Volumes` hangs with AppleEvent timeout -1712 — but not this one, which is the trap that actually fires on a normal internal-disk path.

Key changes:

- `default_stage_root` — the `office` backend now defaults its stage to `~/Library/Containers/<bundle id>/Data/probes/`, the bundle id picked from the base fixture's extension: `com.microsoft.Word`, `com.microsoft.Powerpoint`, `com.microsoft.Excel`. Reaching into *another* Office app's container prompts just the same, so the container has to match the app the format drives — the same key that already picks the AppleScript.
- `mirror_results` — the report and the exported PDFs are copied back to `target/probes/<probe name>/` when the run finishes, and `run_probe` returns the copied-out report path, so results still land where the caller looks for them. The variant packages stay behind in the container; they rebuild deterministically from the spec, while the PDFs are what the run produced.
- An explicit `--stage-root` is untouched: used verbatim, no mirroring, and still gated on the internal disk.
- Both stage locations are printed to stderr, so a run that aborts on the control gate still says where its PDFs are.
- The rule is documented in the module docstring, the `--stage-root` help, and CLAUDE.md's probe-harness section.

`spec.base`'s existence check moves ahead of the `mkdir`, because the extension now decides the stage directory; a missing fixture fails before anything is created rather than after.

## Related issue

Related: #1051, #698

The other callers of the same AppleScript exporters — `public_visual_audit.rs`'s GT regeneration and `measure_powerpoint_chart_axis.py` — still hand the app paths outside its container. That was outside this issue's Fix section and is tracked separately in #1082.

## Testing

`python3 -m unittest discover -s scripts/tests -p 'test_probe_harness.py'` — 43 tests, all passing; the 6 new ones fail against `main` (`AttributeError: module 'probe_harness' has no attribute 'default_stage_root'`) and were written first.

- `StageRootTest` — each extension maps to its own app's container; a format no Office app opens (`.odt`) is a `ProbeError`; `office2pdf` and `soffice` still stage under the repo results root; `mirror_results` copies the report and every PDF out.
- `EndToEndTest.test_an_office_run_stages_in_the_container_and_copies_results_out` — a full run against a fake `osascript`, with the container and results roots patched to a temp tree. It asserts on the argv the exporter is actually handed: *every* path argument must sit inside the container stage. That is the property the issue is about, and it survives a refactor of how the path is built.
- `EndToEndTest.test_an_explicit_stage_root_is_honoured_and_still_guarded` — an override is used verbatim and not redirected, and a `/Volumes` override still aborts before anything is staged.

## Native verification

Ran a real one-factor probe through Excel for Mac against a container path that had never been granted — `~/Library/Containers/com.microsoft.Excel/Data/probes/` did not exist before the run:

```
python3 scripts/probe_harness.py probe.json --backend office
```

Three workbooks (base, re-zip control, one variant) opened and exported, the control gate passed, results were copied out. **No dialog appeared and nothing was clicked**, which is the issue's acceptance criterion. The probe itself reads sensibly too — doubling `defaultRowHeight` from 15.75 to 31.5 on a fixture whose rows carry `customHeight`:

| `defaultRowHeight` | pages | matched | worst dy (pt) | worst pitch (pt) |
| --- | --- | ---: | ---: | ---: |
| 31.5 | 1/1 | 3 | +48.00 | 16.00 |

Control gate: `layout-identical re-zip (bytes differ)`.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Python-only change to `scripts/probe_harness.py`, its unit tests, and CLAUDE.md. It moves where the measurement harness stages files on disk; no converter crate is touched, so no rendered PDF page can differ.
