### PR TITLE
fix(probes): export Excel chartsheets in workbook order

### DIFF
--- a/scripts/macos/export_excel_pdfs.applescript
+++ b/scripts/macos/export_excel_pdfs.applescript
@@ -19,16 +19,20 @@ on run argv
                     open workbook workbook file name inputPath update links do not update links read only true ignore read only recommended true
                     set openedWorkbook to active workbook
                     set visibleSheetCount to 0
+                    -- Excel keeps worksheets and chart sheets in one workbook-order
+                    -- `sheets` collection. Materialize it once so the PDF suffix is
+                    -- the stable workbook index consumed by the later sorted union.
+                    set workbookSheets to get every sheet of openedWorkbook
 
-                    repeat with sheetIndex from 1 to (count worksheets of openedWorkbook)
-                        set currentSheet to worksheet sheetIndex of openedWorkbook
+                    repeat with sheetIndex from 1 to (count workbookSheets)
+                        set currentSheet to item sheetIndex of workbookSheets
                         if visible of currentSheet is sheet visible then
                             set visibleSheetCount to visibleSheetCount + 1
                             set outputPath to outputDirectory & "/" & outputId & "-sheet-" & my paddedIndex(sheetIndex) & ".pdf"
                             set outputFile to my createEmptyFile(outputPath)
                             -- Excel's PDF save as always exports every visible sheet of the
                             -- workbook, so hiding the others is the only way to scope the
-                            -- export to just this worksheet.
+                            -- export to just this worksheet or chart sheet.
                             set hiddenSheetNames to my hideOtherVisibleSheets(openedWorkbook, name of currentSheet)
                             save as currentSheet filename outputFile file format PDF file format
                             my waitForNonEmptyFile(outputPath)
@@ -36,7 +40,7 @@ on run argv
                         end if
                     end repeat
 
-                    if visibleSheetCount is 0 then error "workbook has no visible worksheets"
+                    if visibleSheetCount is 0 then error "workbook has no visible sheets"
                     close openedWorkbook saving no
                 end timeout
             on error errorMessage number errorNumber

--- a/scripts/tests/test_probe_harness.py
+++ b/scripts/tests/test_probe_harness.py
@@ -28,6 +28,9 @@ import probe_harness
 
 
 SLIDE_XML = '<p:sld><a:bodyPr anchor="t"/><a:spcAft val="1000"/></p:sld>'
+EXCEL_EXPORTER = (
+    Path(__file__).resolve().parent.parent / "macos" / "export_excel_pdfs.applescript"
+)
 
 
 def write_base_package(path: Path, slide_xml: str = SLIDE_XML, extra: dict | None = None) -> None:
@@ -378,6 +381,35 @@ class ExportTest(unittest.TestCase):
         self.assertTrue(str(probe_harness.applescript_for(".xlsx")).endswith("export_excel_pdfs.applescript"))
         with self.assertRaisesRegex(probe_harness.ProbeError, "odt"):
             probe_harness.applescript_for(".odt")
+
+    def test_excel_export_walks_chartsheets_in_workbook_order(self):
+        # The exporter itself requires macOS and Excel, so portable CI pins the
+        # workbook-order enumeration feeding the tested PDF-union path (#1316).
+        source = EXCEL_EXPORTER.read_text()
+        self.assertIn(
+            "set workbookSheets to get every sheet of openedWorkbook",
+            source,
+        )
+        self.assertIn(
+            "repeat with sheetIndex from 1 to (count workbookSheets)",
+            source,
+        )
+        self.assertIn(
+            "set currentSheet to item sheetIndex of workbookSheets",
+            source,
+        )
+        self.assertIn(
+            'outputId & "-sheet-" & my paddedIndex(sheetIndex)',
+            source,
+        )
+        self.assertNotIn("count worksheets of openedWorkbook", source)
+
+    def test_a_visible_chartsheet_satisfies_the_excel_export_contract(self):
+        source = EXCEL_EXPORTER.read_text()
+        self.assertIn(
+            'if visibleSheetCount is 0 then error "workbook has no visible sheets"',
+            source,
+        )
 
     def test_the_office_backend_refuses_an_external_volume_stage(self):
         # The Office sandbox cannot write to external volumes; a save there


### PR DESCRIPTION
## Summary

- Enumerate Excel's materialized `every sheet` collection instead of worksheets only, so visible chart sheets are exported alongside visible worksheets.
- Keep each PDF suffix tied to its workbook sheet index, preserving workbook order through the probe harness's sorted PDF union even when hidden sheets create gaps.
- Add portable contracts to the CI-run probe-harness tests for mixed sheet enumeration, stable suffixes, and chartsheet-only visibility.

## Related issue

Fixes #1316

## Testing

- `python3 -m unittest discover -s scripts/tests -p 'test_probe_harness.py'` — 45 passed
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 238 passed; 30 business golden mocks and the layout-baseline manifest validated
- `osacompile -o <temporary>/export_excel_pdfs.scpt scripts/macos/export_excel_pdfs.applescript`
- Live Microsoft Excel 16.100 acceptance with `tests/fixtures/xlsx/any_sheets.xlsx`, staged inside `~/Library/Containers/com.microsoft.Excel/Data/probes/`:
  - `get name of every sheet of openedWorkbook` returned `Visible`, `Hidden`, `VeryHidden`, `Chart` in that order
  - the exporter produced exactly `audit-sheet-0001.pdf` and `audit-sheet-0004.pdf`
  - PDF inspection identified 0001 as the visible A4 portrait worksheet and 0004 as the visible A4 landscape chartsheet; hidden indices 2 and 3 produced no PDFs
- `git diff --cached --check`
- Required documentation freshness reviewer: PASS after verifying the Excel 16.100 mixed-sheet runtime evidence

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: no parser, model, or renderer changed; this only makes the macOS native-reference/probe exporter include visible chartsheets it previously skipped.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
