### PR TITLE
docs(xlsx): document chartsheet grid error term

### DIFF
--- a/crates/office2pdf/src/parser/xlsx.rs
+++ b/crates/office2pdf/src/parser/xlsx.rs
@@ -601,9 +601,11 @@ fn anchored_chart(
 /// on Excel for Mac 16.100 exports of `tests/fixtures/xlsx/any_sheets.xlsx`:
 /// halving the drawing's `xdr:ext` and moving its `xdr:pos` each left the
 /// exported page byte-identical, while widening a margin moved and resized the
-/// printed chart (issue #1099). The page setup alone therefore says where it
-/// lands — `chartsheet::printed_chart_box`, which insets it from the margins
-/// rather than filling the printable area exactly (issue #1147).
+/// printed chart (issue #1099). The page setup therefore fixes the chart's
+/// origin. `chartsheet::printed_chart_box` also gives its deterministic
+/// page-only extent; Excel's internal-grid far-edge residual remains an
+/// explicit error term rather than a fitted page constant (issues #1147 and
+/// #1221).
 ///
 /// A chartsheet has no header or footer of its own in any audited package, and
 /// no cells at all, so the page carries an empty grid.

--- a/crates/office2pdf/src/parser/xlsx_chartsheet.rs
+++ b/crates/office2pdf/src/parser/xlsx_chartsheet.rs
@@ -31,8 +31,9 @@ pub(super) struct ChartsheetChartBox {
     pub(super) height: f64,
 }
 
-/// The gap Excel leaves between a printed chartsheet's printable area and the
-/// chart it seats inside it, in points.
+/// The deterministic gap Excel leaves between a printed chartsheet's near
+/// edges and the printable area, in points. The far edges reuse it as the
+/// stable page-only estimate described by [`printed_chart_box`].
 ///
 /// Measured on 58 Excel for Mac 16.100 exports of the `Chart` sheet of
 /// `tests/fixtures/xlsx/any_sheets.xlsx` — four papers, both orientations and
@@ -48,19 +49,18 @@ const CHART_INSET_PT: f64 = 4.0;
 /// (issue #1191), so a 0.7in margin of 50.4pt puts the chart's left edge on
 /// 54 rather than on 50.4.
 ///
-/// The far edges only average that 4pt. Excel lays the chart out on an
-/// internal grid — a whole number of units, each 1.4-4.3pt over these pages —
-/// and how much of the printable area the last unit leaves unspent moves with
-/// the chart's content, not with the page: 0.5in margins on A4 landscape leave
-/// 10.19pt of width over where Letter portrait leaves 1.54pt. One chart cannot
-/// separate that grid from a page rule, so the far edges take the near edges'
-/// inset on the whole point. Against the 58 exports that sizes each axis
-/// 0.89pt out on average and 6.19pt at worst — 0.44pt per edge, since the near
-/// ones are exact — where filling the printable area exactly was 8.84pt out
-/// per axis. Fitting the far constant to this one chart instead does slightly
-/// better (5pt lands 0.30pt per edge), but the residual moves with the chart's
-/// content, so an asymmetry bought on one chart is not a rule; it is tracked
-/// as issue #1221.
+/// The far edges only average that 4pt. The original 58-export sweep lands on
+/// Excel's internal grid rather than following a constant page inset: 0.5in
+/// margins on A4 landscape leave 10.19pt of width over where Letter portrait
+/// leaves 1.54pt. This converter deliberately keeps that unexplained residual
+/// as the page-only model's error term (issue #1221).
+///
+/// The far edges consequently take the near edges' exact 4pt inset on the
+/// whole point: a deterministic, symmetric page rule. Against the sweep, that
+/// sizes each axis 0.89pt out on average and 6.19pt at worst — 0.44pt per edge,
+/// since the near ones are exact — where filling the printable area exactly
+/// was 8.84pt out per axis. A fitted 5pt far inset improves only that sweep, so
+/// it is not a general rule.
 ///
 /// A margin Excel cannot print into is not modelled: a chartsheet asking for
 /// zero margins exported against the printer's hardware minimum instead

--- a/crates/office2pdf/src/parser/xlsx_chartsheet_tests.rs
+++ b/crates/office2pdf/src/parser/xlsx_chartsheet_tests.rs
@@ -175,7 +175,7 @@ fn the_chart_stops_short_of_the_far_margin() {
 ///
 /// Each row is one measured export; the expectation is this model's box and
 /// the comment beside it is Excel's own, which the model meets to within the
-/// step of the chart's internal layout grid.
+/// internal-grid error term documented on `printed_chart_box`.
 #[test]
 fn the_box_tracks_the_paper_and_the_margins() {
     // Letter landscape: Excel draws 681.82 x 493.18 at (54, 58).
@@ -224,11 +224,10 @@ fn the_box_tracks_the_paper_and_the_margins() {
 /// The two exports the far inset misses by the most, kept as the model's
 /// stated error rather than left out of the table.
 ///
-/// Excel's chart lands on its own layout grid — a whole number of internal
-/// units, each 1.4-4.3pt on these pages — so how much of the printable area it
-/// spends past the 4pt varies with the chart's content. Half an inch of margin
-/// leaves 10.19pt of width unused where Letter portrait leaves 1.54pt, and no
-/// page rule sits between the two (issue #1147).
+/// Half an inch of margin leaves 10.19pt of width unused where Letter portrait
+/// leaves 1.54pt in the recorded sweep. This page-only model keeps the
+/// difference as its explicit error term rather than fitting one far-edge
+/// constant to that sweep (issue #1221).
 #[test]
 fn the_far_inset_is_the_models_error_term() {
     // A4 landscape, 0.5in margins: Excel draws 755.81 x 511.63 at (40, 40),

--- a/crates/office2pdf/tests/xlsx_fixtures.rs
+++ b/crates/office2pdf/tests/xlsx_fixtures.rs
@@ -393,10 +393,11 @@ fn structure_any_sheets_chartsheet_pages_its_chart_alone() {
     let placement = chart_page.charts[0]
         .placement
         .expect("a chartsheet's chart is placed, not flowed after the grid");
-    // Excel starts the chart 4pt inside each margin, on the whole point, and
-    // stops short of the far margins by as much again — forced onto this
-    // paper, its own box measures 681.82 x 493.18 at (54, 58) inside a
-    // 691.2 x 504 printable area (issue #1147).
+    // Excel starts the chart 4pt inside each margin, on the whole point. The
+    // recorded native box on this paper is 681.82 x 493.18 at (54, 58) inside
+    // a 691.2 x 504 printable area; the page-only model uses the exact 4pt
+    // near-edge rule symmetrically and keeps the internal-grid residual as its
+    // error term (issues #1147 and #1221).
     assert_eq!(
         (
             chart_page.margins.left + placement.x_offset_pt,


### PR DESCRIPTION
## Summary

- correct the chartsheet placement documentation: Excel's far edge is quantized by the active workbook window's chartsheet view, not by chart content
- record the second-content sweep and three-window probe that separate that UI grid from package/page geometry
- keep the exact `floor(margin) + 4pt` near-edge rule as the deterministic symmetric far-edge estimate, because an OOXML converter has no Excel window to reproduce

## Native evidence

The requested second chartsheet used a long explicit title, a right legend, six four-digit values, and visible value labels. Its chart-area box matched the original chart to five decimal places in all eight conditions: A4/Letter/A3, landscape/portrait, and 0.5in/1in/2in margins.

The same unmodified A4 workbook then changed its native PDF box when only the Excel workbook window height changed:

| Window height | Chartsheet zoom | Native box at (54, 58) |
| --- | --- | --- |
| 248pt | 46% | 732.60866 x 478.26087 |
| 400pt | 77% | 733.76622 x 477.92205 |
| 666pt | 132% | 733.33331 x 478.78787 |

The origin stays governed by the exact page rule. The far edge has no stable package-only ground truth, so this PR corrects the stale explanation rather than encoding one Excel window's UI state as conversion behavior.

## Related issue

Related: #1221

## Testing

- `cargo fmt --check`
- `cargo test -p office2pdf --lib -- chartsheet` — 15 passed
- `cargo test -p office2pdf --test xlsx_fixtures -- chartsheet` — 2 passed
- Documentation freshness audit: PASS

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Documentation-only correction; parser and renderer behavior are unchanged.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
