### PR TITLE
fix(xlsx): omit malformed raster images

### DIFF
--- a/crates/office2pdf/src/parser/drawingml.rs
+++ b/crates/office2pdf/src/parser/drawingml.rs
@@ -1,11 +1,12 @@
-//! Shared DrawingML color primitives: scheme-color resolution, OOXML color
-//! transforms (tint/shade/lumMod/lumOff/alpha), and the picture transparency
-//! `<a:alphaModFix>` declares.
+//! Shared DrawingML primitives: scheme-color resolution, OOXML color
+//! transforms (tint/shade/lumMod/lumOff/alpha), picture transparency, and
+//! validation of raster media before it reaches the renderer.
 //!
 //! DrawingML color markup (`<a:srgbClr>`, `<a:schemeClr>`, `<a:sysClr>` with
 //! nested transform children) is identical across pptx, docx, and xlsx parts.
 //! This module holds the single implementation; format parsers supply their
-//! own theme palette and alias map through [`SchemeColors`].
+//! own theme palette and alias map through [`SchemeColors`]. Raster picture
+//! parts likewise share one sniff-and-decode validation path here.
 
 use std::collections::HashMap;
 
@@ -14,6 +15,26 @@ use quick_xml::events::{BytesStart, Event};
 
 use crate::ir::{Color, DeclaredFontClass, ImageFormat};
 use crate::parser::xml_util::{get_attr_i64, get_attr_str, parse_hex_color};
+
+/// Detect and fully decode a supported raster image.
+///
+/// OOXML relationship targets are only labels: a `.png` part can still hold
+/// corrupt bytes or bytes in another supported format. Sniffing followed by a
+/// complete decode keeps malformed media out of Typst while preserving the
+/// payload's actual format for both PPTX and XLSX.
+pub(crate) fn validated_raster_format(data: &[u8]) -> Option<ImageFormat> {
+    let detected = image::guess_format(data).ok()?;
+    let format = match detected {
+        image::ImageFormat::Png => ImageFormat::Png,
+        image::ImageFormat::Jpeg => ImageFormat::Jpeg,
+        image::ImageFormat::Gif => ImageFormat::Gif,
+        image::ImageFormat::Bmp => ImageFormat::Bmp,
+        image::ImageFormat::Tiff => ImageFormat::Tiff,
+        _ => return None,
+    };
+    image::load_from_memory_with_format(data, detected).ok()?;
+    Some(format)
+}
 
 /// A format-agnostic view of a theme's color scheme.
 ///

--- a/crates/office2pdf/src/parser/drawingml_tests.rs
+++ b/crates/office2pdf/src/parser/drawingml_tests.rs
@@ -4,7 +4,7 @@ use quick_xml::Reader;
 use quick_xml::events::Event;
 
 use super::*;
-use crate::ir::Color;
+use crate::ir::{Color, ImageFormat};
 
 fn scheme_with(colors: &[(&str, Color)], aliases: &[(&str, &str)]) -> (ColorsMap, AliasMap) {
     let colors: ColorsMap = colors
@@ -20,6 +20,36 @@ fn scheme_with(colors: &[(&str, Color)], aliases: &[(&str, &str)]) -> (ColorsMap
 
 type ColorsMap = HashMap<String, Color>;
 type AliasMap = HashMap<String, String>;
+
+#[test]
+fn supported_raster_formats_survive_sniffing_and_full_decode() {
+    let image = image::DynamicImage::new_rgb8(2, 2);
+    let formats = [
+        (image::ImageFormat::Png, ImageFormat::Png),
+        (image::ImageFormat::Jpeg, ImageFormat::Jpeg),
+        (image::ImageFormat::Gif, ImageFormat::Gif),
+        (image::ImageFormat::Bmp, ImageFormat::Bmp),
+        (image::ImageFormat::Tiff, ImageFormat::Tiff),
+    ];
+
+    for (encoded_format, expected) in formats {
+        let mut encoded = std::io::Cursor::new(Vec::new());
+        image
+            .write_to(&mut encoded, encoded_format)
+            .expect("test raster encodes");
+        assert_eq!(
+            validated_raster_format(&encoded.into_inner()),
+            Some(expected),
+            "{encoded_format:?} must remain supported"
+        );
+    }
+}
+
+#[test]
+fn malformed_raster_is_rejected_even_when_its_signature_is_present() {
+    assert_eq!(validated_raster_format(b"not an image"), None);
+    assert_eq!(validated_raster_format(b"\x89PNG\r\n\x1a\ntruncated"), None);
+}
 
 #[test]
 fn resolve_scheme_color_direct_lookup() {

--- a/crates/office2pdf/src/parser/pptx_package.rs
+++ b/crates/office2pdf/src/parser/pptx_package.rs
@@ -508,7 +508,7 @@ fn normalize_slide_image_asset(target: &str, data: Vec<u8>) -> (Vec<u8>, SlideIm
         if format == ImageFormat::Svg {
             return (data, SlideImageSource::Supported(format));
         }
-        return match validated_raster_format(&data) {
+        return match crate::parser::drawingml::validated_raster_format(&data) {
             Some(actual_format) => (data, SlideImageSource::Supported(actual_format)),
             None => (data, SlideImageSource::Unsupported),
         };
@@ -521,20 +521,6 @@ fn normalize_slide_image_asset(target: &str, data: Vec<u8>) -> (Vec<u8>, SlideIm
     }
 
     (data, SlideImageSource::Unsupported)
-}
-
-fn validated_raster_format(data: &[u8]) -> Option<ImageFormat> {
-    let detected = image::guess_format(data).ok()?;
-    let format = match detected {
-        image::ImageFormat::Png => ImageFormat::Png,
-        image::ImageFormat::Jpeg => ImageFormat::Jpeg,
-        image::ImageFormat::Gif => ImageFormat::Gif,
-        image::ImageFormat::Bmp => ImageFormat::Bmp,
-        image::ImageFormat::Tiff => ImageFormat::Tiff,
-        _ => return None,
-    };
-    image::load_from_memory_with_format(data, detected).ok()?;
-    Some(format)
 }
 
 fn is_image_relationship(rel_type: Option<&str>, target: &str) -> bool {

--- a/crates/office2pdf/src/parser/xlsx.rs
+++ b/crates/office2pdf/src/parser/xlsx.rs
@@ -673,13 +673,13 @@ impl XlsxParser {
         let normal_font = extract_normal_font(data);
 
         let chartsheet_setups = chartsheet::chartsheet_print_setups(data);
+        let mut warnings = Vec::new();
 
         let mut chart_map = extract_charts_with_anchors(data);
-        let mut image_map = extract_images_with_anchors(data);
+        let mut image_map = extract_images_with_anchors(data, &mut warnings);
         let mut text_box_map = extract_text_boxes_with_anchors(data);
 
         let mut chunks = Vec::new();
-        let mut warnings = Vec::new();
 
         for sheet in book.get_sheet_collection() {
             // Sheets the caller excluded by name, and hidden ones nobody
@@ -979,15 +979,15 @@ impl Parser for XlsxParser {
         let normal_font = extract_normal_font(data);
 
         let chartsheet_setups = chartsheet::chartsheet_print_setups(data);
+        let mut warnings = Vec::new();
 
         // Extract charts with anchor positions per sheet
         let mut chart_map = extract_charts_with_anchors(data);
-        let mut image_map = extract_images_with_anchors(data);
+        let mut image_map = extract_images_with_anchors(data, &mut warnings);
         let mut text_box_map = extract_text_boxes_with_anchors(data);
 
         let sheet_count = book.get_sheet_collection().len();
         let mut pages = Vec::with_capacity(sheet_count);
-        let mut warnings = Vec::new();
 
         for sheet in book.get_sheet_collection() {
             // Sheets the caller excluded by name, and hidden ones nobody

--- a/crates/office2pdf/src/parser/xlsx_drawing.rs
+++ b/crates/office2pdf/src/parser/xlsx_drawing.rs
@@ -616,8 +616,13 @@ pub(super) struct RawImageAnchor {
 }
 
 /// Extract anchored pictures per sheet from worksheet drawings.
-/// Metafiles (EMF/WMF) are converted to SVG; unknown formats are skipped.
-pub(super) fn extract_images_with_anchors(data: &[u8]) -> HashMap<String, Vec<RawImageAnchor>> {
+/// Raster parts are sniffed and fully decoded; invalid rasters and unknown
+/// formats are omitted with an unsupported-element warning. Metafiles
+/// (EMF/WMF) are converted to SVG, with conversion failures omitted likewise.
+pub(super) fn extract_images_with_anchors(
+    data: &[u8],
+    warnings: &mut Vec<crate::error::ConvertWarning>,
+) -> HashMap<String, Vec<RawImageAnchor>> {
     let Ok(mut archive) = crate::parser::open_zip(data) else {
         return HashMap::new();
     };
@@ -670,6 +675,10 @@ pub(super) fn extract_images_with_anchors(data: &[u8]) -> HashMap<String, Vec<Ra
                     continue;
                 };
                 let Some((data, format)) = decode_media(&media_path, bytes) else {
+                    warnings.push(crate::error::ConvertWarning::UnsupportedElement {
+                        format: "XLSX".to_string(),
+                        element: format!("image omitted: {media_path}"),
+                    });
                     continue;
                 };
                 // Excel composites a picture carrying `<a:alphaModFix>` onto
@@ -720,11 +729,9 @@ fn decode_media(path: &str, bytes: Vec<u8>) -> Option<(Vec<u8>, crate::ir::Image
     use crate::ir::ImageFormat;
     let extension: String = path.rsplit('.').next().unwrap_or("").to_ascii_lowercase();
     match extension.as_str() {
-        "png" => Some((bytes, ImageFormat::Png)),
-        "jpg" | "jpeg" => Some((bytes, ImageFormat::Jpeg)),
-        "gif" => Some((bytes, ImageFormat::Gif)),
-        "bmp" => Some((bytes, ImageFormat::Bmp)),
-        "tif" | "tiff" => Some((bytes, ImageFormat::Tiff)),
+        "png" | "jpg" | "jpeg" | "gif" | "bmp" | "tif" | "tiff" => {
+            crate::parser::drawingml::validated_raster_format(&bytes).map(|format| (bytes, format))
+        }
         "svg" => Some((bytes, ImageFormat::Svg)),
         "emf" => crate::parser::emf::convert_emf_to_svg(&bytes).map(|svg| (svg, ImageFormat::Svg)),
         "wmf" => crate::parser::wmf::convert_wmf_to_svg(&bytes).map(|svg| (svg, ImageFormat::Svg)),

--- a/crates/office2pdf/src/parser/xlsx_tests.rs
+++ b/crates/office2pdf/src/parser/xlsx_tests.rs
@@ -985,27 +985,28 @@ fn build_drawing_only_sheet_xlsx() -> Vec<u8> {
     let book = umya_spreadsheet::new_file();
     let mut cursor = Cursor::new(Vec::new());
     umya_spreadsheet::writer::xlsx::write_writer(&book, &mut cursor).unwrap();
-    splice_picture_drawing(&cursor.into_inner())
+    splice_picture_drawing(&cursor.into_inner(), &one_pixel_png())
+}
+
+fn one_pixel_png() -> Vec<u8> {
+    let image = image::DynamicImage::new_rgba8(1, 1);
+    let mut encoded = Cursor::new(Vec::new());
+    image
+        .write_to(&mut encoded, image::ImageFormat::Png)
+        .expect("1x1 PNG encodes");
+    encoded.into_inner()
 }
 
 /// Splice `xl/drawings/drawing1.xml` (one twoCellAnchor picture), its rels,
-/// and a 1x1 PNG into a workbook zip, wiring the first worksheet to it.
-fn splice_picture_drawing(data: &[u8]) -> Vec<u8> {
+/// and the supplied PNG media part into a workbook zip, wiring the first
+/// worksheet to it.
+fn splice_picture_drawing(data: &[u8], media: &[u8]) -> Vec<u8> {
     const DRAWING_XML: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:twoCellAnchor><xdr:from><xdr:col>2</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>0</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from><xdr:to><xdr:col>5</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>8</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to><xdr:pic><xdr:nvPicPr><xdr:cNvPr id="2" name="Picture 1"/><xdr:cNvPicPr/></xdr:nvPicPr><xdr:blipFill><a:blip r:embed="rId1"/><a:stretch><a:fillRect/></a:stretch></xdr:blipFill><xdr:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></xdr:spPr></xdr:pic><xdr:clientData/></xdr:twoCellAnchor></xdr:wsDr>"#;
     const DRAWING_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/></Relationships>"#;
     const SHEET_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdDrawing1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/></Relationships>"#;
-    /// Smallest valid PNG: 1x1 RGBA.
-    const PNG_1X1: &[u8] = &[
-        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
-        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F,
-        0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x62, 0x00,
-        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
-        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
-    ];
-
     let mut archive = zip::ZipArchive::new(Cursor::new(data)).expect("readable zip");
     let mut out = zip::ZipWriter::new(Cursor::new(Vec::new()));
     let mut has_sheet_rels = false;
@@ -1063,13 +1064,53 @@ fn splice_picture_drawing(data: &[u8]) -> Vec<u8> {
             "xl/drawings/_rels/drawing1.xml.rels",
             DRAWING_RELS.as_bytes(),
         ),
-        ("xl/media/image1.png", PNG_1X1),
+        ("xl/media/image1.png", media),
     ] {
         out.start_file(path, zip::write::FileOptions::default())
             .expect("writable drawing part");
         std::io::Write::write_all(&mut out, body).expect("writable drawing part body");
     }
     out.finish().expect("finished zip").into_inner()
+}
+
+#[test]
+fn malformed_raster_image_is_omitted_with_warning_and_workbook_still_converts() {
+    let workbook = build_xlsx_bytes("Sheet1", &[("A1", "survives")]);
+    let data = splice_picture_drawing(&workbook, b"not a png");
+
+    let (doc, warnings) = XlsxParser
+        .parse(&data, &ConvertOptions::default())
+        .expect("a malformed picture must not abort XLSX parsing");
+    let page = get_sheet_page(&doc, 0);
+    assert!(
+        page.images.is_empty(),
+        "the malformed picture must not reach the renderer"
+    );
+    assert!(
+        warnings.iter().any(|warning| matches!(
+            warning,
+            ConvertWarning::UnsupportedElement { format, element }
+                if format == "XLSX"
+                    && element.contains("image omitted")
+                    && element.contains("xl/media/image1.png")
+        )),
+        "expected an omission warning naming the malformed media part, got {warnings:?}"
+    );
+
+    let result = crate::convert_bytes(
+        &data,
+        crate::config::Format::Xlsx,
+        &ConvertOptions::default(),
+    )
+    .expect("the workbook must still produce a PDF");
+    assert!(result.pdf.starts_with(b"%PDF-"));
+    assert!(result.warnings.iter().any(|warning| matches!(
+        warning,
+        ConvertWarning::UnsupportedElement { format, element }
+            if format == "XLSX"
+                && element.contains("image omitted")
+                && element.contains("xl/media/image1.png")
+    )));
 }
 
 /// A sheet with no cells must resolve its drawing anchors against the


### PR DESCRIPTION
## Summary

- share raster sniffing and full-decode validation between PPTX and XLSX
- omit malformed XLSX raster parts with an unsupported-element warning naming the media path
- preserve valid PNG, JPEG, GIF, BMP, and TIFF payloads and their detected format
- correct the XLSX test PNG fixture and add an end-to-end malformed-workbook regression

## Related issue

Fixes #1293

## Testing

- red first: `cargo test -p office2pdf --lib malformed_raster_image_is_omitted_with_warning_and_workbook_still_converts -- --nocapture` failed because the malformed picture reached the renderer
- `cargo test -p office2pdf --lib malformed_raster_image_is_omitted_with_warning_and_workbook_still_converts -- --nocapture`
- `cargo test -p office2pdf --lib supported_raster_formats_survive_sniffing_and_full_decode -- --nocapture`
- `cargo test -p office2pdf --lib test_drawing_only_sheet_resolves_anchors_with_normal_font_metric -- --nocapture`
- `cargo test -p office2pdf --lib test_malformed_png_is_omitted_with_warning -- --nocapture`
- `cargo test -p office2pdf --lib raster -- --nocapture`
- `OFFICE2PDF_VALIDATE_PDF=1 cargo test --workspace`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo publish --dry-run -p office2pdf --allow-dirty`
- `cargo fmt --all -- --check`
- `git diff --check`

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: malformed assets previously aborted conversion before a PDF existed; valid raster rendering is unchanged, while an invalid raster is now omitted with a warning.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Documentation freshness audit passed
- [x] Remaining visual deviations each reference an open issue: none for this non-rendering robustness fix
