### PR TITLE
fix(harness): detect matched text visibility changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,7 +29,7 @@
 - Evidence mode: `fix` <!-- `fix` requires gt/before/after; `defect` requires compare -->
 - Layout audit report: `assets/bugfixes/issue-<!-- N -->/layout-audit.json` <!-- fix mode only -->
 - Layout audit page count: <!-- Pass, or #N references when the report differs -->
-- Layout audit text flow: <!-- Pass, or #N references for missing/extra/reflow or changed-wrap findings -->
+- Layout audit text flow: <!-- Pass, or #N references for missing/extra/reflow, changed-wrap, or painted-visibility findings -->
 - Layout audit large shifts: <!-- Pass, or #N references for shifts above the report threshold -->
 - New follow-up issues found in this audit: <!-- #N, #N or None; create issues before completing the audit -->
 - Model vision findings: <!-- Describe what Codex/Claude saw in the full pages, diff, and crops. Numeric output is insufficient. -->
@@ -58,7 +58,7 @@
 - [ ] Stored progressive JPEG quality 86 assets with metadata stripped
 - [ ] Used Codex/Claude vision to inspect the full GT/output pages, diff, and matched crops
 - [ ] Inspected matched region crops at full resolution
-- [ ] Ran compare_layout.py --audit and dispositioned every large text-instance shift
+- [ ] Ran compare_layout.py --audit and dispositioned every large text-instance shift and painted-visibility mismatch
 - [ ] Ran the 5% fuzz pixel-difference sweep
 - [ ] Inventoried hairlines and border dash styles
 - [ ] Inventoried font weight, italic, and underline emphasis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ This project follows a **6-month rolling MSRV policy** (aligned with [tokio](htt
 
 ## Visual Comparison Workflow
 
-- For visual bug fixes tied to an issue, keep `assets/bugfixes/issue-<number>/gt.jpg`, `before.jpg`, `after.jpg`, and `layout-audit.json` from the same fixture, page set, renderer, and resolution; `before.jpg` captures the pre-fix output, while `after.jpg` and the layout report use the current output. Every fix PR must change `after.jpg` and `layout-audit.json`. Generate the report from the same GT and current-output PDFs used for `gt.jpg` and `after.jpg` with `compare_layout.py --json --audit`; classify page-count, missing/extra/reflow or changed-wrap, and large-shift failures with open issues in the PR's `Visual audit` category fields and matching `Remaining:` rows. Use progressive JPEG quality 86 with metadata stripped, preserve the source pixel dimensions, and verify text and images remain legible for direct GitHub links. Strip first, then re-set the density (`-strip -density 150 -units PixelsPerInch`): the contract check rejects evidence recording under 150 DPI, which stripping alone removes.
+- For visual bug fixes tied to an issue, keep `assets/bugfixes/issue-<number>/gt.jpg`, `before.jpg`, `after.jpg`, and `layout-audit.json` from the same fixture, page set, renderer, and resolution; `before.jpg` captures the pre-fix output, while `after.jpg` and the layout report use the current output. Every fix PR must change `after.jpg` and `layout-audit.json`. Generate the report from the same GT and current-output PDFs used for `gt.jpg` and `after.jpg` with `compare_layout.py --json --audit`; classify page-count, missing/extra/reflow or changed-wrap, painted-visibility, and large-shift failures with open issues in the PR's `Visual audit` category fields and matching `Remaining:` rows. Use progressive JPEG quality 86 with metadata stripped, preserve the source pixel dimensions, and verify text and images remain legible for direct GitHub links. Strip first, then re-set the density (`-strip -density 150 -units PixelsPerInch`): the contract check rejects evidence recording under 150 DPI, which stripping alone removes.
 - **When filing a visual defect issue, attach a side-by-side image (GT left, office2pdf output at filing time right)** rendered from the same page and resolution, committed as `assets/bugfixes/issue-<number>/compare.jpg` (same JPEG rules as above) and embedded in the issue body via a commit-pinned raw URL. For classified fixtures, confirm with the user before publishing the image; the surrounding issue text must still follow the Confidentiality rules.
 
 ### Visual check discipline (harness rules)
@@ -145,8 +145,9 @@ just the pages a screenshot shows.
 2. **Run all four axes**, not one: `compare_layout.py` (geometry, per page),
    `compare_text_layer.py` (what a reader can select), `compare_render.py`
    (colour and pixels), and a page-by-page visual at >=150 DPI.
-   Run the geometry axis with `--audit`; every large text-instance shift it
-   names must be fixed or recorded as a remaining deviation with an open issue.
+   Run the geometry axis with `--audit`; every large text-instance shift or
+   painted-visibility mismatch it names must be fixed or recorded as a
+   remaining deviation with an open issue.
    Do not classify the pixel diff as antialiasing while this audit is failing.
    Source/XML inspection and numeric reports only route attention; they never
    constitute a visual pass. The acting Codex or Claude agent must use its image
@@ -181,8 +182,12 @@ producing the files is not itself inspection.
 
 For layout defects, run `python3 scripts/compare_layout.py <GT.pdf> <output.pdf> --audit`
 first: it matches text lines from `mutool` traces and reports missing/extra/
-re-wrapped lines, spatial-anchor dy, pitch and width drift, and a rect census,
-with GT noise floors built in (`--noise-floor 0.12` Word, `0.5` Excel).
+re-wrapped lines, spatial-anchor dy, pitch and width drift, painted visibility,
+and a rect census, with GT noise floors built in (`--noise-floor 0.12` Word,
+`0.5` Excel). Painted visibility uses trace order and flat-background contrast:
+text covered by a later opaque image/rectangle is `hidden`, same-colour text on
+an opaque flat fill is `low_contrast`, and text that remains visible is
+`painted`.
 Horizontal text uses its true baseline; a rotated or skewed `fill_text` stays
 one visual run and uses the minimum fully transformed glyph x/y as its
 comparable anchor. Its numbers are assertable; pixel counts are only a
@@ -190,8 +195,9 @@ tripwire. Repeated strings are matched as separate spatial instances: a chart
 title and legend both named `Sales` appear as `Sales [1/2]` and `Sales [2/2]`,
 with their own `dx`/`dy`. The audit exits nonzero when any instance moves more
 than 5pt (override with `--large-shift PT` for a justified fixture-specific
-threshold); inspect and track every named instance before marking alignment as
-matching.
+threshold), or when a matched line changes between painted and hidden/low
+contrast; inspect and track every named instance before marking alignment or
+text flow as matching.
 
 **Its width column measures origin-to-origin and so counts invisible trailing
 glyphs.** Word emits a trailing space after a paragraph's last character where

--- a/assets/bugfixes/README.md
+++ b/assets/bugfixes/README.md
@@ -35,8 +35,8 @@ request. In the PR's `Visual audit` section, mark each layout-audit category
 field as `Pass` or list the open issues that classify it. Those issue references
 must also appear in `Remaining:` deviation rows. The gate rejects a claimed pass
 when the report contains a page-count
-difference, missing/extra/reflowed text, changed wraps, or a text shift above
-the configured large-shift threshold.
+difference, missing/extra/reflowed text, changed wraps, a painted-visibility
+mismatch, or a text shift above the configured large-shift threshold.
 
 ## Evidence mode: `defect`
 

--- a/scripts/check_layout_baselines.py
+++ b/scripts/check_layout_baselines.py
@@ -17,8 +17,8 @@ on deltas smaller than the GT's own lattice):
   cases (the Quartz export rounds every advance to a whole point);
 - width percentages move materially only past 0.5%;
 - counts (missing/extra lines, wraps, reflows, deviant lines, large shifts,
-  rect census gap, page parity gap) compare exactly — any increase is a
-  regression.
+  painted-visibility mismatches, rect census gap, page parity gap) compare
+  exactly — any increase is a regression.
 
 Exit status is nonzero only when a regression is found; improvements alone
 exit zero so a fix PR can paste the report as its acceptance evidence.
@@ -51,6 +51,7 @@ COUNT_METRICS = (
     ("wraps", "count"),
     ("reflow", "gt_lines"),
     ("instances", "large_shift_count"),
+    ("visibility", "mismatch_count"),
 )
 PT_METRICS = (
     ("baseline", "mean_abs_dy"),
@@ -108,8 +109,11 @@ def compare_page(
 ) -> list[dict]:
     findings: list[dict] = []
     for section, key in COUNT_METRICS:
-        stored_count = int(stored_vector[section][key])
-        fresh_count = int(fresh_vector[section][key])
+        # Visibility was added additively to schema v2. Baselines recorded by
+        # an older generator carry no section and conservatively mean zero
+        # known mismatches; a fresh finding therefore surfaces as a regression.
+        stored_count = int(stored_vector.get(section, {}).get(key, 0))
+        fresh_count = int(fresh_vector.get(section, {}).get(key, 0))
         if fresh_count != stored_count:
             kind = "regression" if fresh_count > stored_count else "improvement"
             findings.append(

--- a/scripts/check_visual_pr.py
+++ b/scripts/check_visual_pr.py
@@ -48,7 +48,7 @@ INSPECTION_ITEMS = (
     "Stored progressive JPEG quality 86 assets with metadata stripped",
     "Used Codex/Claude vision to inspect the full GT/output pages, diff, and matched crops",
     "Inspected matched region crops at full resolution",
-    "Ran compare_layout.py --audit and dispositioned every large text-instance shift",
+    "Ran compare_layout.py --audit and dispositioned every large text-instance shift and painted-visibility mismatch",
     "Ran the 5% fuzz pixel-difference sweep",
     "Inventoried hairlines and border dash styles",
     "Inventoried font weight, italic, and underline emphasis",
@@ -289,12 +289,14 @@ def layout_audit_categories(report: object) -> dict[str, bool]:
             wraps = page["wraps"]
             reflow = page["reflow"]
             instances = page["instances"]
+            visibility = page.get("visibility", {"mismatch_count": 0})
             counts = (
                 line_counts["missing"],
                 line_counts["extra"],
                 wraps["count"],
                 reflow["gt_lines"],
                 reflow["out_lines"],
+                visibility["mismatch_count"],
                 instances["large_shift_count"],
             )
         except (KeyError, TypeError) as exc:
@@ -302,8 +304,8 @@ def layout_audit_categories(report: object) -> dict[str, bool]:
         if any(type(count) is not int or count < 0 for count in counts):
             raise ValueError(f"page {page_number} finding counts must be non-negative integers")
 
-        has_text_flow_findings |= any(counts[:5])
-        has_large_shifts |= counts[5] > 0
+        has_text_flow_findings |= any(counts[:6])
+        has_large_shifts |= counts[6] > 0
 
     return {
         "page count": gt_pages != out_pages,

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -11,6 +11,9 @@ lines by their text, and reports typed deviations:
   pitch deltas between consecutive matched lines. Horizontal text uses its
   true baseline; a rotated or skewed `fill_text` stays one visual run and uses
   the minimum fully transformed glyph x/y as its comparable anchor;
+- painted visibility from trace order: text covered by a later opaque image or
+  rectangular fill, or painted with the same colour as a flat background, is
+  distinguished from text that remains visibly painted;
 - a fill/stroke rect census with nearest-match position deltas.
 
 A noise floor (default 0.12pt — native Word exports quantise coordinates to a
@@ -51,14 +54,20 @@ GLYPH_RE = re.compile(
     r'<g unicode="([^"]*)" glyph="[^"]*" x="([-0-9.e]+)" y="([-0-9.e]+)" adv="([-0-9.e]+)"'
 )
 PATH_RE = re.compile(r"<(fill_path|stroke_path)\b([^>]*)>(.*?)</\1>", re.S)
+FILL_IMAGE_RE = re.compile(r"<fill_image\b([^>]*)/>", re.S)
 POINT_RE = re.compile(r'<(?:moveto|lineto|curveto)[^>]*x="([-0-9.e]+)" y="([-0-9.e]+)"')
 TRANSFORM_RE = re.compile(
     r'transform="([-0-9.e]+) ([-0-9.e]+) ([-0-9.e]+) ([-0-9.e]+) ([-0-9.e]+) ([-0-9.e]+)"'
 )
 TRM_RE = re.compile(r'trm="([-0-9.e]+) ')
+ALPHA_RE = re.compile(r'alpha="([-0-9.e]+)"')
+COLOR_RE = re.compile(r'color="([-0-9.e ]+)"')
 
 LINE_Y_TOLERANCE_PT = 0.6
 RECT_MATCH_RADIUS_PT = 6.0
+OPAQUE_ALPHA = 0.98
+INVISIBLE_ALPHA = 0.02
+LOW_CONTRAST_CHANNEL_DELTA = 0.04
 XML_ESCAPES = {"&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&apos;": "'"}
 
 
@@ -69,6 +78,23 @@ class Glyph:
     unicode: str
     size: float
     advance: float
+    paint_index: int = -1
+    color: tuple[float, float, float] | None = None
+    alpha: float = 1.0
+
+
+@dataclass(frozen=True)
+class Paint:
+    """One later operation that can determine whether text remains visible."""
+
+    index: int
+    kind: str  # "flat" | "image"
+    x0: float
+    y0: float
+    x1: float
+    y1: float
+    alpha: float
+    color: tuple[float, float, float] | None = None
 
 
 @dataclass(frozen=True)
@@ -88,6 +114,7 @@ class Rect:
 class Line:
     y: float
     glyphs: list[Glyph] = field(default_factory=list)
+    visibility: str = "painted"
 
     @property
     def text(self) -> str:
@@ -115,6 +142,7 @@ class Line:
 class PageLayout:
     lines: list[Line]
     rects: list[Rect]
+    paints: list[Paint] = field(default_factory=list)
 
 
 def unescape(text: str) -> str:
@@ -130,17 +158,141 @@ def parse_transform(attrs: str) -> tuple[float, float, float, float, float, floa
     return tuple(float(value) for value in match.groups())  # type: ignore[return-value]
 
 
+def parse_alpha(attrs: str) -> float:
+    match = ALPHA_RE.search(attrs)
+    return float(match.group(1)) if match else 1.0
+
+
+def parse_rgb(attrs: str) -> tuple[float, float, float] | None:
+    """Return a comparable RGB colour for trace operations when available."""
+    match = COLOR_RE.search(attrs)
+    if not match:
+        return None
+    values = [float(value) for value in match.group(1).split()]
+    if len(values) == 1:
+        return (values[0], values[0], values[0])
+    if len(values) == 3:
+        return (values[0], values[1], values[2])
+    if len(values) == 4:
+        cyan, magenta, yellow, black = values
+        return (
+            1.0 - min(1.0, cyan + black),
+            1.0 - min(1.0, magenta + black),
+            1.0 - min(1.0, yellow + black),
+        )
+    return None
+
+
+def transformed_bbox(
+    transform: tuple[float, float, float, float, float, float],
+    points: list[tuple[float, float]],
+) -> tuple[float, float, float, float]:
+    a, b, c, d, e, f = transform
+    transformed = [(a * x + c * y + e, b * x + d * y + f) for x, y in points]
+    xs = [point[0] for point in transformed]
+    ys = [point[1] for point in transformed]
+    return min(xs), min(ys), max(xs), max(ys)
+
+
+def is_axis_aligned_rect(points: list[tuple[float, float]]) -> bool:
+    """Conservatively recognise only fills whose points are all bbox corners."""
+    if len(points) < 4:
+        return False
+    xs = {round(point[0], 6) for point in points}
+    ys = {round(point[1], 6) for point in points}
+    corners = {(x, y) for x in xs for y in ys}
+    actual = {(round(x, 6), round(y, 6)) for x, y in points}
+    return len(xs) == 2 and len(ys) == 2 and corners.issubset(actual)
+
+
+def paint_covers(
+    paint: Paint, bbox: tuple[float, float, float, float], tolerance: float = 0.05
+) -> bool:
+    x0, y0, x1, y1 = bbox
+    return (
+        paint.x0 <= x0 + tolerance
+        and paint.y0 <= y0 + tolerance
+        and paint.x1 >= x1 - tolerance
+        and paint.y1 >= y1 - tolerance
+    )
+
+
+def glyph_bbox(glyph: Glyph) -> tuple[float, float, float, float]:
+    """A conservative device-space ink box around one horizontal glyph."""
+    return (
+        glyph.x,
+        glyph.y - glyph.size,
+        glyph.x + max(glyph.advance, glyph.size * 0.25),
+        glyph.y + glyph.size * 0.25,
+    )
+
+
+def glyph_visibility(glyph: Glyph, paints: list[Paint]) -> str:
+    if glyph.alpha <= INVISIBLE_ALPHA:
+        return "hidden"
+    bbox = glyph_bbox(glyph)
+    if any(
+        paint.index > glyph.paint_index
+        and paint.alpha >= OPAQUE_ALPHA
+        and paint_covers(paint, bbox)
+        for paint in paints
+    ):
+        return "hidden"
+
+    background = next(
+        (
+            paint
+            for paint in reversed(paints)
+            if paint.index < glyph.paint_index
+            and paint_covers(paint, bbox)
+        ),
+        None,
+    )
+    if (
+        glyph.color is not None
+        and background is not None
+        and background.kind == "flat"
+        and background.alpha >= OPAQUE_ALPHA
+        and background.color is not None
+    ):
+        channel_delta = max(
+            abs(channel - backdrop)
+            for channel, backdrop in zip(glyph.color, background.color)
+        )
+        if channel_delta <= LOW_CONTRAST_CHANNEL_DELTA:
+            return "low_contrast"
+    return "painted"
+
+
+def classify_line_visibility(line: Line, paints: list[Paint]) -> str:
+    states = [
+        glyph_visibility(glyph, paints)
+        for glyph in line.glyphs
+        if not glyph.unicode.isspace()
+    ]
+    if not states:
+        return "painted"
+    if all(state == "hidden" for state in states):
+        return "hidden"
+    if all(state in {"hidden", "low_contrast"} for state in states):
+        return "low_contrast"
+    return "painted"
+
+
 def parse_trace(trace_xml: str) -> list[PageLayout]:
     pages: list[PageLayout] = []
     for page_match in PAGE_RE.finditer(trace_xml):
         content = page_match.group(1)
         glyphs: list[Glyph] = []
         rotated_lines: list[Line] = []
-        for op_attrs, op_body in FILL_TEXT_RE.findall(content):
+        for op_match in FILL_TEXT_RE.finditer(content):
+            op_attrs, op_body = op_match.groups()
             transform = parse_transform(op_attrs)
             if transform is None:
                 continue
             a, b, c, d, e, f = transform
+            color = parse_rgb(op_attrs)
+            alpha = parse_alpha(op_attrs)
             transformed_run: list[Glyph] = []
             for span_attrs, span_body in SPAN_RE.findall(op_body):
                 trm = TRM_RE.search(span_attrs)
@@ -156,6 +308,9 @@ def parse_trace(trace_xml: str) -> list[PageLayout]:
                             unicode=unescape(unicode_char),
                             size=size_pt,
                             advance=abs(float(adv) * size_units * a),
+                            paint_index=op_match.start(),
+                            color=color,
+                            alpha=alpha,
                         )
                     )
             if not transformed_run:
@@ -174,7 +329,9 @@ def parse_trace(trace_xml: str) -> list[PageLayout]:
             else:
                 glyphs.extend(transformed_run)
         rects: list[Rect] = []
-        for kind, op_attrs, op_body in PATH_RE.findall(content):
+        paints: list[Paint] = []
+        for op_match in PATH_RE.finditer(content):
+            kind, op_attrs, op_body = op_match.groups()
             transform = parse_transform(op_attrs) or (1, 0, 0, 1, 0, 0)
             a, b, c, d, e, f = transform
             xs: list[float] = []
@@ -194,10 +351,53 @@ def parse_trace(trace_xml: str) -> list[PageLayout]:
                         y1=max(ys),
                     )
                 )
+                transformed_points = list(zip(xs, ys))
+                if kind == "fill_path" and "<curveto" not in op_body and is_axis_aligned_rect(
+                    transformed_points
+                ):
+                    paints.append(
+                        Paint(
+                            index=op_match.start(),
+                            kind="flat",
+                            x0=min(xs),
+                            y0=min(ys),
+                            x1=max(xs),
+                            y1=max(ys),
+                            alpha=parse_alpha(op_attrs),
+                            color=parse_rgb(op_attrs),
+                        )
+                    )
+        for op_match in FILL_IMAGE_RE.finditer(content):
+            op_attrs = op_match.group(1)
+            transform = parse_transform(op_attrs)
+            if transform is None:
+                continue
+            a, b, c, d, _, _ = transform
+            # A rotated image's axis-aligned bbox can include areas it never
+            # paints, so only use rectangular page/background images here.
+            if abs(b) > 1e-9 or abs(c) > 1e-9:
+                continue
+            x0, y0, x1, y1 = transformed_bbox(
+                transform, [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+            )
+            paints.append(
+                Paint(
+                    index=op_match.start(),
+                    kind="image",
+                    x0=x0,
+                    y0=y0,
+                    x1=x1,
+                    y1=y1,
+                    alpha=parse_alpha(op_attrs),
+                )
+            )
+        paints.sort(key=lambda paint: paint.index)
         lines = build_lines(glyphs)
         lines.extend(rotated_lines)
+        for line in lines:
+            line.visibility = classify_line_visibility(line, paints)
         lines.sort(key=lambda line: (line.y, line.x0))
-        pages.append(PageLayout(lines=lines, rects=rects))
+        pages.append(PageLayout(lines=lines, rects=rects, paints=paints))
     return pages
 
 
@@ -330,12 +530,15 @@ def diff_page(
         for index, line in enumerate(ordered_occurrences, start=1):
             occurrence_by_id[id(line)] = (index, len(ordered_occurrences))
 
-    instances: list[dict] = []
-    for gt_line, out_line in matches:
-        occurrence, occurrence_count = occurrence_by_id[id(gt_line)]
-        label = gt_line.key[:60]
+    def instance_label(line: Line) -> str:
+        occurrence, occurrence_count = occurrence_by_id[id(line)]
+        label = line.key[:60]
         if occurrence_count > 1:
             label = f"{label} [{occurrence}/{occurrence_count}]"
+        return label
+
+    instances: list[dict] = []
+    for gt_line, out_line in matches:
         width_pct = (
             (out_line.width - gt_line.width) / gt_line.width * 100
             if gt_line.width > 1.0
@@ -343,7 +546,7 @@ def diff_page(
         )
         instances.append(
             {
-                "label": label,
+                "label": instance_label(gt_line),
                 "gt_x": gt_line.x0,
                 "gt_y": gt_line.y,
                 "out_x": out_line.x0,
@@ -353,6 +556,15 @@ def diff_page(
                 "width_pct": width_pct,
             }
         )
+    visibility_mismatches = [
+        {
+            "label": instance_label(gt_line),
+            "gt": gt_line.visibility,
+            "out": out_line.visibility,
+        }
+        for gt_line, out_line in matches
+        if (gt_line.visibility == "painted") != (out_line.visibility == "painted")
+    ]
     large_shifts = [
         instance
         for instance in instances
@@ -427,6 +639,10 @@ def diff_page(
             "large_shift_count": len(large_shifts),
             "large_shifts": large_shifts,
         },
+        "visibility": {
+            "mismatch_count": len(visibility_mismatches),
+            "mismatches": visibility_mismatches,
+        },
         "pitch": {"pairs": len(pitch_deltas), "worst_delta": abs(stats(pitch_deltas)["worst"])},
         "wraps": {"count": len(wraps), "samples": wraps[:5]},
         "reflow": reflow,
@@ -481,6 +697,16 @@ def render_reading(vectors: list[dict]) -> str:
                 f"past {vector['instances']['large_shift_threshold']:.2f}pt: {examples}. "
                 "These are layout differences, not antialiasing; inspect and track each one"
             )
+        if vector["visibility"]["mismatch_count"]:
+            examples = "; ".join(
+                f"'{item['label']}' GT {item['gt']} vs output {item['out']}"
+                for item in vector["visibility"]["mismatches"]
+            )
+            page_notes.append(
+                f"{vector['visibility']['mismatch_count']} matched text instance(s) differ in "
+                f"painted visibility: {examples}. Check z-order, opacity, or foreground/background "
+                "contrast"
+            )
         if vector["pitch"]["worst_delta"] > vector["noise_floor"]:
             page_notes.append(
                 f"line pitch drifts up to {vector['pitch']['worst_delta']:.2f}pt — "
@@ -503,6 +729,7 @@ def audit_failures(vectors: list[dict]) -> int:
     """Count material text findings that require visual disposition."""
     return sum(
         vector["instances"]["large_shift_count"]
+        + vector["visibility"]["mismatch_count"]
         + vector["lines"]["missing"]
         + vector["lines"]["extra"]
         + vector["wraps"]["count"]
@@ -547,7 +774,7 @@ def main() -> int:
         action="store_true",
         help=(
             "exit nonzero on missing/extra/reflowed text, changed wraps, "
-            "a large instance shift, or a page-count mismatch"
+            "a painted-visibility mismatch, a large instance shift, or a page-count mismatch"
         ),
     )
     parser.add_argument("--json", action="store_true", help="emit the deviation vectors as JSON")
@@ -579,7 +806,12 @@ def main() -> int:
     ]
 
     if args.json:
-        print(json.dumps({"pages": vectors, "gt_pages": len(gt_pages), "out_pages": len(out_pages)}, indent=1))
+        print(
+            json.dumps(
+                {"pages": vectors, "gt_pages": len(gt_pages), "out_pages": len(out_pages)},
+                indent=1,
+            )
+        )
         if args.audit and (audit_failures(vectors) or len(gt_pages) != len(out_pages)):
             return 1
         return 0
@@ -597,6 +829,7 @@ def main() -> int:
             f"pitch worst {vector['pitch']['worst_delta']:.2f}pt | "
             f"width worst {vector['width']['worst_pct']:.1f}% | "
             f"large shifts {vector['instances']['large_shift_count']} | "
+            f"visibility {vector['visibility']['mismatch_count']} | "
             f"rects {vector['rects']['gt_count']}/{vector['rects']['out_count']}"
         )
     print()

--- a/scripts/generate_layout_baselines.py
+++ b/scripts/generate_layout_baselines.py
@@ -11,7 +11,8 @@ For every case in ``tests/golden_mocks/business/manifest.json`` this pipeline:
    ``compare_layout`` deviation vector for every page, using the per-format
    noise floor (0.12pt for Word/PowerPoint GT, whose exports quantise to a
    0.24pt grid; 0.5pt for Excel GT, whose Quartz export rounds every advance
-   to a whole point).
+   to a whole point), including painted-visibility mismatches caused by
+   z-order or flat-background contrast.
 
 A trace that parses to zero pages is a hard failure, never an empty vector: on
 mutool 1.23.x that state used to look exactly like a perfect comparison
@@ -156,6 +157,10 @@ def build_baseline_document(
         "extra_lines": sum(vector["lines"]["extra"] for vector in pages),
         "deviant_lines": sum(vector["lines"]["deviant"] for vector in pages),
         "large_shifts": sum(vector["instances"]["large_shift_count"] for vector in pages),
+        "visibility_mismatches": sum(
+            vector.get("visibility", {"mismatch_count": 0})["mismatch_count"]
+            for vector in pages
+        ),
     }
     return {
         "schema_version": SCHEMA_VERSION,
@@ -230,11 +235,16 @@ def main() -> int:
                     build_case_record(case, args.office2pdf, corpus_root, Path(scratch))
                 )
                 record = case_records[-1]
+                visibility_mismatches = sum(
+                    vector.get("visibility", {"mismatch_count": 0})["mismatch_count"]
+                    for vector in record["pages"]
+                )
                 print(
                     f"{record['id']}: {record['out_pages']}/{record['gt_pages']} pages, "
                     f"{sum(v['lines']['missing'] for v in record['pages'])} missing, "
                     f"{sum(v['instances']['large_shift_count'] for v in record['pages'])} "
-                    "large shifts"
+                    "large shifts, "
+                    f"{visibility_mismatches} visibility mismatches"
                 )
     except BaselineError as error:
         print(f"baseline generation failed: {error}", file=sys.stderr)

--- a/scripts/probe_harness.py
+++ b/scripts/probe_harness.py
@@ -389,6 +389,11 @@ def layout_identical_failures(report: dict) -> list[str]:
             failures.append(
                 f"page {index}: {vector['instances']['large_shift_count']} large shift(s)"
             )
+        visibility = vector.get("visibility", {"mismatch_count": 0})
+        if visibility["mismatch_count"]:
+            failures.append(
+                f"page {index}: {visibility['mismatch_count']} visibility mismatch(es)"
+            )
         rects = vector["rects"]
         if rects["gt_count"] != rects["out_count"]:
             failures.append(f"page {index}: rects {rects['gt_count']} vs {rects['out_count']}")
@@ -443,6 +448,10 @@ def variant_row(value: str, patched: int, report: dict) -> dict:
         "worst_pitch": max((vector["pitch"]["worst_delta"] for vector in vectors), default=0.0),
         "worst_width": max((vector["width"]["worst_pct"] for vector in vectors), default=0.0),
         "large_shifts": sum(vector["instances"]["large_shift_count"] for vector in vectors),
+        "visibility": sum(
+            vector.get("visibility", {"mismatch_count": 0})["mismatch_count"]
+            for vector in vectors
+        ),
         "rects": "{}/{}".format(
             sum(vector["rects"]["gt_count"] for vector in vectors),
             sum(vector["rects"]["out_count"] for vector in vectors),
@@ -465,6 +474,7 @@ def render_table(spec: Spec, backend: str, control_verdict: str, rows: list[dict
         "worst pitch (pt)",
         "worst width (%)",
         "large shifts",
+        "visibility",
         "rects",
     )
     lines = [
@@ -493,6 +503,7 @@ def render_table(spec: Spec, backend: str, control_verdict: str, rows: list[dict
             f"{row['worst_pitch']:.2f}",
             f"{row['worst_width']:.1f}",
             str(row["large_shifts"]),
+            str(row["visibility"]),
             row["rects"],
         )
         lines.append("| " + " | ".join(cells) + " |")

--- a/scripts/tests/test_check_layout_baselines.py
+++ b/scripts/tests/test_check_layout_baselines.py
@@ -42,6 +42,7 @@ def page_vector(**overrides: object) -> dict:
             "large_shift_count": 0,
             "large_shifts": [],
         },
+        "visibility": {"mismatch_count": 0, "mismatches": []},
         "pitch": {"pairs": 9, "worst_delta": 0.3},
         "wraps": {"count": 0, "samples": []},
         "reflow": {"gt_lines": 0, "out_lines": 0, "samples": []},
@@ -157,6 +158,15 @@ class CountTests(unittest.TestCase):
         findings = checker.compare_baselines(stored, fresh)
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0]["kind"], "improvement")
+
+    def test_visibility_mismatch_increase_is_a_regression(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["pages"][0]["visibility"]["mismatch_count"] = 1
+        findings = checker.compare_baselines(stored, fresh)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["kind"], "regression")
+        self.assertEqual(findings[0]["metric"], "visibility.mismatch_count")
 
     def test_rect_census_gap_widening_is_a_regression(self) -> None:
         stored = baseline_document()

--- a/scripts/tests/test_check_visual_pr.py
+++ b/scripts/tests/test_check_visual_pr.py
@@ -86,6 +86,7 @@ def layout_report(
     reflow_gt=0,
     reflow_out=0,
     large_shifts=0,
+    visibility=0,
 ):
     return {
         "pages": [
@@ -94,6 +95,7 @@ def layout_report(
                 "wraps": {"count": wraps},
                 "reflow": {"gt_lines": reflow_gt, "out_lines": reflow_out},
                 "instances": {"large_shift_count": large_shifts},
+                "visibility": {"mismatch_count": visibility},
             }
         ],
         "gt_pages": gt_pages,
@@ -162,16 +164,16 @@ class PullRequestBodyTests(unittest.TestCase):
         )
         self.assertTrue(any("rendered preview" in error for error in errors))
 
-    def test_visual_audit_requires_large_instance_shift_audit(self):
+    def test_visual_audit_requires_layout_finding_disposition(self):
         required = (
             "- [x] Ran compare_layout.py --audit and dispositioned every "
-            "large text-instance shift"
+            "large text-instance shift and painted-visibility mismatch"
         )
         errors = validate_pr_body(
             visual_body().replace(required, required.replace("[x]", "[ ]")),
             ["assets/bugfixes/issue-186/after.jpg"],
         )
-        self.assertTrue(any("large text-instance shift" in error for error in errors))
+        self.assertTrue(any("painted-visibility mismatch" in error for error in errors))
 
     def test_visual_audit_requires_model_vision_inspection(self):
         required = (
@@ -305,6 +307,15 @@ class LayoutAuditTests(unittest.TestCase):
             layout_report(large_shifts=5),
         )
         self.assertTrue(any("large shifts" in error and "issue reference" in error for error in errors))
+
+    def test_visibility_failure_rejects_pass_text_flow_disposition(self):
+        errors = validate_report(
+            visual_body(),
+            layout_report(visibility=1),
+        )
+        self.assertTrue(
+            any("text flow" in error and "issue reference" in error for error in errors)
+        )
 
     def test_failed_categories_accept_remaining_issue_references(self):
         body = visual_body(

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -69,16 +69,32 @@ def line_of(text: str, x0: float, baseline_y: float, pitch: float = 6.0) -> str:
     return text_op(words, baseline_y)
 
 
-def rect_op(x0: float, y0: float, x1: float, y1: float, kind: str = "fill_path") -> str:
+def rect_op(
+    x0: float,
+    y0: float,
+    x1: float,
+    y1: float,
+    kind: str = "fill_path",
+    color: str = ".8 .8 .8",
+    alpha: float = 1.0,
+) -> str:
     extra = ' winding="nonzero"' if kind == "fill_path" else ' linewidth="1"'
     return (
-        f'<{kind}{extra} colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".8 .8 .8" '
-        f'ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 841.92">\n'
+        f'<{kind}{extra} colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color="{color}" '
+        f'alpha="{alpha}" ri="1" bp="1" op="0" opm="0" '
+        f'transform="1 0 0 -1 0 841.92">\n'
         f'<moveto x="{x0}" y="{841.92 - y0}"/>\n'
         f'<lineto x="{x1}" y="{841.92 - y0}"/>\n'
         f'<lineto x="{x1}" y="{841.92 - y1}"/>\n'
         f'<lineto x="{x0}" y="{841.92 - y1}"/>\n'
         f"<closepath/>\n</{kind}>"
+    )
+
+
+def image_op() -> str:
+    return (
+        '<fill_image alpha="1" colorspace="DeviceRGB" ri="1" bp="1" op="0" opm="0" '
+        'transform="595.2 0 0 841.92 0 0" width="1280" height="720"/>'
     )
 
 
@@ -288,6 +304,74 @@ class MatchAndDiffTest(unittest.TestCase):
             [120, -27],
         )
         self.assertEqual(compare_layout.audit_failures([vector]), 2)
+
+    def test_same_text_hidden_by_later_image_reports_visibility_mismatch(self) -> None:
+        text = line_of("Slide9", 72, 100)
+        gt = "\n".join([text, image_op()])
+        out = "\n".join([image_op(), text])
+
+        vector = self.diff(gt, out)
+
+        self.assertEqual(vector["lines"]["matched"], 1)
+        self.assertEqual(vector["visibility"]["mismatch_count"], 1)
+        self.assertEqual(
+            vector["visibility"]["mismatches"][0],
+            {"label": "Slide9", "gt": "hidden", "out": "painted"},
+        )
+        self.assertEqual(compare_layout.audit_failures([vector]), 1)
+
+    def test_same_color_text_on_flat_fill_reports_low_contrast(self) -> None:
+        background = rect_op(0, 0, 595.2, 841.92, color=".8 .8 .8")
+        gt = "\n".join(
+            [
+                background,
+                line_of("Muted", 72, 100).replace(
+                    'color="0 0 0"', 'color=".8 .8 .8"'
+                ),
+            ]
+        )
+        out = "\n".join([background, line_of("Muted", 72, 100)])
+
+        vector = self.diff(gt, out)
+
+        self.assertEqual(vector["visibility"]["mismatch_count"], 1)
+        self.assertEqual(
+            vector["visibility"]["mismatches"][0],
+            {"label": "Muted", "gt": "low_contrast", "out": "painted"},
+        )
+
+    def test_later_opaque_rectangle_hides_text(self) -> None:
+        text = line_of("Covered", 72, 100)
+        cover = rect_op(60, 80, 150, 110)
+
+        vector = self.diff("\n".join([text, cover]), "\n".join([cover, text]))
+
+        self.assertEqual(vector["visibility"]["mismatch_count"], 1)
+        self.assertEqual(vector["visibility"]["mismatches"][0]["gt"], "hidden")
+
+    def test_later_translucent_rectangle_does_not_hide_text(self) -> None:
+        text = line_of("Tinted", 72, 100)
+        tint = rect_op(60, 80, 150, 110, alpha=0.5)
+
+        vector = self.diff("\n".join([text, tint]), "\n".join([tint, text]))
+
+        self.assertEqual(vector["visibility"]["mismatch_count"], 0)
+
+    def test_minor_text_color_substitution_is_not_a_visibility_mismatch(self) -> None:
+        background = rect_op(0, 0, 595.2, 841.92, color="1 1 1")
+        gt = "\n".join([background, line_of("Stable", 72, 100)])
+        out = "\n".join(
+            [
+                background,
+                line_of("Stable", 72, 100).replace(
+                    'color="0 0 0"', 'color=".02 .02 .02"'
+                ),
+            ]
+        )
+
+        vector = self.diff(gt, out)
+
+        self.assertEqual(vector["visibility"]["mismatch_count"], 0)
 
 
 class ReadingTest(unittest.TestCase):

--- a/scripts/tests/test_generate_layout_baselines.py
+++ b/scripts/tests/test_generate_layout_baselines.py
@@ -180,6 +180,7 @@ class DocumentTests(unittest.TestCase):
                 {
                     "lines": {"missing": 1, "extra": 0, "matched": 5, "deviant": 2},
                     "instances": {"large_shift_count": 1},
+                    "visibility": {"mismatch_count": 2},
                 }
             ],
         }
@@ -197,6 +198,7 @@ class DocumentTests(unittest.TestCase):
         self.assertEqual(summary["pages_compared"], 1)
         self.assertEqual(summary["missing_lines"], 1)
         self.assertEqual(summary["large_shifts"], 1)
+        self.assertEqual(summary["visibility_mismatches"], 2)
 
     def test_serialisation_is_deterministic(self) -> None:
         record = {

--- a/scripts/tests/test_probe_harness.py
+++ b/scripts/tests/test_probe_harness.py
@@ -71,6 +71,7 @@ def page_vector(
     wraps: int = 0,
     reflow: int = 0,
     large_shifts: int = 0,
+    visibility: int = 0,
     mean_abs_dy: float = 0.0,
     worst_dy: float = 0.0,
     worst_pitch: float = 0.0,
@@ -102,6 +103,7 @@ def page_vector(
             "large_shift_count": large_shifts,
             "large_shifts": [],
         },
+        "visibility": {"mismatch_count": visibility, "mismatches": []},
         "pitch": {"pairs": max(matched - 1, 0), "worst_delta": worst_pitch},
         "wraps": {"count": wraps, "samples": []},
         "reflow": {"gt_lines": reflow, "out_lines": reflow},
@@ -671,12 +673,44 @@ class ControlGateTest(unittest.TestCase):
             with self.assertRaisesRegex(probe_harness.ProbeError, "page"):
                 probe_harness.verify_control(tmp / "base.pdf", tmp / "control.pdf", runner=runner)
 
+    def test_a_control_visibility_mismatch_aborts_the_run(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "base.pdf").write_bytes(b"%PDF a")
+            (tmp / "control.pdf").write_bytes(b"%PDF b")
+
+            def runner(argv):
+                return completed(
+                    argv,
+                    stdout=json.dumps(differ_report(page_vector(visibility=1))),
+                )
+
+            with self.assertRaisesRegex(probe_harness.ProbeError, "visibility"):
+                probe_harness.verify_control(tmp / "base.pdf", tmp / "control.pdf", runner=runner)
+
 
 class RowTest(unittest.TestCase):
     def test_multi_page_reports_sum_counts_and_keep_worst_magnitudes(self):
         report = differ_report(
-            page_vector(matched=10, missing=1, wraps=1, mean_abs_dy=0.2, worst_dy=-0.5, worst_pitch=0.3),
-            page_vector(matched=30, extra=2, deviant=3, mean_abs_dy=0.6, worst_dy=1.4, worst_pitch=0.1, rects=(4, 5)),
+            page_vector(
+                matched=10,
+                missing=1,
+                wraps=1,
+                visibility=1,
+                mean_abs_dy=0.2,
+                worst_dy=-0.5,
+                worst_pitch=0.3,
+            ),
+            page_vector(
+                matched=30,
+                extra=2,
+                deviant=3,
+                visibility=2,
+                mean_abs_dy=0.6,
+                worst_dy=1.4,
+                worst_pitch=0.1,
+                rects=(4, 5),
+            ),
         )
         row = probe_harness.variant_row("500", 1, report)
         self.assertEqual(row["value"], "500")
@@ -687,6 +721,7 @@ class RowTest(unittest.TestCase):
         self.assertEqual(row["extra"], 2)
         self.assertEqual(row["wraps"], 1)
         self.assertEqual(row["deviant"], 3)
+        self.assertEqual(row["visibility"], 3)
         self.assertAlmostEqual(row["mean_abs_dy"], (0.2 * 10 + 0.6 * 30) / 40)
         self.assertAlmostEqual(row["worst_dy"], 1.4)
         self.assertAlmostEqual(row["worst_pitch"], 0.3)


### PR DESCRIPTION
## Summary

- classify matched PDF text as painted, hidden by a later opaque image/rectangle, or low-contrast on an opaque flat fill
- report painted-visibility mismatches through `compare_layout.py --audit`, baseline comparison, probe control gates, and the Visual PR Contract
- keep older schema-v2 baselines compatible while treating every fresh visibility finding as a regression
- document the new disposition requirement and add focused z-order, opacity, contrast, noise, and integration tests

## Related issue

Fixes #1422

## Testing

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (262 passed)
- `python3 -m py_compile scripts/compare_layout.py scripts/check_visual_pr.py scripts/probe_harness.py scripts/generate_layout_baselines.py scripts/check_layout_baselines.py`
- `git diff --check`
- `python3 scripts/compare_layout.py supplied-libreoffice.pdf office2pdf.pdf --page 9 --audit --json`
  - reports exactly one matched visibility finding: slide number `9`, GT `hidden` vs output `painted`
- `python3 scripts/compare_layout.py native-powerpoint.pdf office2pdf.pdf --page 9 --audit --json`
  - reports no painted-visibility mismatch, preserving reference provenance
- mandatory documentation freshness review: `PASS`

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Harness, tests, and workflow documentation only; exported PDF rendering is unchanged.

## Checklist

- [x] Commit includes a `Signed-off-by` line
- [x] PR scope contains one root cause