### PR TITLE
fix(tooling): stage the non-harness Office exports in the app container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
         run: python3 -m unittest discover -s scripts/tests -p 'test_check_gt_integrity.py'
       - name: Test probe harness
         run: python3 -m unittest discover -s scripts/tests -p 'test_probe_harness.py'
+      - name: Test PowerPoint chart-axis harness
+        run: python3 -m unittest discover -s scripts/tests -p 'test_measure_powerpoint_chart_axis.py'
       - name: Test issue-loop viewer
         run: python3 -m unittest discover -s scripts/tests -p 'test_issue_loop_watch.py'
       - name: Check issue-loop script syntax

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,6 +280,13 @@ overrides that and must still sit on the internal disk: the sandbox cannot
 write to `/Volumes` at all (AppleEvent timeout -1712), which the harness
 enforces.
 
+The same container rule binds every other caller of those AppleScripts. The
+`GENERATE_MICROSOFT_GT=1` exports in `public_visual_audit.rs` and
+`scripts/measure_powerpoint_chart_axis.py` stage the fixtures and the PDFs in
+the driven app's container and copy the results out afterwards; the last
+caller, `scripts/macos/export_business_golden_pdfs.sh`, still stages under the
+checkout (#1128).
+
 ### Fine-detail analysis (thin and small elements)
 
 Whole-page thumbnails at 80 DPI hide hairlines, dash patterns, font weight, and sub-pixel offsets. For every compared page:

--- a/crates/office2pdf/tests/public_visual_audit.rs
+++ b/crates/office2pdf/tests/public_visual_audit.rs
@@ -101,30 +101,171 @@ fn relative_image_paths(images: &[PathBuf], report_dir: &Path) -> Vec<String> {
         .collect()
 }
 
+/// How a format's ground truth is produced: which AppleScript exports it, and
+/// which sandboxed Microsoft app that script drives.
+struct NativeExporter {
+    /// File name under `scripts/macos/`.
+    script: &'static str,
+    /// Bundle identifier, i.e. the app's container directory name.
+    bundle_id: &'static str,
+    /// How the app is named in a failure message.
+    app_name: &'static str,
+}
+
+fn native_exporter(format: Format) -> NativeExporter {
+    match format {
+        Format::Docx => NativeExporter {
+            script: "export_word_pdfs.applescript",
+            bundle_id: "com.microsoft.Word",
+            app_name: "Word",
+        },
+        Format::Pptx => NativeExporter {
+            script: "export_powerpoint_pdfs.applescript",
+            bundle_id: "com.microsoft.Powerpoint",
+            app_name: "PowerPoint",
+        },
+        Format::Xlsx => NativeExporter {
+            script: "export_excel_pdfs.applescript",
+            bundle_id: "com.microsoft.Excel",
+            app_name: "Excel",
+        },
+    }
+}
+
+/// Directory a GT export stages the fixtures and PDFs it hands the native app.
+///
+/// The Microsoft apps are sandboxed: a fixture opened from, or a PDF saved to,
+/// anywhere outside the app's own container costs a per-file "Grant Access"
+/// dialog, and an unattended export stalls on the first one (#1051, #1082).
+/// Reaching into a *different* app's container prompts just the same, so each
+/// format stages in the container of the app that opens it.
+fn office_stage_dir(containers_root: &Path, format: Format) -> PathBuf {
+    containers_root
+        .join(native_exporter(format).bundle_id)
+        .join("Data")
+        .join("visual-audit")
+}
+
+fn home_containers_root() -> PathBuf {
+    PathBuf::from(std::env::var_os("HOME").expect("HOME is set"))
+        .join("Library")
+        .join("Containers")
+}
+
+/// Copy every case's fixture into `stage`; return the exporter's `(id, path)`
+/// arguments.
+///
+/// Each copy is named after the case id, which `assert_manifest_cases` pins as
+/// unique — two cases pointing at one fixture would otherwise share a staged
+/// file and race each other.
+fn stage_fixtures(
+    stage: &Path,
+    fixtures_dir: &Path,
+    cases: &[VisualAuditCase],
+) -> Vec<(String, PathBuf)> {
+    let input_dir = stage.join("input");
+    std::fs::create_dir_all(&input_dir).expect("create staged fixture directory");
+    cases
+        .iter()
+        .map(|case| {
+            let source = fixtures_dir.join(&case.fixture);
+            let staged = input_dir.join(match source.extension() {
+                Some(extension) => format!("{}.{}", case.id, extension.to_string_lossy()),
+                None => case.id.clone(),
+            });
+            std::fs::copy(&source, &staged).unwrap_or_else(|error| {
+                panic!("stage visual audit fixture {}: {error}", source.display())
+            });
+            (case.id.clone(), staged)
+        })
+        .collect()
+}
+
+/// Move every PDF the sandboxed app wrote into `destination`; return the count.
+///
+/// A plain rename would fail when `VISUAL_AUDIT_DIR` points at another volume,
+/// so the PDFs are copied and then dropped from the container.
+fn collect_exported_pdfs(staged_pdf_dir: &Path, destination: &Path) -> usize {
+    std::fs::create_dir_all(destination).expect("create ground truth directory");
+    let mut exported: usize = 0;
+    for entry in std::fs::read_dir(staged_pdf_dir).expect("read staged PDF directory") {
+        let path = entry.expect("read staged PDF entry").path();
+        if !path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("pdf"))
+        {
+            continue;
+        }
+        let target = destination.join(path.file_name().expect("staged PDF file name"));
+        std::fs::copy(&path, &target)
+            .unwrap_or_else(|error| panic!("copy GT PDF out of the container: {error}"));
+        std::fs::remove_file(&path)
+            .unwrap_or_else(|error| panic!("drop the container's GT PDF copy: {error}"));
+        exported += 1;
+    }
+    exported
+}
+
+/// Export every manifest case with the native app that owns `format`.
+///
+/// The app only ever sees paths inside its own container; the PDFs are moved
+/// into `ground_truth_dir` once it has quit.
+fn export_ground_truth(
+    manifest: &VisualAuditManifest,
+    format: Format,
+    fixtures_dir: &Path,
+    ground_truth_dir: &Path,
+) {
+    let exporter = native_exporter(format);
+    assert_eq!(
+        std::env::consts::OS,
+        "macos",
+        "Microsoft {} GT export is only available on macOS",
+        exporter.app_name
+    );
+    std::fs::create_dir_all(ground_truth_dir).expect("create GT directory");
+
+    // A stage left behind by an aborted run would hand the audit its stale
+    // PDFs, so start from nothing.
+    let stage = office_stage_dir(&home_containers_root(), format);
+    if stage.exists() {
+        std::fs::remove_dir_all(&stage).expect("clean stale sandbox stage");
+    }
+    let staged_pdf_dir = stage.join("pdf");
+    std::fs::create_dir_all(&staged_pdf_dir).expect("create staged PDF directory");
+
+    let mut command = Command::new("osascript");
+    command
+        .arg(project_root().join("scripts/macos").join(exporter.script))
+        .arg(&staged_pdf_dir);
+    for (id, staged_fixture) in stage_fixtures(&stage, fixtures_dir, &manifest.cases) {
+        command.arg(id).arg(staged_fixture);
+    }
+    let output = command.output().expect("run native GT exporter");
+
+    // Salvage whatever did export before reporting a partial batch's failure.
+    let exported = collect_exported_pdfs(&staged_pdf_dir, ground_truth_dir);
+    std::fs::remove_dir_all(&stage).expect("remove the sandbox stage");
+    assert!(
+        output.status.success(),
+        "{} GT export failed:\nstdout: {}\nstderr: {}",
+        exporter.app_name,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        exported > 0,
+        "{} exported no PDFs at all",
+        exporter.app_name
+    );
+}
+
 fn generate_powerpoint_ground_truth(
     manifest: &VisualAuditManifest,
     fixtures_dir: &Path,
     ground_truth_dir: &Path,
 ) {
-    assert_eq!(
-        std::env::consts::OS,
-        "macos",
-        "Microsoft PowerPoint GT export is only available on macOS"
-    );
-    std::fs::create_dir_all(ground_truth_dir).expect("create PowerPoint GT directory");
-    let script = project_root().join("scripts/macos/export_powerpoint_pdfs.applescript");
-    let mut command = Command::new("osascript");
-    command.arg(script).arg(ground_truth_dir);
-    for case in &manifest.cases {
-        command.arg(&case.id).arg(fixtures_dir.join(&case.fixture));
-    }
-    let output = command.output().expect("run PowerPoint GT exporter");
-    assert!(
-        output.status.success(),
-        "PowerPoint GT export failed:\nstdout: {}\nstderr: {}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    export_ground_truth(manifest, Format::Pptx, fixtures_dir, ground_truth_dir);
 }
 
 fn generate_excel_ground_truth(
@@ -132,25 +273,7 @@ fn generate_excel_ground_truth(
     fixtures_dir: &Path,
     ground_truth_dir: &Path,
 ) {
-    assert_eq!(
-        std::env::consts::OS,
-        "macos",
-        "Microsoft Excel GT export is only available on macOS"
-    );
-    std::fs::create_dir_all(ground_truth_dir).expect("create Excel GT directory");
-    let script = project_root().join("scripts/macos/export_excel_pdfs.applescript");
-    let mut command = Command::new("osascript");
-    command.arg(script).arg(ground_truth_dir);
-    for case in &manifest.cases {
-        command.arg(&case.id).arg(fixtures_dir.join(&case.fixture));
-    }
-    let output = command.output().expect("run Excel GT exporter");
-    assert!(
-        output.status.success(),
-        "Excel GT export failed:\nstdout: {}\nstderr: {}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    export_ground_truth(manifest, Format::Xlsx, fixtures_dir, ground_truth_dir);
 
     for case in &manifest.cases {
         let prefix = format!("{}-sheet-", case.id);
@@ -376,6 +499,137 @@ fn run_visual_audit(
         manifest.format.to_uppercase(),
         report_dir.display()
     );
+}
+
+/// A scratch directory for the staging tests below, unique per call.
+///
+/// Tests run in parallel threads of one process, so a shared name would let
+/// two of them delete each other's files mid-assertion.
+fn scratch_dir(label: &str) -> PathBuf {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let path = std::env::temp_dir().join(format!(
+        "office2pdf-visual-audit-{label}-{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    if path.exists() {
+        std::fs::remove_dir_all(&path).expect("clean scratch directory");
+    }
+    std::fs::create_dir_all(&path).expect("create scratch directory");
+    path
+}
+
+#[test]
+fn each_format_is_exported_by_its_own_sandboxed_app() {
+    // Reaching into another app's container prompts exactly like reaching
+    // outside the sandbox, so the container has to match the exporter.
+    let powerpoint = native_exporter(Format::Pptx);
+    assert_eq!(powerpoint.bundle_id, "com.microsoft.Powerpoint");
+    assert_eq!(powerpoint.script, "export_powerpoint_pdfs.applescript");
+
+    let excel = native_exporter(Format::Xlsx);
+    assert_eq!(excel.bundle_id, "com.microsoft.Excel");
+    assert_eq!(excel.script, "export_excel_pdfs.applescript");
+
+    assert!(
+        project_root()
+            .join("scripts/macos")
+            .join(powerpoint.script)
+            .is_file()
+    );
+    assert!(
+        project_root()
+            .join("scripts/macos")
+            .join(excel.script)
+            .is_file()
+    );
+}
+
+#[test]
+fn the_ground_truth_stage_sits_inside_the_driven_apps_container() {
+    let containers = Path::new("/home/tester/Library/Containers");
+    assert!(
+        office_stage_dir(containers, Format::Pptx)
+            .starts_with(containers.join("com.microsoft.Powerpoint").join("Data")),
+        "PowerPoint GT must stage inside PowerPoint's container"
+    );
+    assert_ne!(
+        office_stage_dir(containers, Format::Pptx),
+        office_stage_dir(containers, Format::Xlsx)
+    );
+}
+
+#[test]
+fn staged_fixtures_are_container_local_copies_named_by_case_id() {
+    let stage = scratch_dir("stage");
+    let fixtures = scratch_dir("fixtures");
+    std::fs::write(fixtures.join("bar-chart.pptx"), b"PK fixture").expect("write fixture");
+    let cases = vec![
+        VisualAuditCase {
+            id: "chart".to_string(),
+            fixture: "bar-chart.pptx".to_string(),
+            focus: "chart".to_string(),
+        },
+        VisualAuditCase {
+            id: "chart-again".to_string(),
+            fixture: "bar-chart.pptx".to_string(),
+            focus: "chart".to_string(),
+        },
+    ];
+
+    let jobs = stage_fixtures(&stage, &fixtures, &cases);
+
+    assert_eq!(jobs.len(), 2);
+    for (index, (id, staged)) in jobs.iter().enumerate() {
+        assert_eq!(id, &cases[index].id);
+        assert!(
+            staged.starts_with(&stage),
+            "fixture staged outside the container: {}",
+            staged.display()
+        );
+        assert_eq!(
+            staged.file_name().and_then(|name| name.to_str()),
+            Some(format!("{id}.pptx").as_str()),
+            "two cases sharing one fixture must not collide"
+        );
+        assert_eq!(
+            std::fs::read(staged).expect("read staged fixture"),
+            b"PK fixture"
+        );
+    }
+
+    std::fs::remove_dir_all(&stage).ok();
+    std::fs::remove_dir_all(&fixtures).ok();
+}
+
+#[test]
+fn exported_pdfs_are_moved_out_of_the_container() {
+    let staged_pdf_dir = scratch_dir("exported");
+    let destination = scratch_dir("ground-truth").join("nested");
+    std::fs::write(staged_pdf_dir.join("chart.pdf"), b"%PDF chart").expect("write staged PDF");
+    std::fs::write(staged_pdf_dir.join("grid-sheet-01.pdf"), b"%PDF sheet")
+        .expect("write staged sheet PDF");
+    std::fs::write(staged_pdf_dir.join("chart.pptx"), b"PK copy").expect("write staged package");
+
+    let moved = collect_exported_pdfs(&staged_pdf_dir, &destination);
+
+    assert_eq!(moved, 2);
+    assert_eq!(
+        std::fs::read(destination.join("chart.pdf")).expect("read moved PDF"),
+        b"%PDF chart"
+    );
+    assert!(destination.join("grid-sheet-01.pdf").is_file());
+    assert!(
+        !staged_pdf_dir.join("chart.pdf").exists(),
+        "the container copy must not linger"
+    );
+    assert!(
+        staged_pdf_dir.join("chart.pptx").is_file(),
+        "only PDFs are the export's product"
+    );
+
+    std::fs::remove_dir_all(&staged_pdf_dir).ok();
+    std::fs::remove_dir_all(destination.parent().expect("scratch parent")).ok();
 }
 
 #[test]

--- a/scripts/measure_powerpoint_chart_axis.py
+++ b/scripts/measure_powerpoint_chart_axis.py
@@ -18,6 +18,11 @@ chart text size or graphic-frame width. Frame-width output also reports the
 plot width recovered from the longest bar, which is the width the scaling rule
 actually consumes.
 
+Every probe package and every exported PDF is staged inside PowerPoint's own
+sandbox container and the stage is removed when the run ends, so an unattended
+run never stops on a "Grant Access" dialog (#1082). ``--keep`` copies the
+packages and PDFs out to a directory of your choice before that cleanup.
+
 Requires macOS, Microsoft PowerPoint, ``pdftotext`` (Poppler), and, for
 ``frame-width``, ``mutool`` (MuPDF).
 """
@@ -27,14 +32,17 @@ from __future__ import annotations
 import argparse
 import io
 import re
+import shutil
 import subprocess
-import tempfile
 import zipfile
 from pathlib import Path
+
+import probe_harness
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_FIXTURE = REPO_ROOT / "tests/fixtures/pptx/bar-chart.pptx"
 POWERPOINT_EXPORTER = REPO_ROOT / "scripts/macos/export_powerpoint_pdfs.applescript"
+STAGE_NAME = "powerpoint-chart-axis"
 
 SERIES_VALUES: tuple[float, ...] = (8.2, 3.2, 1.4, 1.2)
 FIXTURE_MAX = max(SERIES_VALUES)
@@ -145,6 +153,32 @@ def build_probe(source: Path, destination: Path, mode: str, value: float) -> Non
             archive_out.writestr(item, payload)
 
 
+def container_stage() -> Path:
+    """Directory PowerPoint can open and save in without a consent dialog.
+
+    The app is sandboxed: a package it opens from, or a PDF it saves to,
+    anywhere outside its own container costs a per-file "Grant Access" dialog,
+    and an unattended run stalls on the first one (#1051, #1082). The probe
+    harness already maps a format to its app's container, so reuse that rather
+    than spelling the path out a second time. Its own subdirectory keeps a
+    concurrent ``probe_harness.py`` run from clearing these packages.
+    """
+    return probe_harness.default_stage_root("office", ".pptx") / STAGE_NAME
+
+
+def mirror_stage(stage: Path, destination: Path) -> None:
+    """Copy the staged probe packages and their PDFs out of the container."""
+    for name in ("pptx", "pdf"):
+        source = stage / name
+        if not source.is_dir():
+            continue
+        target = destination / name
+        target.mkdir(parents=True, exist_ok=True)
+        for item in sorted(source.iterdir()):
+            if item.is_file():
+                shutil.copyfile(item, target / item.name)
+
+
 def export_probes(probes: list[tuple[str, Path]], out_dir: Path) -> None:
     command = ["osascript", str(POWERPOINT_EXPORTER), str(out_dir)]
     for identifier, probe in probes:
@@ -202,7 +236,7 @@ def plot_width(pdf: Path, axis_max: float) -> float:
     return max(widths) * axis_max / FIXTURE_MAX
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("values", type=float, nargs="+")
     parser.add_argument(
@@ -212,26 +246,26 @@ def main() -> int:
     )
     parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE)
     parser.add_argument("--rust", action="store_true", help="emit Rust rows")
-    parser.add_argument("--keep", type=Path, help="keep generated PPTX/PDF probes here")
-    args = parser.parse_args()
+    parser.add_argument(
+        "--keep", type=Path, help="copy the generated PPTX/PDF probes out to here"
+    )
+    args = parser.parse_args(argv)
 
     for required in (args.fixture, POWERPOINT_EXPORTER):
         if not required.is_file():
             raise SystemExit(f"required file not found: {required}")
 
-    temporary: tempfile.TemporaryDirectory[str] | None = None
-    if args.keep is None:
-        temporary = tempfile.TemporaryDirectory(prefix="powerpoint-chart-axis-")
-        work_root = Path(temporary.name)
-    else:
-        work_root = args.keep
-        work_root.mkdir(parents=True, exist_ok=True)
+    # Both the packages PowerPoint opens and the PDFs it writes stay in its own
+    # sandbox container for the whole run; a leftover stage from an aborted run
+    # would otherwise feed stale PDFs to the measurement below.
+    work_root = container_stage()
+    shutil.rmtree(work_root, ignore_errors=True)
 
     try:
         probe_dir = work_root / "pptx"
         pdf_dir = work_root / "pdf"
-        probe_dir.mkdir(exist_ok=True)
-        pdf_dir.mkdir(exist_ok=True)
+        probe_dir.mkdir(parents=True)
+        pdf_dir.mkdir(parents=True)
         probes: list[tuple[str, Path]] = []
         for value in args.values:
             identifier = f"{args.mode}-{slug(value)}"
@@ -239,6 +273,10 @@ def main() -> int:
             build_probe(args.fixture, probe, args.mode, value)
             probes.append((identifier, probe))
         export_probes(probes, pdf_dir)
+        # Copy out before measuring, so an analysis failure still leaves the
+        # artifacts behind for inspection.
+        if args.keep is not None:
+            mirror_stage(work_root, args.keep)
 
         if not args.rust:
             suffix = "     plot pt" if args.mode == "frame-width" else ""
@@ -271,8 +309,7 @@ def main() -> int:
                     f"{format_number(step):>12}"
                 )
     finally:
-        if temporary is not None:
-            temporary.cleanup()
+        shutil.rmtree(work_root, ignore_errors=True)
     return 0
 
 

--- a/scripts/tests/test_measure_powerpoint_chart_axis.py
+++ b/scripts/tests/test_measure_powerpoint_chart_axis.py
@@ -1,0 +1,143 @@
+"""Unit tests for the PowerPoint chart-axis measurement harness (#1082).
+
+Microsoft PowerPoint is sandboxed: every package it opens and every PDF it
+saves has to sit inside its own container, or macOS raises a per-file "Grant
+Access" dialog and an unattended run stalls on the first one (#1051). These
+tests pin that staging contract — and the copy back out of the container — with
+the export stage stubbed, so they need neither a Mac nor a copy of PowerPoint.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+import zipfile
+from contextlib import redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import measure_powerpoint_chart_axis as chart_axis
+import probe_harness
+
+
+class StageLocationTest(unittest.TestCase):
+    """Where the run stages the probes PowerPoint has to open (#1082)."""
+
+    def test_the_stage_sits_inside_the_powerpoint_sandbox_container(self):
+        stage = chart_axis.container_stage()
+        container = probe_harness.default_stage_root("office", ".pptx")
+        self.assertEqual(stage.parent, container)
+        self.assertIn(
+            probe_harness.OFFICE_BUNDLE_ID_BY_EXTENSION[".pptx"], stage.parts
+        )
+
+    def test_the_stage_is_its_own_directory_under_the_container(self):
+        # A concurrent probe_harness run stages siblings there; sharing one
+        # directory would let either run delete the other's packages.
+        self.assertNotEqual(
+            chart_axis.container_stage(),
+            probe_harness.default_stage_root("office", ".pptx"),
+        )
+
+
+class MirrorTest(unittest.TestCase):
+    def test_probes_and_pdfs_are_copied_out_of_the_container(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            stage = tmp / "container" / "powerpoint-chart-axis"
+            (stage / "pptx").mkdir(parents=True)
+            (stage / "pdf").mkdir(parents=True)
+            (stage / "pptx" / "maximum-8p2.pptx").write_bytes(b"PK probe")
+            (stage / "pdf" / "maximum-8p2.pdf").write_bytes(b"%PDF probe")
+            destination = tmp / "keep"
+
+            chart_axis.mirror_stage(stage, destination)
+
+            self.assertEqual(
+                (destination / "pptx" / "maximum-8p2.pptx").read_bytes(), b"PK probe"
+            )
+            self.assertEqual(
+                (destination / "pdf" / "maximum-8p2.pdf").read_bytes(), b"%PDF probe"
+            )
+
+
+class RunTest(unittest.TestCase):
+    """A full run: nothing PowerPoint touches may sit outside the container."""
+
+    def stubbed_run(self, tmp: Path, argv: list[str]) -> tuple[dict, str]:
+        stage = tmp / "container" / "powerpoint-chart-axis"
+        seen: dict = {}
+
+        def fake_export(probes, out_dir: Path) -> None:
+            seen["probes"] = [str(probe) for _, probe in probes]
+            seen["out_dir"] = str(out_dir)
+            for identifier, _ in probes:
+                (out_dir / f"{identifier}.pdf").write_bytes(b"%PDF probe")
+
+        buffer = io.StringIO()
+        with patch.object(chart_axis, "container_stage", return_value=stage), patch.object(
+            chart_axis, "export_probes", fake_export
+        ), patch.object(
+            chart_axis, "value_axis_labels", return_value=[0.0, 2.0, 4.0, 6.0, 8.0, 10.0]
+        ), redirect_stdout(buffer):
+            self.assertEqual(chart_axis.main(argv), 0)
+        seen["stage"] = stage
+        return seen, buffer.getvalue()
+
+    def test_every_path_handed_to_powerpoint_sits_inside_the_stage(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            seen, report = self.stubbed_run(tmp, ["8.2", "1.9"])
+
+            self.assertEqual(len(seen["probes"]), 2)
+            for probe in seen["probes"]:
+                self.assertTrue(
+                    probe.startswith(str(seen["stage"])),
+                    f"probe staged outside the container: {probe}",
+                )
+                self.assertTrue(zipfile.is_zipfile(probe) or not Path(probe).exists())
+            self.assertTrue(seen["out_dir"].startswith(str(seen["stage"])))
+            self.assertIn("10", report)
+
+    def test_the_container_stage_is_removed_when_the_run_finishes(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            seen, _ = self.stubbed_run(tmp, ["8.2"])
+            self.assertFalse(seen["stage"].exists())
+
+    def test_keep_copies_the_artifacts_out_before_the_stage_is_cleaned(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            keep = tmp / "keep"
+            seen, _ = self.stubbed_run(tmp, ["8.2", "--keep", str(keep)])
+
+            self.assertTrue((keep / "pptx" / "maximum-8p2.pptx").is_file())
+            self.assertTrue((keep / "pdf" / "maximum-8p2.pdf").is_file())
+            self.assertFalse(seen["stage"].exists())
+
+
+class ExportCommandTest(unittest.TestCase):
+    def test_the_exporter_is_driven_with_the_staged_paths(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            probe = tmp / "maximum-8p2.pptx"
+            probe.write_bytes(b"PK probe")
+            recorded: list[list[str]] = []
+
+            with patch.object(
+                chart_axis.subprocess, "run", lambda *args, **kwargs: recorded.append(list(args[0]))
+            ):
+                chart_axis.export_probes([("maximum-8p2", probe)], tmp / "pdf")
+
+            self.assertEqual(recorded[0][0], "osascript")
+            self.assertTrue(recorded[0][1].endswith("export_powerpoint_pdfs.applescript"))
+            self.assertEqual(recorded[0][2], str(tmp / "pdf"))
+            self.assertEqual(recorded[0][3:], ["maximum-8p2", str(probe.resolve())])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

#1083 moved `probe_harness.py --backend office` inside the driven app's sandbox container so an unattended probe stops asking for consent. The two other callers of the same `scripts/macos/export_*_pdfs.applescript` exporters were out of that issue's scope and still handed a sandboxed Microsoft app paths it has no standing access to:

- `crates/office2pdf/tests/public_visual_audit.rs` — `GENERATE_MICROSOFT_GT=1` passed the fixture under `tests/fixtures/` **and** the output directory under `target/visual-audit/`, i.e. two files per case inside `~/Documents`. 9 PPTX cases and 11 XLSX ones.
- `scripts/measure_powerpoint_chart_axis.py` — built its probe packages and took its PDFs in a `tempfile.TemporaryDirectory`.

macOS charges consent per file there, and the first dialog stalls the run.

Key changes:

- `export_ground_truth` (Rust) — one flow for both formats, keyed by a `NativeExporter` record that maps `Format` to its AppleScript, its bundle id, and its name in a failure message. The same key picks all three, so an exporter can never be paired with the wrong container; reaching into *another* Office app's container prompts just the same.
- `stage_fixtures` copies each case's fixture into `~/Library/Containers/<bundle id>/Data/visual-audit/input/` named after its **case id**, not its file name — two cases pointing at one fixture would otherwise share a staged file. `collect_exported_pdfs` copies the PDFs into `ground_truth_dir` and drops the container's copies; it copies rather than renames, because `VISUAL_AUDIT_DIR` may sit on another volume.
- The PDFs are salvaged before a partial batch's failure is reported, and the stage is cleared *before* each run — a stage left by an aborted run would otherwise feed the audit a previous run's PDFs.
- `pdfunite`, the Excel sheet uniting, and the JPEG rendering are unsandboxed and still run on the caller's directory, unchanged.
- `container_stage` / `mirror_stage` (Python) reuse `probe_harness.default_stage_root` rather than spelling the container path out a second time. Their own `powerpoint-chart-axis/` subdirectory keeps a concurrent `probe_harness.py` run from clearing the packages. `--keep` now *copies out* — before the stage is removed, so an analysis failure still leaves the artifacts behind — and `main` takes `argv` so a test can drive it.

## Related issue

Related: #1082, #1051, #698

`scripts/macos/export_business_golden_pdfs.sh` is the last caller staging under the checkout. It was in neither issue's list and drives three apps in one run, so it needs three containers; filed separately as #1128 rather than widened into this branch.

## Testing

Written first; both suites fail against `main`.

`python3 -m unittest discover -s scripts/tests -p 'test_measure_powerpoint_chart_axis.py'` — 7 new tests (`AttributeError: module 'measure_powerpoint_chart_axis' has no attribute 'container_stage'` on `main`), wired into CI beside the probe-harness step.

- `RunTest` drives a whole run with only the AppleScript stage and the PDF reader stubbed, then asserts on the paths the exporter was actually handed: *every* one must sit inside the stage. That is the property the issue is about, and it survives a refactor of how the path is built. It also pins that the stage is gone afterwards and that `--keep` got the artifacts first.
- `StageLocationTest` pins the container against `probe_harness`'s own mapping, and that the two runs do not share one directory.

`cargo test --test public_visual_audit` — 4 new tests (the file did not compile against `main`), plus the whole workspace green (2287 + 184 + 177 + … , 0 failed).

- `each_format_is_exported_by_its_own_sandboxed_app` — bundle id and script agree per format, and both scripts exist on disk.
- `staged_fixtures_are_container_local_copies_named_by_case_id` — two cases sharing one fixture get distinct staged copies, all inside the stage, with the fixture's bytes.
- `exported_pdfs_are_moved_out_of_the_container` — PDFs move out (including Excel's `-sheet-NN` intermediates), the container copies go, and a non-PDF neighbour stays.

## Native verification

macOS 25.6, PowerPoint and Excel for Mac 16, into container subdirectories that had never been granted — `Data/visual-audit/` and `Data/probes/powerpoint-chart-axis/` did not exist before the runs.

```
GENERATE_MICROSOFT_GT=1 VISUAL_AUDIT_DIR=/Volumes/T7/scratch/... \
  cargo test --test public_visual_audit -- --ignored test_public_pptx_visual_audit
```

| run | result |
| --- | --- |
| PPTX GT, 9 cases | 73.4s, 9 PDFs, 1-30 pages each |
| XLSX GT, 11 cases | 111.0s, 11 PDFs, sheet intermediates united and removed |
| `measure_powerpoint_chart_axis.py 8.2 1.9` | axis max 10 unit 2, and 2 / 0.5 — the committed table's rows |
| the same with `--keep` | `pptx/` and `pdf/` copied out, stage gone |

**No dialog appeared and nothing was clicked** in any of them, which is the issue's acceptance criterion. `VISUAL_AUDIT_DIR` pointed at an external volume for both GT runs — a path the sandbox cannot write to at all (AppleEvent timeout -1712) — so the PDFs landing there is itself proof the app only ever saw the container.

Both stages were gone afterwards, and the XLSX report shows the uniting still works (`repository-workbook` 23 GT pages, `number-formats` 9). The output-vs-GT page gaps that report carries (`drawings` 4/2, `text-boxes` 3/1) are converter defects the audit exists to surface, untouched by this change.

One PowerPoint cold-start returned `-50` before any of this and succeeded on every run after; it reproduces through the pristine committed fixture as well as a rewritten one, so it is the exporter's own launch flake, not the staging.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: test-harness and script change only. `crates/office2pdf/tests/public_visual_audit.rs` is a test binary and `scripts/measure_powerpoint_chart_axis.py` a measurement tool; no converter source is touched, so no rendered PDF page can differ.