### PR TITLE
fix: omit malformed PPTX raster images

### DIFF
--- a/crates/office2pdf/src/parser/pptx_image_tests.rs
+++ b/crates/office2pdf/src/parser/pptx_image_tests.rs
@@ -756,6 +756,37 @@ fn test_wdp_only_picture_emits_unsupported_warning() {
 }
 
 #[test]
+fn test_malformed_png_is_omitted_with_warning() {
+    let pic = make_pic_xml(0, 0, 1_000_000, 1_000_000, "rId3");
+    let slide_xml = make_slide_xml(&[pic]);
+    let slide_images = vec![TestSlideImage {
+        rid: "rId3".to_string(),
+        path: "../media/image1.png".to_string(),
+        data: b"not a png".to_vec(),
+        relationship_type: None,
+    }];
+    let data = build_test_pptx_with_images(SLIDE_CX, SLIDE_CY, &[(slide_xml, slide_images)]);
+    let parser = PptxParser;
+    let (doc, warnings) = parser.parse(&data, &ConvertOptions::default()).unwrap();
+
+    let page = first_fixed_page(&doc);
+    assert!(
+        page.elements.is_empty(),
+        "Malformed image must not reach the renderer"
+    );
+    assert!(
+        warnings.iter().any(|warning| matches!(
+            warning,
+            ConvertWarning::UnsupportedElement { format, element }
+                if format == "PPTX"
+                    && element.contains("image omitted")
+                    && element.contains("image1.png")
+        )),
+        "Expected an omission warning for malformed PNG, got: {warnings:?}"
+    );
+}
+
+#[test]
 fn test_image_dimensions_preserved() {
     let bmp_data = make_test_bmp();
     let pic = make_pic_xml(0, 0, 2_540_000, 1_270_000, "rId3");

--- a/crates/office2pdf/src/parser/pptx_package.rs
+++ b/crates/office2pdf/src/parser/pptx_package.rs
@@ -505,7 +505,13 @@ fn image_format_from_ext(path: &str) -> Option<ImageFormat> {
 
 fn normalize_slide_image_asset(target: &str, data: Vec<u8>) -> (Vec<u8>, SlideImageSource) {
     if let Some(format) = image_format_from_ext(target) {
-        return (data, SlideImageSource::Supported(format));
+        if format == ImageFormat::Svg {
+            return (data, SlideImageSource::Supported(format));
+        }
+        return match validated_raster_format(&data) {
+            Some(actual_format) => (data, SlideImageSource::Supported(actual_format)),
+            None => (data, SlideImageSource::Unsupported),
+        };
     }
 
     if target.to_ascii_lowercase().ends_with(".emf")
@@ -515,6 +521,20 @@ fn normalize_slide_image_asset(target: &str, data: Vec<u8>) -> (Vec<u8>, SlideIm
     }
 
     (data, SlideImageSource::Unsupported)
+}
+
+fn validated_raster_format(data: &[u8]) -> Option<ImageFormat> {
+    let detected = image::guess_format(data).ok()?;
+    let format = match detected {
+        image::ImageFormat::Png => ImageFormat::Png,
+        image::ImageFormat::Jpeg => ImageFormat::Jpeg,
+        image::ImageFormat::Gif => ImageFormat::Gif,
+        image::ImageFormat::Bmp => ImageFormat::Bmp,
+        image::ImageFormat::Tiff => ImageFormat::Tiff,
+        _ => return None,
+    };
+    image::load_from_memory_with_format(data, detected).ok()?;
+    Some(format)
 }
 
 fn is_image_relationship(rel_type: Option<&str>, target: &str) -> bool {


### PR DESCRIPTION
## Summary

- validate embedded raster payloads before exposing them to the renderer
- detect the actual supported raster format instead of trusting the filename extension
- omit undecodable assets through the existing unsupported-element warning path
- add a synthetic malformed-PNG regression test

## Related issue

Fixes #1290

## Testing

- `cargo test -p office2pdf test_malformed_png_is_omitted_with_warning`
- `OFFICE2PDF_VALIDATE_PDF=1 cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo publish --dry-run -p office2pdf --allow-dirty`
- `cargo fmt --all -- --check`
- external PPTX acceptance conversion: passed

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: malformed assets previously aborted conversion before a PDF existed; valid raster rendering is unchanged, while the invalid asset is now omitted with a warning.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue