### PR TITLE
fix(scripts): count only the sheets Excel prints in the GT integrity gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,7 +337,8 @@ are reproducible without a native export (#634).
 export poisons every downstream number silently: the workbook-per-sheet
 duplication of #616 survived because nothing checked the GT itself. The gate
 detects page-sequence periodicity (the duplication signature), implausible page
-counts against the source's worksheet count, and GT-side font substitutions —
+counts against the worksheets the source would actually print (hidden sheets
+excluded, #1211), and GT-side font substitutions —
 the last so an exporter's Arial-to-Liberation swap is never filed as a converter
 defect. Exits non-zero only when the GT cannot be trusted at all.
 

--- a/scripts/check_gt_integrity.py
+++ b/scripts/check_gt_integrity.py
@@ -13,8 +13,11 @@ Three checks, each aimed at a failure this corpus has actually seen:
    worksheet produces a perfectly periodic page sequence. This is what would
    have caught #616 the day it was written.
 2. **Page-count plausibility** — for XLSX, compare the GT page count against the
-   workbook's worksheet count. A GT with fewer pages than sheets cannot be
-   complete; an exact multiple is the duplication signature again.
+   worksheets the workbook would actually print. A GT with fewer pages than
+   those cannot be complete; an exact multiple is the duplication signature
+   again. Sheets marked `hidden` or `veryHidden` are excluded, because Excel
+   never pages them (issue #1065) and counting them failed correct exports of
+   every workbook carrying a hidden lookup sheet (issue #1211).
 3. **Font census** — list the fonts the GT actually embeds and compare against
    the families the source declares. A substitution (Calibri rendered as Malgun
    Gothic) or lost emphasis is a *GT-side* artefact; reporting it here stops an
@@ -93,16 +96,56 @@ def detect_periodicity(hashes: list[str]) -> int | None:
     return None
 
 
-def worksheet_count(source: Path) -> int | None:
-    """Worksheets declared by an XLSX, or None for other formats."""
+# `state` is optional on `<sheet>`; ECMA-376's ST_SheetState defaults it to
+# `visible`. `veryHidden` differs from `hidden` only in keeping the sheet out
+# of Excel's unhide dialog — neither ever reaches paper (issue #1065).
+HIDDEN_SHEET_STATES = frozenset({"hidden", "veryhidden"})
+
+# `<sheets>`, `<sheetPr>` and `<sheetView>` share the prefix, so the word
+# boundary is what makes this select sheet declarations alone. The optional
+# prefix group covers producers that write the main namespace explicitly.
+SHEET_ELEMENT = re.compile(r"<(?:[\w.-]+:)?sheet\b[^>]*>")
+SHEET_STATE_ATTRIBUTE = re.compile(r'\bstate\s*=\s*"([^"]*)"')
+
+
+def sheet_states(workbook_xml: str) -> list[str]:
+    """The visibility state of every sheet the workbook declares, in order."""
+    states: list[str] = []
+    for element in SHEET_ELEMENT.findall(workbook_xml):
+        state = SHEET_STATE_ATTRIBUTE.search(element)
+        states.append(state.group(1).strip().lower() if state else "visible")
+    return states
+
+
+def printable_sheet_count(workbook_xml: str) -> int:
+    """Sheets Excel would put on paper: every declared sheet bar the hidden ones.
+
+    Counting the hidden ones made this gate reject correct exports: a native
+    export of a workbook with a hidden lookup sheet — an ordinary template
+    shape — legitimately has fewer pages than the workbook declares sheets, and
+    the gate called that INVALID (issue #1211).
+    """
+    return sum(
+        1 for state in sheet_states(workbook_xml) if state not in HIDDEN_SHEET_STATES
+    )
+
+
+def hidden_sheet_count(workbook_xml: str) -> int:
+    """Sheets the workbook hides, reported so a low page count explains itself."""
+    return sum(
+        1 for state in sheet_states(workbook_xml) if state in HIDDEN_SHEET_STATES
+    )
+
+
+def read_workbook_xml(source: Path) -> str | None:
+    """`xl/workbook.xml` from an XLSX, or None for other or unreadable formats."""
     if source.suffix.lower() != ".xlsx":
         return None
     try:
         with zipfile.ZipFile(source) as archive:
-            workbook = archive.read("xl/workbook.xml").decode("utf-8", "replace")
+            return archive.read("xl/workbook.xml").decode("utf-8", "replace")
     except (OSError, KeyError, zipfile.BadZipFile):
         return None
-    return len(re.findall(r"<sheet\b", workbook))
 
 
 def declared_fonts(source: Path) -> set[str]:
@@ -156,7 +199,8 @@ def check(gt: Path, source: Path | None) -> dict:
     result: dict = {
         "pages": len(hashes),
         "periodicity": period,
-        "worksheets": None,
+        "printable_worksheets": None,
+        "hidden_worksheets": None,
         "font_substitutions": [],
         "invalid": False,
     }
@@ -164,15 +208,22 @@ def check(gt: Path, source: Path | None) -> dict:
         result["invalid"] = True
 
     if source is not None:
-        sheets = worksheet_count(source)
-        result["worksheets"] = sheets
-        if sheets:
-            # Fewer pages than sheets cannot be a complete export.
-            if len(hashes) < sheets:
-                result["invalid"] = True
-            # An exact multiple is the duplication signature again.
-            elif sheets > 1 and len(hashes) % sheets == 0 and len(hashes) // sheets > 1:
-                result["suspicious_multiple"] = len(hashes) // sheets
+        workbook_xml = read_workbook_xml(source)
+        if workbook_xml is not None:
+            sheets = printable_sheet_count(workbook_xml)
+            result["printable_worksheets"] = sheets
+            result["hidden_worksheets"] = hidden_sheet_count(workbook_xml)
+            if sheets:
+                # Fewer pages than sheets cannot be a complete export.
+                if len(hashes) < sheets:
+                    result["invalid"] = True
+                # An exact multiple is the duplication signature again.
+                elif (
+                    sheets > 1
+                    and len(hashes) % sheets == 0
+                    and len(hashes) // sheets > 1
+                ):
+                    result["suspicious_multiple"] = len(hashes) // sheets
         declared = declared_fonts(source)
         embedded = embedded_fonts(gt)
         if declared and embedded:
@@ -183,8 +234,12 @@ def check(gt: Path, source: Path | None) -> dict:
 
 def render_report(result: dict) -> str:
     lines = ["## GT integrity", "", f"Pages: {result['pages']}"]
-    if result["worksheets"] is not None:
-        lines.append(f"Worksheets declared by source: {result['worksheets']}")
+    if result["printable_worksheets"] is not None:
+        lines.append(f"Printable worksheets in source: {result['printable_worksheets']}")
+    if result.get("hidden_worksheets"):
+        lines.append(
+            f"Hidden worksheets, which Excel never prints: {result['hidden_worksheets']}"
+        )
     lines.append("")
 
     if result["periodicity"] is not None:
@@ -197,7 +252,7 @@ def render_report(result: dict) -> str:
         ]
     elif result["invalid"]:
         lines += [
-            "**INVALID — fewer pages than the source has worksheets.**",
+            "**INVALID — fewer pages than the source has printable worksheets.**",
             "",
             "The export cannot be complete, so page-indexed comparisons will be",
             "misaligned. Re-export before measuring.",

--- a/scripts/tests/test_check_gt_integrity.py
+++ b/scripts/tests/test_check_gt_integrity.py
@@ -5,12 +5,66 @@ exists to catch.
 """
 
 import sys
+import tempfile
 import unittest
+import zipfile
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from check_gt_integrity import detect_periodicity, render_report
+import check_gt_integrity
+from check_gt_integrity import (
+    check,
+    detect_periodicity,
+    hidden_sheet_count,
+    printable_sheet_count,
+    read_workbook_xml,
+    render_report,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+# A real two-sheet probe workbook whose lookup sheet is `state="hidden"`,
+# committed for issue #1065.
+HIDDEN_SHEET_WORKBOOK = (
+    PROJECT_ROOT / "tests" / "fixtures" / "xlsx" / "issue_1065_hidden_sheet_probe.xlsx"
+)
+
+
+def workbook_declaring(sheets: str) -> str:
+    """An `xl/workbook.xml` whose `<sheets>` block is `sheets`.
+
+    The surrounding elements are the ones Excel for Mac actually writes, so the
+    sheet scan is exercised against a document that also carries `<workbookPr>`,
+    `<bookViews>` and `<sheetPr>`-adjacent names it must not mistake for sheets.
+    """
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+        ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+        '<fileVersion appName="xl" lastEdited="7"/>'
+        '<workbookPr defaultThemeVersion="202300"/>'
+        '<bookViews><workbookView xWindow="640" yWindow="700"/></bookViews>'
+        f"<sheets>{sheets}</sheets>"
+        '<calcPr calcId="181029"/>'
+        "</workbook>"
+    )
+
+
+# The workbook of issue #1211: two visible sheets and a hidden lookup sheet.
+GIFT_TRACKER_SHEETS = (
+    '<sheet name="Start" sheetId="1" state="visible" r:id="rId3"/>'
+    '<sheet name="Gift budget and tracker" sheetId="2" state="visible" r:id="rId4"/>'
+    '<sheet name="Data" sheetId="3" state="hidden" r:id="rId5"/>'
+)
+
+
+def write_workbook(directory: Path, name: str, sheets: str) -> Path:
+    """A minimal but openable XLSX declaring `sheets`."""
+    source = directory / name
+    with zipfile.ZipFile(source, "w") as archive:
+        archive.writestr("xl/workbook.xml", workbook_declaring(sheets))
+    return source
 
 
 class PeriodicityTest(unittest.TestCase):
@@ -43,28 +97,47 @@ class PeriodicityTest(unittest.TestCase):
 class ReportTest(unittest.TestCase):
     def test_periodic_gt_is_called_invalid_and_says_why(self):
         report = render_report(
-            {"pages": 9, "periodicity": 3, "worksheets": 3,
-             "font_substitutions": [], "invalid": True}
+            {"pages": 9, "periodicity": 3, "printable_worksheets": 3,
+             "hidden_worksheets": 0, "font_substitutions": [], "invalid": True}
         )
         self.assertIn("INVALID", report)
         self.assertIn("#616", report)
 
     def test_clean_gt_says_so(self):
         report = render_report(
-            {"pages": 5, "periodicity": None, "worksheets": None,
-             "font_substitutions": [], "invalid": False}
+            {"pages": 5, "periodicity": None, "printable_worksheets": None,
+             "hidden_worksheets": None, "font_substitutions": [], "invalid": False}
         )
         self.assertIn("No structural corruption", report)
 
     def test_font_substitutions_are_marked_gt_side(self):
         # The whole point: an auditor must not file these as converter defects.
         report = render_report(
-            {"pages": 2, "periodicity": None, "worksheets": 1,
-             "font_substitutions": ["Calibri"], "invalid": False}
+            {"pages": 2, "periodicity": None, "printable_worksheets": 1,
+             "hidden_worksheets": 0, "font_substitutions": ["Calibri"],
+             "invalid": False}
         )
         self.assertIn("not", report)
         self.assertIn("converter defects", report)
         self.assertIn("Calibri", report)
+
+    def test_the_page_count_line_names_the_printable_sheets(self):
+        # "Worksheets declared by source" would be a lie once the hidden ones
+        # are excluded, and the operator needs to see why the count dropped.
+        report = render_report(
+            {"pages": 2, "periodicity": None, "printable_worksheets": 2,
+             "hidden_worksheets": 1, "font_substitutions": [], "invalid": False}
+        )
+        self.assertIn("Printable worksheets in source: 2", report)
+        self.assertIn("1", report.split("Printable worksheets")[1])
+        self.assertIn("hidden", report.lower())
+
+    def test_a_workbook_with_no_hidden_sheets_says_nothing_about_them(self):
+        report = render_report(
+            {"pages": 3, "periodicity": None, "printable_worksheets": 3,
+             "hidden_worksheets": 0, "font_substitutions": [], "invalid": False}
+        )
+        self.assertNotIn("hidden", report.lower())
 
 
 class PeriodicityLimitTest(unittest.TestCase):
@@ -74,6 +147,150 @@ class PeriodicityLimitTest(unittest.TestCase):
         # defeats, so this is pathological rather than ordinary. Pinned so the
         # behaviour is deliberate rather than a surprise.
         self.assertEqual(detect_periodicity(["a", "b"] * 3), 2)
+
+
+class SheetVisibilityTest(unittest.TestCase):
+    """Excel never prints a hidden sheet (#1065), so the gate must not count it.
+
+    Counting them declared a correct native export INVALID for every workbook
+    carrying a hidden lookup sheet (#1211).
+    """
+
+    def test_the_gift_tracker_shape_counts_only_its_visible_sheets(self):
+        # Two visible sheets plus a hidden `Data` lookup sheet: the workbook of
+        # issue #1211, whose correct native export is two pages.
+        self.assertEqual(printable_sheet_count(workbook_declaring(GIFT_TRACKER_SHEETS)), 2)
+        self.assertEqual(hidden_sheet_count(workbook_declaring(GIFT_TRACKER_SHEETS)), 1)
+
+    def test_very_hidden_sheets_are_not_printed_either(self):
+        # `veryHidden` also keeps the sheet out of the unhide dialog; both
+        # states stay off paper.
+        sheets = (
+            '<sheet name="Report" sheetId="1" r:id="rId1"/>'
+            '<sheet name="Lookups" sheetId="2" state="veryHidden" r:id="rId2"/>'
+        )
+        self.assertEqual(printable_sheet_count(workbook_declaring(sheets)), 1)
+        self.assertEqual(hidden_sheet_count(workbook_declaring(sheets)), 1)
+
+    def test_a_sheet_without_a_state_attribute_is_visible(self):
+        # ST_SheetState defaults to `visible`; Excel omits the attribute for
+        # every sheet it has never hidden.
+        sheets = (
+            '<sheet name="Jan" sheetId="1" r:id="rId1"/>'
+            '<sheet name="Feb" sheetId="2" r:id="rId2"/>'
+        )
+        self.assertEqual(printable_sheet_count(workbook_declaring(sheets)), 2)
+        self.assertEqual(hidden_sheet_count(workbook_declaring(sheets)), 0)
+
+    def test_an_all_visible_workbook_still_counts_every_sheet(self):
+        # The truncation check has to keep its teeth: nothing here is hidden,
+        # so all four sheets must be demanded of the export.
+        sheets = "".join(
+            f'<sheet name="Q{quarter}" sheetId="{quarter}" state="visible" r:id="rId{quarter}"/>'
+            for quarter in range(1, 5)
+        )
+        self.assertEqual(printable_sheet_count(workbook_declaring(sheets)), 4)
+
+    def test_a_workbook_hiding_everything_reports_no_printable_sheet(self):
+        sheets = (
+            '<sheet name="A" sheetId="1" state="hidden" r:id="rId1"/>'
+            '<sheet name="B" sheetId="2" state="veryHidden" r:id="rId2"/>'
+        )
+        self.assertEqual(printable_sheet_count(workbook_declaring(sheets)), 0)
+
+    def test_the_scan_ignores_elements_that_merely_start_with_sheet(self):
+        # `<sheets>`, `<sheetPr>` and `<sheetView>` all share the prefix; only
+        # `<sheet>` itself declares one.
+        sheets = (
+            '<sheet name="Only" sheetId="1" r:id="rId1"><sheetPr codeName="Sheet1"/>'
+            "</sheet>"
+        )
+        self.assertEqual(printable_sheet_count(workbook_declaring(sheets)), 1)
+
+    def test_an_element_merely_ending_in_sheet_is_not_a_declaration(self):
+        # The prefix group must require a colon, or `<worksheet>` would count.
+        sheets = '<sheet name="Only" sheetId="1" r:id="rId1"/><worksheet name="x"/>'
+        self.assertEqual(printable_sheet_count(workbook_declaring(sheets)), 1)
+
+    def test_a_namespace_prefixed_sheet_element_still_counts(self):
+        # Some producers write `xl/workbook.xml` with an explicit prefix rather
+        # than a default namespace.
+        sheets = (
+            '<x:sheet name="Visible" sheetId="1" xmlns:x="urn:main"/>'
+            '<x:sheet name="Lookup" sheetId="2" state="hidden" xmlns:x="urn:main"/>'
+        )
+        self.assertEqual(printable_sheet_count(workbook_declaring(sheets)), 1)
+        self.assertEqual(hidden_sheet_count(workbook_declaring(sheets)), 1)
+
+    def test_a_real_workbook_with_a_hidden_sheet_reads_one_printable_sheet(self):
+        self.assertTrue(
+            HIDDEN_SHEET_WORKBOOK.is_file(), f"missing fixture {HIDDEN_SHEET_WORKBOOK}"
+        )
+        workbook_xml = read_workbook_xml(HIDDEN_SHEET_WORKBOOK)
+        self.assertIsNotNone(workbook_xml)
+        self.assertEqual(printable_sheet_count(workbook_xml), 1)
+        self.assertEqual(hidden_sheet_count(workbook_xml), 1)
+
+    def test_a_non_xlsx_source_yields_no_workbook_part(self):
+        self.assertIsNone(read_workbook_xml(Path("deck.pptx")))
+
+
+class PageCountGateTest(unittest.TestCase):
+    """The gate's verdict, with the raster step stubbed so no poppler is needed."""
+
+    def gate(self, source: Path, pages: int) -> dict:
+        with mock.patch.object(
+            check_gt_integrity,
+            "page_hashes",
+            return_value=[f"page-{index}" for index in range(pages)],
+        ):
+            return check(Path("gt.pdf"), source)
+
+    def test_a_correct_export_of_a_workbook_with_a_hidden_sheet_is_valid(self):
+        # Issue #1211: three declared sheets, one hidden, and a native export of
+        # exactly two pages — which is right.
+        with tempfile.TemporaryDirectory() as directory:
+            source = write_workbook(Path(directory), "tracker.xlsx", GIFT_TRACKER_SHEETS)
+            result = self.gate(source, pages=2)
+        self.assertFalse(result["invalid"])
+        self.assertEqual(result["printable_worksheets"], 2)
+        self.assertEqual(result["hidden_worksheets"], 1)
+        self.assertNotIn("INVALID", render_report(result))
+
+    def test_a_truncated_export_of_an_all_visible_workbook_still_fails(self):
+        # The check the fix must not weaken: nothing is hidden, so two pages
+        # cannot be a complete export of three sheets.
+        sheets = (
+            '<sheet name="Start" sheetId="1" state="visible" r:id="rId3"/>'
+            '<sheet name="Gift budget and tracker" sheetId="2" state="visible" r:id="rId4"/>'
+            '<sheet name="Data" sheetId="3" state="visible" r:id="rId5"/>'
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            source = write_workbook(Path(directory), "tracker.xlsx", sheets)
+            result = self.gate(source, pages=2)
+        self.assertTrue(result["invalid"])
+        self.assertIn("INVALID", render_report(result))
+
+    def test_a_hidden_sheet_does_not_hide_a_truncated_export(self):
+        # One hidden sheet of four, so two printable sheets are still expected
+        # and a one-page export is still short.
+        sheets = (
+            '<sheet name="Start" sheetId="1" r:id="rId1"/>'
+            '<sheet name="Detail" sheetId="2" r:id="rId2"/>'
+            '<sheet name="Data" sheetId="3" state="hidden" r:id="rId3"/>'
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            source = write_workbook(Path(directory), "tracker.xlsx", sheets)
+            result = self.gate(source, pages=1)
+        self.assertTrue(result["invalid"])
+
+    def test_the_duplication_signature_is_measured_against_printable_sheets(self):
+        # Issue #616 again, in a workbook that also hides a lookup sheet: two
+        # printable sheets exported once per sheet give four distinct pages.
+        with tempfile.TemporaryDirectory() as directory:
+            source = write_workbook(Path(directory), "tracker.xlsx", GIFT_TRACKER_SHEETS)
+            result = self.gate(source, pages=4)
+        self.assertEqual(result["suspicious_multiple"], 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`scripts/check_gt_integrity.py` counted every `<sheet>` an XLSX declares, hidden
ones included. Excel never prints a sheet marked `state="hidden"` or
`"veryHidden"` (#1065), so a correct native export of a workbook carrying a
hidden lookup sheet legitimately has fewer pages than the workbook has sheets —
and the gate read that as a truncated export, printed **INVALID** and exited 1.

The gate is the first step of the fine-detail audit workflow in `CLAUDE.md` and
exits non-zero "only when the GT cannot be trusted at all", so a false INVALID
either stops an audit or teaches the operator to ignore the gate.

The page-count check now measures against the printable sheets alone.

## Related issue

Related: #1211

## Key changes

- `worksheet_count()` is replaced by `read_workbook_xml()` plus three pure
  functions over the part — `sheet_states()`, `printable_sheet_count()` and
  `hidden_sheet_count()`. `state` is optional on `<sheet>` and ST_SheetState
  defaults it to `visible`, so a sheet that omits it still counts.
- The result keys `worksheets` becomes `printable_worksheets`, and
  `hidden_worksheets` is added, so the report can explain a low page count
  instead of leaving it looking like corruption:

  ```
  Pages: 1
  Printable worksheets in source: 1
  Hidden worksheets, which Excel never prints: 1

  No structural corruption detected.
  ```

- The truncation check keeps its teeth: an all-visible workbook still demands
  one page per sheet, and the duplication signature of #616 is measured against
  the printable count too.
- The element scan requires a word boundary after `sheet` and a colon on the
  optional namespace prefix, so `<sheets>`, `<sheetPr>` and `<worksheet>` are
  not mistaken for declarations while `<x:sheet>` still counts.

## Testing

`python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 236 tests, all
pass. 13 of them are new: the `#1211` workbook shape (two visible sheets plus a
hidden `Data` sheet), `veryHidden`, a sheet with no `state` attribute, an
all-hidden workbook, a namespace-prefixed declaration, the prefix false
positives above, the committed `issue_1065_hidden_sheet_probe.xlsx` fixture,
and four gate-level cases that stub the raster step so no poppler is needed.

Verified on real files as well, not only in unit tests:

- The unchanged native GT `tests/golden_mocks/business/expected/xlsx/05_project_schedule_en.pdf`
  (1 page) with a hidden lookup sheet added to a copy of its workbook — the
  shape reported in the issue. On `main` the gate prints
  `Worksheets declared by source: 2`, `**INVALID**` and exits 1. On this branch
  it prints 1 printable and 1 hidden worksheet, no structural corruption, and
  exits 0.
- `02_financial_model_en.xlsx` (2 visible sheets) still passes against its
  2-page native GT (exit 0) and still fails (exit 1) when that GT is cut to one
  page with `pdfseparate`.

`scripts/generate_layout_baselines.py`, the only in-repo consumer of `check()`,
reads `invalid` and `periodicity` only and is unaffected; its tests pass.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: the change is confined to `scripts/check_gt_integrity.py`, an audit-time gate that reads a PDF and a workbook and prints a report. No converter code, fixture, or golden baseline is touched, so no rendered PDF differs.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
