### PR TITLE
test(pptx): pin an unwrapped 32pt label's native first baseline

### DIFF
--- a/crates/office2pdf/src/render/typst_gen_fixed_page_textbox_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_fixed_page_textbox_tests.rs
@@ -2148,6 +2148,63 @@ fn the_contoso_scaled_attribution_lands_on_its_native_baseline() {
     );
 }
 
+/// An unwrapped 32pt slide label lands on its native first baseline.
+///
+/// `tests/fixtures/pptx/run-fill-alpha.pptx` seats its `txBox="1"` frame at
+/// `a:off y="2133600"` under the default `tIns` of 45720 EMU, putting the
+/// content top on 171.60pt, and sets all three of its paragraphs in 32pt Arial
+/// at a width none of them wraps at. None writes an `<a:endParaRPr>`, so each
+/// mark resolves through `presentation.xml`'s `<a:defaultTextStyle>`, whose
+/// `<a:latin typeface="+mn-lt"/>` names the theme's minor Latin font — here
+/// `Calisto MT` — and shares the line box with the run. A native PowerPoint
+/// 16.112 export puts the first baseline on 202.56pt.
+///
+/// The two faces settle on 0.963654em, a 31pt seat at this size, which is also
+/// where Arial's own 0.972378em share rounds: a frame this shallow cannot tell
+/// the mark's contribution apart, and no claim about it is made here. What it
+/// does separate is the **metric source**. Folding Arial's 67/2048 hhea line
+/// gap into the descent gives 0.944713em and a 30pt seat, landing the line on
+/// 201.60pt — 0.96pt high, four times the export's 0.24pt position grid
+/// (issue #1179).
+#[test]
+fn the_unwrapped_label_lands_on_its_native_first_baseline() {
+    const EMU_PER_PT: f64 = 12700.0;
+    const NATIVE_BASELINE_PT: f64 = 202.56;
+    const SIZE_PT: f64 = 32.0;
+    let content_top_pt: f64 = (2133600.0 + 45720.0) / EMU_PER_PT;
+    let baseline_of = |above_em: f64| -> f64 {
+        let (seat_em, _) = crate::render::typst_gen::text::powerpoint_percentage_line_box_em(
+            above_em, SIZE_PT, 1.0,
+        );
+        content_top_pt + seat_em * SIZE_PT
+    };
+
+    // Arial usWin 1854/434 and Calisto MT usWin 1894/470, both per 2048 upem.
+    let (shared_above, _) = crate::render::pdf::powerpoint_line_box_split_em([
+        (1854.0 / 2048.0, 434.0 / 2048.0),
+        (1894.0 / 2048.0, 470.0 / 2048.0),
+    ])
+    .expect("a positive ascent splits the line box");
+    let baseline_pt: f64 = baseline_of(shared_above);
+    assert!(
+        (baseline_pt - NATIVE_BASELINE_PT).abs() <= 0.24,
+        "the unwrapped 32pt label must land on the native {NATIVE_BASELINE_PT}pt \
+         baseline within the export's 0.24pt position grid, got {baseline_pt}pt"
+    );
+
+    // Triangulation: the reading this issue measured against, Arial's hhea pair
+    // with its line gap folded in, is a whole point short of that.
+    let (gap_inclusive_above, _) =
+        crate::render::pdf::powerpoint_line_box_split_em([(1854.0 / 2048.0, 501.0 / 2048.0)])
+            .expect("a positive ascent splits the line box");
+    let gap_inclusive_pt: f64 = baseline_of(gap_inclusive_above);
+    assert!(
+        (gap_inclusive_pt - NATIVE_BASELINE_PT).abs() > 0.24,
+        "folding the hhea line gap into the box must not reach the native \
+         baseline, got {gap_inclusive_pt}pt"
+    );
+}
+
 /// The paragraph mark's face reaches the emitted line box.
 ///
 /// PowerPoint's 1.2em box is shared by every font on the line and the mark —

--- a/crates/office2pdf/tests/pptx_fixtures.rs
+++ b/crates/office2pdf/tests/pptx_fixtures.rs
@@ -1048,6 +1048,45 @@ fn run_fill_alpha_composites_in_the_generated_source() {
     );
 }
 
+/// A paragraph that writes no `<a:endParaRPr>` at all still puts its mark in
+/// the theme's minor Latin font.
+///
+/// PowerPoint shares one 1.2em line box across every font on the line, the
+/// paragraph mark included, so the mark's face decides where the baseline sits
+/// inside it. The golden mocks' Korean titles carry a bare `<a:endParaRPr>`
+/// (issue #1176); these three paragraphs omit the element entirely, and the
+/// mark still has to end up where `presentation.xml`'s `<a:defaultTextStyle>`
+/// puts it — its `<a:latin typeface="+mn-lt"/>` names this deck's `Calisto MT`,
+/// whose usWin descent is deeper than the runs' Arial and so moves the shared
+/// box (issue #1179).
+#[test]
+fn structure_run_fill_alpha_marks_take_the_theme_minor_latin_font() {
+    let pages = fixed_pages("run-fill-alpha.pptx");
+    let text_box = pages[0]
+        .elements
+        .iter()
+        .find_map(|element| match &element.kind {
+            FixedElementKind::TextBox(text_box) => Some(text_box),
+            _ => None,
+        })
+        .expect("fixture should contain its label frame");
+    let mark_families: Vec<Option<&str>> = text_box
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            Block::Paragraph(paragraph) => Some(paragraph),
+            _ => None,
+        })
+        .map(|paragraph| paragraph.style.paragraph_mark_font_family.as_deref())
+        .collect();
+
+    assert_eq!(
+        mark_families,
+        vec![Some("Calisto MT"); 3],
+        "a mark declaring nothing must fall to the theme's minor Latin font"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // hard_break_wrapped_line_advance.pptx — `hard_break_line_advance.pptx` with
 // `<a:bodyPr wrap="none">` changed to `wrap="square"` (issue #1172). A wrapping


### PR DESCRIPTION
## Summary

Issue #1179 reports `tests/fixtures/pptx/run-fill-alpha.pptx` seating its first
slide baseline 0.96pt above where native PowerPoint seats it: 201.60pt against
the export's 202.56pt, on a frame whose content top is 171.60pt and whose three
32pt Arial paragraphs each fit on one line.

**It is already closed, by #1258.** That PR made the shared 1.2em slide line box
read OS/2's `usWin*` pair instead of hhea with the line gap, and take the
paragraph mark's face into the box. This deck's marks resolve to `Calisto MT`
(usWin 1894/470 per 2048 upem), which shares with Arial at 0.963654em — a 31pt
seat at this size, where the gap-inclusive reading gave 30pt. A fresh native
PowerPoint 16 export of the same fixture, staged in
`~/Library/Containers/com.microsoft.Powerpoint/Data/probes/`, measures the
remainder:

| | first baseline | seat above content top |
| --- | ---: | ---: |
| PowerPoint | 202.56pt | 30.96pt |
| office2pdf at #1179's `a1c6259` | 201.60pt | 30.00pt |
| office2pdf at `5530c3fe` | 202.60pt | 31.00pt |

0.04pt, well inside the export's own 0.24pt position grid.

Nothing guarded that cell, so this PR adds the two regression tests it was
missing and changes no runtime code:

- `the_unwrapped_label_lands_on_its_native_first_baseline` seats 32pt text from
  Arial's and Calisto MT's usWin pairs and asserts it lands on the export's
  202.56pt. It triangulates the metric source in the same test: folding Arial's
  67/2048 hhea line gap into the descent gives 0.944713em, a 30pt seat and
  201.60pt, which the test asserts *misses* the native baseline. This frame
  cannot separate the mark's contribution — Arial's own 0.972378em share rounds
  to the same 31pt — and the test says so rather than claiming otherwise.
- `structure_run_fill_alpha_marks_take_the_theme_minor_latin_font` pins the
  parse side. The #1176 coverage is a Korean deck whose marks carry a bare
  `<a:endParaRPr>`; these three paragraphs omit the element entirely, and the
  mark still has to reach the IR as this deck's `+mn-lt`.

## Related issue

Related: #1179

## Testing

- `cargo test --workspace` — 3,083 passed, 15 ignored, 0 failures.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --
  -D warnings`, plus `cargo +1.97 clippy --workspace --all-targets` on the newer
  toolchain CI has been running — all clean.
- Native GT: `scripts/macos/export_powerpoint_pdfs.applescript` on the fixture,
  staged inside PowerPoint's own container. `scripts/compare_layout.py --audit`
  against it reports `1 matched (0 missing, 2 extra, 0 re-wrapped) | dy mean
  0.04pt worst +0.04pt | pitch worst 0.00pt | width worst 0.0%`. The two extra
  lines are the `a:alpha` paragraphs we draw as text where the export
  rasterises them to sprites, which is what #1121 measured and #1179 records as
  not GT ink.
- `scripts/compare_render.py --page 1 --artifacts-dir` reports colour shift
  0.0000, ink coverage equal to the GT's, and no diff cluster of 20pt² or more.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: tests only — no runtime code is touched, so the PDF this branch emits
  is byte-identical to `main`'s. The rendered change that closes #1179 shipped
  in #1258 and carries its evidence there.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
