### PR TITLE
fix(tooling): stage the business golden exports in each app's container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
         run: python3 -m unittest discover -s scripts/tests -p 'test_generate_layout_baselines.py'
       - name: Test layout baseline consumer
         run: python3 -m unittest discover -s scripts/tests -p 'test_check_layout_baselines.py'
+      - name: Test native golden export staging
+        run: python3 -m unittest discover -s scripts/tests -p 'test_export_business_golden_pdfs.py'
       - name: Validate business golden corpus
         run: python3 scripts/validate_business_golden_mocks.py
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,12 +280,15 @@ overrides that and must still sit on the internal disk: the sandbox cannot
 write to `/Volumes` at all (AppleEvent timeout -1712), which the harness
 enforces.
 
-The same container rule binds every other caller of those AppleScripts. The
-`GENERATE_MICROSOFT_GT=1` exports in `public_visual_audit.rs` and
-`scripts/measure_powerpoint_chart_axis.py` stage the fixtures and the PDFs in
-the driven app's container and copy the results out afterwards; the last
-caller, `scripts/macos/export_business_golden_pdfs.sh`, still stages under the
-checkout (#1128).
+The same container rule binds every other caller of those AppleScripts, and
+every one of them now follows it. The `GENERATE_MICROSOFT_GT=1` exports in
+`public_visual_audit.rs` and `scripts/measure_powerpoint_chart_axis.py` stage
+the fixtures and the PDFs in the driven app's container and copy the results
+out afterwards. `scripts/macos/export_business_golden_pdfs.sh` drives three
+apps, so it uses three stages — `Data/business-golden-export/` in each app's
+own container, removed when the run ends — and copies the PDFs back to its
+stage-root argument, which only the unsandboxed `pdfunite`/`pdfinfo` steps read
+(#1128).
 
 ### Fine-detail analysis (thin and small elements)
 

--- a/scripts/macos/export_business_golden_pdfs.sh
+++ b/scripts/macos/export_business_golden_pdfs.sh
@@ -5,6 +5,10 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 project_root="$(cd "$script_dir/../.." && pwd)"
 corpus_root="$project_root/tests/golden_mocks/business"
 stage_root="${1:-$project_root/target/business-golden-office-export}"
+containers_root="$HOME/Library/Containers"
+# PlistBuddy is the one tool here with no PATH entry to shadow, so the version
+# probe takes an override; the script's tests run where Office is not installed.
+plist_buddy="${PLIST_BUDDY_BIN:-/usr/libexec/PlistBuddy}"
 
 command -v osascript >/dev/null
 command -v pdfunite >/dev/null
@@ -12,27 +16,61 @@ command -v pdfinfo >/dev/null
 
 mkdir -p "$stage_root/docx" "$stage_root/pptx" "$stage_root/xlsx-sheets" "$stage_root/xlsx"
 
-word_args=("$stage_root/docx")
-while IFS= read -r -d '' source; do
-    stem="$(basename "${source%.docx}")"
-    word_args+=("$stem" "$source")
-done < <(find "$corpus_root/sources/docx" -maxdepth 1 -type f -name '*.docx' -print0 | sort -z)
+container_stages=()
 
-powerpoint_args=("$stage_root/pptx")
-while IFS= read -r -d '' source; do
-    stem="$(basename "${source%.pptx}")"
-    powerpoint_args+=("$stem" "$source")
-done < <(find "$corpus_root/sources/pptx" -maxdepth 1 -type f -name '*.pptx' -print0 | sort -z)
+remove_container_stages() {
+    local stage
+    for stage in ${container_stages+"${container_stages[@]}"}; do
+        rm -rf "$stage"
+    done
+}
+trap remove_container_stages EXIT
 
-excel_args=("$stage_root/xlsx-sheets")
-while IFS= read -r -d '' source; do
-    stem="$(basename "${source%.xlsx}")"
-    excel_args+=("$stem" "$source")
-done < <(find "$corpus_root/sources/xlsx" -maxdepth 1 -type f -name '*.xlsx' -print0 | sort -z)
+# Word, PowerPoint and Excel are sandboxed: a source opened from, or a PDF saved
+# to, anywhere outside the app's own container costs a per-file "Grant Access"
+# dialog, and an unattended run stalls on the first one (#1051, #1082, #1128).
+# So each format round-trips through the container of the app that exports it —
+# reaching into another app's container prompts just the same — and the PDFs are
+# copied back to the caller's stage root afterwards. Only the unsandboxed
+# pdfunite/pdfinfo steps below ever touch that stage root.
+export_format() {
+    local extension="$1" bundle_id="$2" exporter="$3" destination="$4"
+    local stage="$containers_root/$bundle_id/Data/business-golden-export"
+    local staged_sources="$stage/sources" staged_pdfs="$stage/pdf"
 
-osascript "$script_dir/export_word_pdfs.applescript" "${word_args[@]}"
-osascript "$script_dir/export_powerpoint_pdfs.applescript" "${powerpoint_args[@]}"
-osascript "$script_dir/export_excel_pdfs.applescript" "${excel_args[@]}"
+    # A stage left behind by an aborted run is the next run's stale input.
+    rm -rf "$stage"
+    container_stages+=("$stage")
+    mkdir -p "$staged_sources" "$staged_pdfs"
+
+    local -a exporter_args=("$staged_pdfs")
+    local source stem staged
+    while IFS= read -r -d '' source; do
+        stem="$(basename "${source%.$extension}")"
+        staged="$staged_sources/$stem.$extension"
+        cp "$source" "$staged"
+        exporter_args+=("$stem" "$staged")
+    done < <(find "$corpus_root/sources/$extension" -maxdepth 1 -type f -name "*.$extension" -print0 | sort -z)
+
+    if [[ ${#exporter_args[@]} -eq 1 ]]; then
+        echo "no $extension sources found under $corpus_root/sources/$extension" >&2
+        exit 1
+    fi
+
+    osascript "$script_dir/$exporter" "${exporter_args[@]}"
+
+    local -a exported=("$staged_pdfs"/*.pdf)
+    if [[ ! -e "${exported[0]}" ]]; then
+        echo "no native PDFs exported for $extension sources" >&2
+        exit 1
+    fi
+    cp "${exported[@]}" "$destination/"
+    rm -rf "$stage"
+}
+
+export_format docx com.microsoft.Word export_word_pdfs.applescript "$stage_root/docx"
+export_format pptx com.microsoft.Powerpoint export_powerpoint_pdfs.applescript "$stage_root/pptx"
+export_format xlsx com.microsoft.Excel export_excel_pdfs.applescript "$stage_root/xlsx-sheets"
 
 while IFS= read -r -d '' source; do
     stem="$(basename "${source%.xlsx}")"
@@ -48,7 +86,7 @@ done < <(find "$corpus_root/sources/xlsx" -maxdepth 1 -type f -name '*.xlsx' -pr
     echo "exported_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     echo "macos=$(sw_vers -productVersion) build $(sw_vers -buildVersion)"
     for application in "Microsoft Word" "Microsoft PowerPoint" "Microsoft Excel"; do
-        version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "/Applications/$application.app/Contents/Info.plist")"
+        version="$("$plist_buddy" -c 'Print :CFBundleShortVersionString' "/Applications/$application.app/Contents/Info.plist")"
         echo "$application=$version"
     done
     find "$stage_root/docx" "$stage_root/pptx" "$stage_root/xlsx" -type f -name '*.pdf' -print0 \

--- a/scripts/tests/test_export_business_golden_pdfs.py
+++ b/scripts/tests/test_export_business_golden_pdfs.py
@@ -1,0 +1,228 @@
+"""Unit tests for the business golden native-export script (#1128).
+
+Word, PowerPoint and Excel are sandboxed: every source they open and every PDF
+they save has to sit inside that app's own container, or macOS raises a
+per-file "Grant Access" dialog and an unattended run stalls on the first one
+(#1051, #1082). This script drives all three apps in one run, so it needs three
+containers, not one shared stage. The tests below pin that staging contract and
+the copy back out to the caller's stage root, with `osascript` and the Poppler
+tools stubbed, so they need neither a Mac nor a copy of Office.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+EXPORT_SCRIPT = REPO_ROOT / "scripts" / "macos" / "export_business_golden_pdfs.sh"
+CORPUS_SOURCES = REPO_ROOT / "tests" / "golden_mocks" / "business" / "sources"
+
+BUNDLE_ID_BY_EXPORTER = {
+    "export_word_pdfs.applescript": "com.microsoft.Word",
+    "export_powerpoint_pdfs.applescript": "com.microsoft.Powerpoint",
+    "export_excel_pdfs.applescript": "com.microsoft.Excel",
+}
+
+# Stands in for `osascript`: records the argv the exporter was driven with and
+# writes the PDFs that invocation promised, so the rest of the pipeline runs.
+OSASCRIPT_STUB = r"""#!/usr/bin/env python3
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+exporter = Path(sys.argv[1]).name
+output_directory = Path(sys.argv[2])
+pairs = list(zip(sys.argv[3::2], sys.argv[4::2]))
+log = Path(os.environ["OSASCRIPT_LOG"])
+calls = json.loads(log.read_text()) if log.exists() else []
+# The stage is torn down when the run ends, so the digest of what the app was
+# handed has to be taken here, while the file still exists.
+calls.append(
+    {
+        "argv": sys.argv[1:],
+        "digests": {
+            identifier: hashlib.sha256(Path(source).read_bytes()).hexdigest()
+            for identifier, source in pairs
+        },
+    }
+)
+log.write_text(json.dumps(calls))
+
+output_directory.mkdir(parents=True, exist_ok=True)
+for identifier, source in pairs:
+    if exporter == "export_excel_pdfs.applescript":
+        names = [f"{identifier}-sheet-01.pdf", f"{identifier}-sheet-02.pdf"]
+    else:
+        names = [f"{identifier}.pdf"]
+    for name in names:
+        (output_directory / name).write_bytes(
+            b"%PDF-1.7 " + Path(source).read_bytes()[:16]
+        )
+"""
+
+PDFUNITE_STUB = r"""#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+*sheets, united = sys.argv[1:]
+Path(united).write_bytes(b"".join(Path(sheet).read_bytes() for sheet in sheets))
+"""
+
+TRUE_STUB = "#!/bin/sh\nexit 0\n"
+SW_VERS_STUB = '#!/bin/sh\ncase "$1" in\n-buildVersion) echo 25G99 ;;\n*) echo 26.6.1 ;;\nesac\n'
+SHASUM_STUB = '#!/bin/sh\nif [ "$1" = "-a" ]; then shift 2; fi\nfor path in "$@"; do\n  echo "0000000000000000000000000000000000000000000000000000000000000000  $path"\ndone\n'
+PLIST_BUDDY_STUB = "#!/bin/sh\necho 16.90\n"
+
+
+def write_stub(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def source_digests(extension: str) -> dict[str, str]:
+    return {
+        source.stem: hashlib.sha256(source.read_bytes()).hexdigest()
+        for source in CORPUS_SOURCES.joinpath(extension).glob(f"*.{extension}")
+    }
+
+
+class ExportRun:
+    """One stubbed run of the export script against a throwaway HOME."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.home = root / "home"
+        self.stage_root = root / "staged"
+        self.bin = root / "bin"
+        self.log = root / "osascript-calls.json"
+        self.bin.mkdir(parents=True)
+        self.home.mkdir(parents=True)
+        write_stub(self.bin / "osascript", OSASCRIPT_STUB)
+        write_stub(self.bin / "pdfunite", PDFUNITE_STUB)
+        write_stub(self.bin / "pdfinfo", TRUE_STUB)
+        write_stub(self.bin / "sw_vers", SW_VERS_STUB)
+        write_stub(self.bin / "shasum", SHASUM_STUB)
+        write_stub(self.bin / "plistbuddy", PLIST_BUDDY_STUB)
+
+    def run(self) -> subprocess.CompletedProcess:
+        environment = dict(os.environ)
+        environment.update(
+            HOME=str(self.home),
+            PATH=f"{self.bin}:{environment['PATH']}",
+            OSASCRIPT_LOG=str(self.log),
+            PLIST_BUDDY_BIN=str(self.bin / "plistbuddy"),
+        )
+        return subprocess.run(
+            ["bash", str(EXPORT_SCRIPT), str(self.stage_root)],
+            capture_output=True,
+            text=True,
+            env=environment,
+            timeout=300,
+        )
+
+    @property
+    def containers(self) -> Path:
+        return self.home / "Library" / "Containers"
+
+    def calls(self) -> list[dict]:
+        return json.loads(self.log.read_text())
+
+
+class StagingContractTest(unittest.TestCase):
+    """Where the sandboxed apps are pointed (#1128)."""
+
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.run_context = ExportRun(Path(self._tmp.name))
+        self.result = self.run_context.run()
+        self.assertEqual(
+            self.result.returncode,
+            0,
+            f"export script failed: {self.result.stdout}{self.result.stderr}",
+        )
+
+    def test_every_path_an_office_app_touches_sits_in_its_own_container(self):
+        calls = self.run_context.calls()
+        self.assertEqual(len(calls), 3, "one exporter invocation per format")
+        for call in calls:
+            argv = call["argv"]
+            exporter = Path(argv[0]).name
+            bundle_id = BUNDLE_ID_BY_EXPORTER[exporter]
+            container = self.run_context.containers / bundle_id / "Data"
+            for argument in argv[1:]:
+                if "/" not in argument:
+                    continue
+                self.assertTrue(
+                    Path(argument).is_relative_to(container),
+                    f"{exporter} was handed {argument}, outside {bundle_id}",
+                )
+
+    def test_each_app_opens_a_byte_identical_copy_of_its_own_sources(self):
+        # Staging must copy the corpus, not stand in for it: every source the
+        # app is handed has to be the tracked fixture, byte for byte.
+        expected = {
+            "export_word_pdfs.applescript": source_digests("docx"),
+            "export_powerpoint_pdfs.applescript": source_digests("pptx"),
+            "export_excel_pdfs.applescript": source_digests("xlsx"),
+        }
+        for call in self.run_context.calls():
+            exporter = Path(call["argv"][0]).name
+            self.assertEqual(call["digests"], expected[exporter], exporter)
+
+    def test_the_containers_are_left_clean_when_the_run_finishes(self):
+        # A staged copy of the corpus left inside a container outlives the run
+        # and is the next run's stale input.
+        for bundle_id in BUNDLE_ID_BY_EXPORTER.values():
+            container = self.run_context.containers / bundle_id / "Data"
+            leftovers = sorted(
+                path.name
+                for path in container.rglob("*")
+                if path.suffix in {".docx", ".pptx", ".xlsx", ".pdf"}
+            )
+            self.assertEqual(leftovers, [], f"{bundle_id} still holds {leftovers}")
+
+    def test_the_stage_root_layout_is_unchanged(self):
+        stage_root = self.run_context.stage_root
+        for extension, subdirectory in (("docx", "docx"), ("pptx", "pptx")):
+            for source in sorted(CORPUS_SOURCES.joinpath(extension).glob(f"*.{extension}")):
+                pdf = stage_root / subdirectory / f"{source.stem}.pdf"
+                self.assertTrue(pdf.is_file(), f"missing {pdf}")
+                self.assertTrue(pdf.read_bytes().startswith(b"%PDF-1.7 "))
+        for source in sorted(CORPUS_SOURCES.joinpath("xlsx").glob("*.xlsx")):
+            sheets = sorted(
+                (stage_root / "xlsx-sheets").glob(f"{source.stem}-sheet-*.pdf")
+            )
+            self.assertEqual(len(sheets), 2, f"missing sheet PDFs for {source.stem}")
+            united = stage_root / "xlsx" / f"{source.stem}.pdf"
+            self.assertEqual(
+                united.read_bytes(),
+                b"".join(sheet.read_bytes() for sheet in sheets),
+            )
+        provenance = (stage_root / "provenance.txt").read_text()
+        self.assertIn("Microsoft Word=16.90", provenance)
+        self.assertIn("macos=26.6.1 build 25G99", provenance)
+        self.assertIn(str(stage_root / "docx" / "01_invoice_en.pdf"), provenance)
+
+    def test_the_stage_root_is_never_handed_to_a_sandboxed_app(self):
+        # The caller's stage root is the one path the script cannot control;
+        # the Poppler steps that read it afterwards are not sandboxed.
+        stage_root = str(self.run_context.stage_root)
+        for call in self.run_context.calls():
+            for argument in call["argv"][1:]:
+                self.assertFalse(
+                    argument.startswith(stage_root),
+                    f"{argument} exposes the stage root to a sandboxed app",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/golden_mocks/business/README.md
+++ b/tests/golden_mocks/business/README.md
@@ -121,6 +121,8 @@ scripts/macos/export_business_golden_pdfs.sh /tmp/office2pdf-business-goldens
 
 Word and PowerPoint export whole documents in source order. Excel exports every visible worksheet with its native print settings, then `pdfunite` losslessly combines the sheet PDFs in workbook order. The staging directory includes `provenance.txt` with Office versions, macOS build, export time, and SHA-256 hashes. Review the staged PDFs visually before replacing any tracked file and then update the matching hashes and metadata in `manifest.json`.
 
+The three apps are sandboxed, so the run copies each format's sources into `~/Library/Containers/<bundle id>/Data/business-golden-export/` — Word, PowerPoint, and Excel each in their own container — exports there, copies the PDFs back to the staging directory, and removes the container stage. Files anywhere else raise a per-file "Grant Access" dialog that stalls the run (#1128), so the staging directory argument is free to sit wherever is convenient.
+
 Run both validator layers after any source or golden update:
 
 ```sh


### PR DESCRIPTION
## Summary

`scripts/macos/export_business_golden_pdfs.sh` drove Microsoft Word, PowerPoint and
Excel with a stage root under the checkout (`target/business-golden-office-export`
by default) and with the sources read straight from
`tests/golden_mocks/business/sources/`. All three apps are sandboxed, so each of
those 30 files costs a per-file "Grant Access" dialog on a machine that has not
already granted the path, and an unattended run stalls on the first one. That is
the failure #1051 removed from `probe_harness.py --backend office` and #1082
removed from the two callers it enumerated; this script was the last caller of the
same `scripts/macos/export_*_pdfs.applescript` exporters still outside the rule.

It drives three apps in one run, so it needs three stages, not one. Each format now
round-trips through `Data/business-golden-export/` in the container of the app that
exports it — `com.microsoft.Word`, `com.microsoft.Powerpoint`, `com.microsoft.Excel`
— and the PDFs are copied back to the caller's stage root afterwards, which only the
unsandboxed `pdfunite`/`pdfinfo`/provenance steps read. Reaching into another app's
container prompts just the same, so the mapping is per exporter.

A stage left behind by an aborted run is cleared before staging and removed when the
run ends (EXIT trap), so a stale copy of the corpus can never become the next run's
input. The stage-root layout is untouched: `docx/`, `pptx/`, `xlsx-sheets/`, `xlsx/`
and `provenance.txt`, same names, same contents. One side effect worth naming: since
no sandboxed app sees the stage root any more, it is now free to sit anywhere,
including an external volume.

`scripts/tests/test_export_business_golden_pdfs.py` pins the contract with
`osascript` and the Poppler tools stubbed and a throwaway `HOME`, so it needs
neither a Mac nor a copy of Office and runs in the `business-golden-contract` job:
every path an exporter is handed sits inside that app's own container, the staged
sources are byte-identical to the tracked fixtures, the containers are left clean,
the stage root is never handed to a sandboxed app, and the stage-root layout and
provenance are unchanged. The version probe reads a `PLIST_BUDDY_BIN` override for
the same reason — `/usr/libexec/PlistBuddy` has no PATH entry to shadow on the
Linux runner (the same seam `prepare-release.sh` uses for `GH_CLI_BIN`).

## Related issue

Related: #1128, #1082, #1051, #698

## Testing

- `python3 -m unittest discover -s scripts/tests -p 'test_export_business_golden_pdfs.py'` — 5 passed; reverting the script to its pre-fix form fails 3 of them (`export_word_pdfs.applescript was handed …/staged/docx, outside com.microsoft.Word`)
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 211 passed
- `bash -n scripts/macos/export_business_golden_pdfs.sh`
- Real Office, one file per app staged in its own container: Word, PowerPoint and Excel each exported with exit 0 and no dialog
- Real Office, full run: `bash scripts/macos/export_business_golden_pdfs.sh /tmp/office2pdf-business-goldens-1128` completed in 33s with zero Grant Access dialogs, wrote all 30 PDFs plus the sheet PDFs and `provenance.txt`, and left no `business-golden-export` directory in any of the three containers
- All 30 fresh exports match the tracked `expected/` goldens' page counts (`pdfinfo`), so container staging changes nothing about what Office produces

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: tooling only — a shell export harness, its new test, a CI step and docs. No converter code is touched and no tracked golden is regenerated.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
