### PR TITLE
fix(pptx): pivot a rotated text box on its own centre

### DIFF
--- a/crates/office2pdf/src/render/pdf.rs
+++ b/crates/office2pdf/src/render/pdf.rs
@@ -352,7 +352,9 @@ fn compile_to_pdf_inner(
 #[cfg(all(test, not(target_arch = "wasm32")))]
 #[derive(Debug, Clone)]
 pub(crate) struct PlacedTextRun {
-    /// Distance from the page's top edge down to the run's baseline, in points.
+    /// Distance from the page's top edge down to the run's baseline origin, in
+    /// points. A turned run reports the page-space image of that origin, so it
+    /// is the point the transform moved rather than a horizontal baseline.
     pub baseline_pt: f64,
     /// Distance from the page's left edge to the run's origin, in points.
     pub left_pt: f64,
@@ -370,27 +372,28 @@ pub(crate) struct PlacedTextRun {
 /// the paragraph it touched. Tests for placement therefore compile the source
 /// and read the frames.
 ///
-/// Group transforms are followed by their translation only; nothing in a header
-/// or footer story rotates or scales, and a run inside such a group would be
-/// reported at the wrong place rather than silently skipped.
+/// Group transforms are accumulated in full, not just their translation: a
+/// rotated text box turns the group its runs sit in, and reading only `tx`/`ty`
+/// reports every one of those runs at the unturned place (issue #1078).
 #[cfg(all(test, not(target_arch = "wasm32")))]
 pub(crate) fn compiled_text_runs(
     typst_source: &str,
     page_index: usize,
 ) -> Result<Vec<PlacedTextRun>, ConvertError> {
-    use typst::layout::{Frame, FrameItem, Point};
+    use typst::layout::{Frame, FrameItem, Transform};
 
-    fn collect(frame: &Frame, origin: Point, out: &mut Vec<PlacedTextRun>) {
+    fn collect(frame: &Frame, transform: Transform, out: &mut Vec<PlacedTextRun>) {
         for (position, item) in frame.items() {
-            let at: Point = origin + *position;
+            let at: Transform = transform.pre_concat(Transform::translate(position.x, position.y));
             match item {
                 FrameItem::Group(group) => {
-                    let shift = Point::new(group.transform.tx, group.transform.ty);
-                    collect(&group.frame, at + shift, out);
+                    collect(&group.frame, at.pre_concat(group.transform), out);
                 }
+                // The run's own origin is the local `(0, 0)` the accumulated
+                // transform maps to, which is exactly its translation column.
                 FrameItem::Text(text) => out.push(PlacedTextRun {
-                    baseline_pt: at.y.to_pt(),
-                    left_pt: at.x.to_pt(),
+                    baseline_pt: at.ty.to_pt(),
+                    left_pt: at.tx.to_pt(),
                     family: text.font.info().family.clone(),
                     text: text.text.to_string(),
                 }),
@@ -422,7 +425,7 @@ pub(crate) fn compiled_text_runs(
         ))
     })?;
     let mut runs: Vec<PlacedTextRun> = Vec::new();
-    collect(&page.frame, Point::zero(), &mut runs);
+    collect(&page.frame, Transform::identity(), &mut runs);
     Ok(runs)
 }
 

--- a/crates/office2pdf/src/render/typst_gen.rs
+++ b/crates/office2pdf/src/render/typst_gen.rs
@@ -1142,8 +1142,9 @@ fn generate_fixed_element(
     Ok(())
 }
 
-/// How far a picture mirrored and turned about its box's **top-left corner**
-/// has to move to land where PowerPoint's **centre** pivot would have put it.
+/// How far a box mirrored and turned about its **top-left corner** has to move
+/// to land where PowerPoint's **centre** pivot would have put it. Pictures pass
+/// their mirror flags; a text box turns without mirroring and passes `false`.
 ///
 /// With a `top + left` origin the mirror maps the box to `(±u, ±v)` and the
 /// turn follows as `R`, so the composed map is `R(S(p))`. PowerPoint's is
@@ -1211,16 +1212,34 @@ fn generate_fixed_text_box(
     // box and the whole result turns about its centre, so `reflow: false`
     // keeps the placed geometry where the slide puts it. This wraps the
     // vertical-text case below, which rotates the glyphs inside the box.
+    //
+    // `origin: center` cannot name that centre: Typst resolves it against the
+    // frame it lays the body out in, and that frame is clamped to the region,
+    // so a box taller or wider than the slide turns about the slide's midpoint
+    // and lands translated. Pivot on the frame's own top-left corner, which no
+    // clamp can move, and carry the difference in an enclosing `#move` — the
+    // same correction #1032 made for a picture (issue #1078). A box that fits
+    // the region is unaffected: the shift is exactly what `origin: center`
+    // resolved to there.
     if let Some(rotation) = text_box.shape_rotation_deg.filter(|deg| *deg != 0.0) {
         let mut inner: TextBoxData = text_box.clone();
         inner.shape_rotation_deg = None;
+        let (dx, dy): (f64, f64) = centre_pivot_shift(
+            elem.width.max(0.0),
+            elem.height.max(0.0),
+            rotation,
+            false,
+            false,
+        );
         let _ = write!(
             out,
-            "#rotate({}deg, origin: center, reflow: false)[",
+            "#move(dx: {}pt, dy: {}pt)[#rotate({}deg, origin: top + left, reflow: false)[",
+            format_f64(dx),
+            format_f64(dy),
             format_f64(rotation)
         );
         generate_fixed_text_box(out, elem, &inner, ctx)?;
-        out.push_str("]\n");
+        out.push_str("]]\n");
         return Ok(());
     }
 
@@ -1261,11 +1280,24 @@ fn generate_fixed_text_box(
         };
         // The outer #place pins the top-left of a width x height region;
         // center the swapped box on that region before rotating in place.
+        //
+        // The swap trades the box's two dimensions, so a box wider than the
+        // slide is high lays out as a frame taller than the region and meets
+        // the same clamp as the shape-rotation case above. Pivot on the corner
+        // for the same reason, and fold both translations into the one `#move`
+        // (issue #1078).
+        let (pivot_dx, pivot_dy): (f64, f64) = centre_pivot_shift(
+            swapped_elem.width,
+            swapped_elem.height,
+            rotation,
+            false,
+            false,
+        );
         let _ = write!(
             out,
-            "#move(dx: {}pt, dy: {}pt)[#rotate({}deg, origin: center, reflow: false)[",
-            format_f64((elem.width - elem.height) / 2.0),
-            format_f64((elem.height - elem.width) / 2.0),
+            "#move(dx: {}pt, dy: {}pt)[#rotate({}deg, origin: top + left, reflow: false)[",
+            format_f64((elem.width - elem.height) / 2.0 + pivot_dx),
+            format_f64((elem.height - elem.width) / 2.0 + pivot_dy),
             format_f64(rotation)
         );
         generate_fixed_text_box(out, &swapped_elem, &inner, ctx)?;

--- a/crates/office2pdf/src/render/typst_gen_fixed_page_textbox_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_fixed_page_textbox_tests.rs
@@ -3005,3 +3005,182 @@ fn the_contoso_slide_number_lands_on_its_native_origin() {
         );
     }
 }
+
+/// Where the rotated-box probes below seat their element on the slide. Off
+/// both the slide's midlines, so a pivot on the box centre and a pivot on the
+/// slide centre cannot coincide.
+#[cfg(not(target_arch = "wasm32"))]
+const TURNED_BOX_X_PT: f64 = 120.0;
+#[cfg(not(target_arch = "wasm32"))]
+const TURNED_BOX_Y_PT: f64 = 40.0;
+
+/// One text box on a 960 x 540pt slide, with `apply` free to turn it.
+#[cfg(not(target_arch = "wasm32"))]
+fn turned_slide_text_box(
+    width_pt: f64,
+    height_pt: f64,
+    apply: impl FnOnce(&mut crate::ir::TextBoxData),
+) -> crate::ir::Document {
+    let mut element: FixedElement = make_fixed_text_box(
+        TURNED_BOX_X_PT,
+        TURNED_BOX_Y_PT,
+        width_pt,
+        height_pt,
+        Insets::default(),
+        crate::ir::TextBoxVerticalAlign::Top,
+        vec![Block::Paragraph(Paragraph {
+            style: ParagraphStyle::default(),
+            runs: vec![Run {
+                text: "Turned".to_string(),
+                style: TextStyle::default(),
+                href: None,
+                footnote: None,
+            }],
+        })],
+    );
+    let FixedElementKind::TextBox(text_box) = &mut element.kind else {
+        unreachable!("make_fixed_text_box builds a text box");
+    };
+    apply(text_box);
+    make_doc(vec![make_fixed_page(960.0, 540.0, vec![element])])
+}
+
+/// Every text run's page-space origin, in layout order.
+#[cfg(not(target_arch = "wasm32"))]
+fn placed_run_origins(doc: &crate::ir::Document) -> Vec<(f64, f64)> {
+    let output = generate_typst(doc).expect("the slide generates");
+    let runs = crate::render::pdf::compiled_text_runs(&output.source, 0)
+        .unwrap_or_else(|error| panic!("compile failed: {error}\n{}", output.source));
+    assert!(
+        !runs.is_empty(),
+        "the slide carries text:\n{}",
+        output.source
+    );
+    runs.iter()
+        .map(|run| (run.left_pt, run.baseline_pt))
+        .collect()
+}
+
+/// Turn `seat` clockwise about `centre` the way PowerPoint turns a shape,
+/// evaluated here independently of the markup under test.
+#[cfg(not(target_arch = "wasm32"))]
+fn turned_about(seat: (f64, f64), centre: (f64, f64), rotation_deg: f64) -> (f64, f64) {
+    let (sin, cos): (f64, f64) = rotation_deg.to_radians().sin_cos();
+    let (dx, dy): (f64, f64) = (seat.0 - centre.0, seat.1 - centre.1);
+    (
+        centre.0 + cos * dx - sin * dy,
+        centre.1 + sin * dx + cos * dy,
+    )
+}
+
+/// `<a:xfrm rot>` on a shape turns its text box about the box's own centre,
+/// whatever the box measures.
+///
+/// Typst resolves `origin: center` against the frame it lays the body out in,
+/// and that frame is clamped to the region. A box taller than the slide
+/// therefore pivoted on the slide's midpoint and the whole box landed
+/// translated — the clamp #1032 took out of the picture path, still in the
+/// text path (issue #1078).
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn an_oversized_turned_text_box_pivots_on_its_own_centre() {
+    const WIDTH_PT: f64 = 400.0;
+    const HEIGHT_PT: f64 = 856.8;
+    const ROTATION_DEG: f64 = 30.0;
+
+    let unturned: Vec<(f64, f64)> =
+        placed_run_origins(&turned_slide_text_box(WIDTH_PT, HEIGHT_PT, |_| {}));
+    let turned: Vec<(f64, f64)> =
+        placed_run_origins(&turned_slide_text_box(WIDTH_PT, HEIGHT_PT, |text_box| {
+            text_box.shape_rotation_deg = Some(ROTATION_DEG);
+        }));
+    assert_eq!(
+        unturned.len(),
+        turned.len(),
+        "the turn lays the content out unchanged and moves the result"
+    );
+
+    let centre: (f64, f64) = (
+        TURNED_BOX_X_PT + WIDTH_PT / 2.0,
+        TURNED_BOX_Y_PT + HEIGHT_PT / 2.0,
+    );
+    for (index, (seat, got)) in unturned.iter().zip(turned.iter()).enumerate() {
+        let want: (f64, f64) = turned_about(*seat, centre, ROTATION_DEG);
+        assert!(
+            (want.0 - got.0).abs() < 0.05 && (want.1 - got.1).abs() < 0.05,
+            "run {index} sits at {got:?}, a turn about the box centre seats it at {want:?}"
+        );
+    }
+}
+
+/// The same clamp under `<a:bodyPr vert>`: the content lays out in a box with
+/// the dimensions swapped, so a box wider than the slide is tall becomes a
+/// laid-out block taller than the region and the turn pivots on the slide
+/// (issue #1078).
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn an_oversized_vertical_text_box_pivots_on_its_own_centre() {
+    const WIDTH_PT: f64 = 700.0;
+    const HEIGHT_PT: f64 = 200.0;
+    const ROTATION_DEG: f64 = 270.0;
+
+    // The control is that swapped box standing unturned on the same seat,
+    // which is exactly what the vertical path lays out before turning it.
+    let unturned: Vec<(f64, f64)> =
+        placed_run_origins(&turned_slide_text_box(HEIGHT_PT, WIDTH_PT, |_| {}));
+    let turned: Vec<(f64, f64)> =
+        placed_run_origins(&turned_slide_text_box(WIDTH_PT, HEIGHT_PT, |text_box| {
+            text_box.text_rotation_deg = Some(ROTATION_DEG);
+        }));
+    assert_eq!(
+        unturned.len(),
+        turned.len(),
+        "the turn lays the content out unchanged and moves the result"
+    );
+
+    // Turn about the swapped box's centre, then re-centre that box on the
+    // element's own width x height region — the box geometry stays unrotated.
+    let centre: (f64, f64) = (
+        TURNED_BOX_X_PT + HEIGHT_PT / 2.0,
+        TURNED_BOX_Y_PT + WIDTH_PT / 2.0,
+    );
+    let recentre: (f64, f64) = ((WIDTH_PT - HEIGHT_PT) / 2.0, (HEIGHT_PT - WIDTH_PT) / 2.0);
+    for (index, (seat, got)) in unturned.iter().zip(turned.iter()).enumerate() {
+        let pivoted: (f64, f64) = turned_about(*seat, centre, ROTATION_DEG);
+        let want: (f64, f64) = (pivoted.0 + recentre.0, pivoted.1 + recentre.1);
+        assert!(
+            (want.0 - got.0).abs() < 0.05 && (want.1 - got.1).abs() < 0.05,
+            "run {index} sits at {got:?}, PowerPoint seats it at {want:?}"
+        );
+    }
+}
+
+/// A box that fits the region never met the clamp, so the corner pivot has to
+/// leave it exactly where the centre pivot did — otherwise the fix would move
+/// every rotated label on the corpus.
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn a_turned_text_box_inside_the_slide_keeps_its_seat() {
+    const WIDTH_PT: f64 = 300.0;
+    const HEIGHT_PT: f64 = 120.0;
+    const ROTATION_DEG: f64 = 45.0;
+
+    let unturned: Vec<(f64, f64)> =
+        placed_run_origins(&turned_slide_text_box(WIDTH_PT, HEIGHT_PT, |_| {}));
+    let turned: Vec<(f64, f64)> =
+        placed_run_origins(&turned_slide_text_box(WIDTH_PT, HEIGHT_PT, |text_box| {
+            text_box.shape_rotation_deg = Some(ROTATION_DEG);
+        }));
+
+    let centre: (f64, f64) = (
+        TURNED_BOX_X_PT + WIDTH_PT / 2.0,
+        TURNED_BOX_Y_PT + HEIGHT_PT / 2.0,
+    );
+    for (index, (seat, got)) in unturned.iter().zip(turned.iter()).enumerate() {
+        let want: (f64, f64) = turned_about(*seat, centre, ROTATION_DEG);
+        assert!(
+            (want.0 - got.0).abs() < 0.05 && (want.1 - got.1).abs() < 0.05,
+            "run {index} sits at {got:?}, a turn about the box centre seats it at {want:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`generate_fixed_text_box` turned a rotated shape's text with `#rotate(origin: center, reflow: false)`, and wrapped `<a:bodyPr vert>` in the same. Typst resolves `origin: center` against the frame it lays the body out in, and `measure_and_layout` clamps that frame to the region — so a text box taller or wider than the slide pivots on the **slide's** midpoint instead of its own box centre, and the whole box lands translated. #1032 removed that clamp from the picture path; this is the same clamp still sitting under the text path.

Measured on a 960x540pt slide by compiling the emitted source and reading the frame transforms back:

| case | run landed at | a turn about the box centre seats it at |
| --- | --- | --- |
| 400 x 856.8pt box, `<a:xfrm rot>` 30° | (276.79, -15.17) | (355.99, 6.05) |
| 700 x 200pt box, `<a:bodyPr vert270>` | (210.0, 160.0) | (130.0, 240.0) |

Both deltas are the slide midpoint substituting for the box's own.

### Key changes

- `crates/office2pdf/src/render/typst_gen.rs` — both rotated text-box branches now pivot on `origin: top + left`, a corner no clamp can move, and carry the difference in an enclosing `#move`. `centre_pivot_shift` already derives that translation for pictures and applies unchanged here with both mirror flags `false`; the vertical-text branch folds it into the `#move` that already re-centres the swapped box, so it stays one translation.
- `crates/office2pdf/src/render/pdf.rs` — the test-only `compiled_text_runs` followed a group's *translation* only, which reports every run of a turned box at the unturned place. It now accumulates the full frame transform. Translation-only groups are unaffected, so every existing caller reads the same numbers.
- Three tests, red before the fix: the two oversized cases above, plus `a_turned_text_box_inside_the_slide_keeps_its_seat`, which pins that a box fitting the region does not move — the shift is exactly what `origin: center` resolved to there.

## Related issue

Related: #1078

## Testing

- `cargo test --workspace` — green (2253 lib tests, all integration targets).
- `cargo +1.97 clippy --workspace --all-targets -- -D warnings` — clean on the toolchain CI uses.
- `cargo fmt --all -- --check` — clean.
- `cargo check --target wasm32-unknown-unknown -p office2pdf` and `--features wasm --tests` — clean.
- Corpus regression sweep: converted all 65 tracked PPTX fixtures with the pre-fix and post-fix CLI and diffed `mutool draw -F trace` per file. All 65 are identical, including the ten that actually carry an `<a:xfrm rot>` or a non-horizontal `<a:bodyPr vert>` (`10-slides`, `customGeo`, `office2pdf_introduction_ko`, `oxp_PB001-Input1/2/3`, `rotated_text_box`, `svg-srcrect-clip-probe`, `themes`, `table_test2`).

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: the defect only shows when a rotated text box's laid-out frame exceeds the slide region, and no fixture in the corpus does that — #1078 records it as a latent defect found while fixing #1032, with the mechanism measured rather than a rendered deviation attached. The trace sweep above confirms all 65 tracked PPTX fixtures render identically before and after, so there is no before/after page to photograph and no ground truth to compare against.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue