### PR TITLE
fix(harness): detect clipped shading occlusion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,8 +186,9 @@ first: it matches text lines from `mutool` traces and reports missing/extra/
 re-wrapped lines, spatial-anchor dy, pitch and width drift, painted visibility,
 and a rect census, with GT noise floors built in (`--noise-floor 0.12` Word,
 `0.5` Excel). Painted visibility uses trace order and flat-background contrast:
-text covered by a later opaque image/rectangle is `hidden`, same-colour text on
-an opaque flat fill is `low_contrast`, and text that remains visible is
+text covered by a later opaque image, single closed axis-aligned rectangle, or
+fully extended shading under such a rectangular clip is `hidden`; same-colour
+text on an opaque flat fill is `low_contrast`, and text that remains visible is
 `painted`.
 Horizontal text uses its true baseline; a rotated or skewed `fill_text` stays
 one visual run and uses the minimum fully transformed glyph x/y as its

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -11,9 +11,11 @@ lines by their text, and reports typed deviations:
   pitch deltas between consecutive matched lines. Horizontal text uses its
   true baseline; a rotated or skewed `fill_text` stays one visual run and uses
   the minimum fully transformed glyph x/y as its comparable anchor;
-- painted visibility from trace order: text covered by a later opaque image or
-  rectangular fill, or painted with the same colour as a flat background, is
-  distinguished from text that remains visibly painted;
+- painted visibility from trace order: text covered by a later opaque image,
+  single closed axis-aligned rectangular fill, or fully extended shading under
+  a single closed axis-aligned rectangular clip, or painted with the same
+  colour as a flat background, is distinguished from text that remains visibly
+  painted;
 - a fill/stroke rect census with nearest-match position deltas.
 
 A noise floor (default 0.12pt — native Word exports quantise coordinates to a
@@ -55,7 +57,18 @@ GLYPH_RE = re.compile(
 )
 PATH_RE = re.compile(r"<(fill_path|stroke_path)\b([^>]*)>(.*?)</\1>", re.S)
 FILL_IMAGE_RE = re.compile(r"<fill_image\b([^>]*)/>", re.S)
+CLIP_PATH_RE = re.compile(r"<clip_path\b([^>]*)>(.*?)</clip_path>", re.S)
+FILL_SHADE_RE = re.compile(r"<fill_shade\b([^>]*)/>", re.S)
+POP_CLIP_RE = re.compile(r"<pop_clip\s*/>")
+CLIP_SHADE_EVENT_RE = re.compile(
+    r"<clip_path\b[^>]*>.*?</clip_path>|<fill_shade\b[^>]*/>|<pop_clip\s*/>", re.S
+)
 POINT_RE = re.compile(r'<(?:moveto|lineto|curveto)[^>]*x="([-0-9.e]+)" y="([-0-9.e]+)"')
+PATH_COMMAND_RE = re.compile(
+    r"<(?:(?P<point>moveto|lineto)\b(?P<attrs>[^>]*)|(?P<close>closepath)\s*)/>"
+)
+X_RE = re.compile(r'\bx="([-0-9.e]+)"')
+Y_RE = re.compile(r'\by="([-0-9.e]+)"')
 TRANSFORM_RE = re.compile(
     r'transform="([-0-9.e]+) ([-0-9.e]+) ([-0-9.e]+) ([-0-9.e]+) ([-0-9.e]+) ([-0-9.e]+)"'
 )
@@ -88,7 +101,7 @@ class Paint:
     """One later operation that can determine whether text remains visible."""
 
     index: int
-    kind: str  # "flat" | "image"
+    kind: str  # "flat" | "image" | "shade"
     x0: float
     y0: float
     x1: float
@@ -194,15 +207,128 @@ def transformed_bbox(
     return min(xs), min(ys), max(xs), max(ys)
 
 
-def is_axis_aligned_rect(points: list[tuple[float, float]]) -> bool:
-    """Conservatively recognise only fills whose points are all bbox corners."""
-    if len(points) < 4:
-        return False
-    xs = {round(point[0], 6) for point in points}
-    ys = {round(point[1], 6) for point in points}
+def axis_aligned_rect_bbox(
+    attrs: str, body: str
+) -> tuple[float, float, float, float] | None:
+    """Return a bbox only for one closed, ordered axis-aligned rectangle.
+
+    Merely visiting all four bounding-box corners is not enough: a bow-tie or
+    a second subpath does not prove that the bounding box is fully painted.
+    """
+    commands: list[tuple[str, tuple[float, float] | None]] = []
+    cursor = 0
+    for match in PATH_COMMAND_RE.finditer(body):
+        if body[cursor : match.start()].strip():
+            return None
+        cursor = match.end()
+        if match.group("close"):
+            commands.append(("closepath", None))
+            continue
+        point_attrs = match.group("attrs")
+        x_match = X_RE.search(point_attrs)
+        y_match = Y_RE.search(point_attrs)
+        if not x_match or not y_match:
+            return None
+        commands.append(
+            (
+                match.group("point"),
+                (float(x_match.group(1)), float(y_match.group(1))),
+            )
+        )
+    if body[cursor:].strip():
+        return None
+    if not commands or commands[0][0] != "moveto" or commands[-1][0] != "closepath":
+        return None
+    if any(command != "lineto" for command, _ in commands[1:-1]):
+        return None
+
+    points = [point for _, point in commands[:-1] if point is not None]
+    if len(points) == 5 and points[-1] == points[0]:
+        points.pop()
+    if len(points) != 4:
+        return None
+
+    transform = parse_transform(attrs) or (1, 0, 0, 1, 0, 0)
+    a, b, c, d, e, f = transform
+    transformed = [(a * x + c * y + e, b * x + d * y + f) for x, y in points]
+    rounded = [(round(x, 6), round(y, 6)) for x, y in transformed]
+    xs = {x for x, _ in rounded}
+    ys = {y for _, y in rounded}
     corners = {(x, y) for x in xs for y in ys}
-    actual = {(round(x, 6), round(y, 6)) for x, y in points}
-    return len(xs) == 2 and len(ys) == 2 and corners.issubset(actual)
+    if len(xs) != 2 or len(ys) != 2 or set(rounded) != corners:
+        return None
+    for start, end in zip(rounded, rounded[1:] + rounded[:1]):
+        same_x = start[0] == end[0]
+        same_y = start[1] == end[1]
+        if same_x == same_y:
+            return None
+    return transformed_bbox((1, 0, 0, 1, 0, 0), transformed)
+
+
+def intersect_bboxes(
+    first: tuple[float, float, float, float],
+    second: tuple[float, float, float, float],
+) -> tuple[float, float, float, float]:
+    x0 = max(first[0], second[0])
+    y0 = max(first[1], second[1])
+    x1 = min(first[2], second[2])
+    y1 = min(first[3], second[3])
+    if x0 >= x1 or y0 >= y1:
+        return (x0, y0, x0, y0)
+    return (x0, y0, x1, y1)
+
+
+def clipped_shade_paints(content: str) -> list[Paint]:
+    """Collect shadings clipped by one closed axis-aligned rectangle.
+
+    A shading has no useful geometric bounds in mutool's trace; the active
+    clip is the only conservative device-space extent available. Unknown or
+    non-rectangular outer clips poison nested clips rather than letting a
+    smaller rectangle overclaim coverage. Non-extended shadings are skipped
+    because their colour ramp may not paint the entire clip (issue #1450).
+    """
+
+    no_clip = object()
+    unknown_clip = object()
+    active_clip: object | tuple[float, float, float, float] = no_clip
+    stack: list[object | tuple[float, float, float, float]] = []
+    paints: list[Paint] = []
+
+    for event in CLIP_SHADE_EVENT_RE.finditer(content):
+        operation = event.group(0)
+        clip_match = CLIP_PATH_RE.fullmatch(operation)
+        if clip_match:
+            stack.append(active_clip)
+            bbox = axis_aligned_rect_bbox(*clip_match.groups())
+            if bbox is None or active_clip is unknown_clip:
+                active_clip = unknown_clip
+            elif active_clip is no_clip:
+                active_clip = bbox
+            else:
+                active_clip = intersect_bboxes(active_clip, bbox)
+            continue
+
+        shade_match = FILL_SHADE_RE.fullmatch(operation)
+        if shade_match:
+            attrs = shade_match.group(1)
+            if isinstance(active_clip, tuple) and re.search(r'\bextend="1\s+1"', attrs):
+                paints.append(
+                    Paint(
+                        index=event.start(),
+                        kind="shade",
+                        x0=active_clip[0],
+                        y0=active_clip[1],
+                        x1=active_clip[2],
+                        y1=active_clip[3],
+                        alpha=parse_alpha(attrs),
+                    )
+                )
+            continue
+
+        if POP_CLIP_RE.fullmatch(operation):
+            active_clip = stack.pop() if stack else no_clip
+
+    return paints
 
 
 def paint_covers(
@@ -351,18 +477,16 @@ def parse_trace(trace_xml: str) -> list[PageLayout]:
                         y1=max(ys),
                     )
                 )
-                transformed_points = list(zip(xs, ys))
-                if kind == "fill_path" and "<curveto" not in op_body and is_axis_aligned_rect(
-                    transformed_points
-                ):
+                flat_bbox = axis_aligned_rect_bbox(op_attrs, op_body)
+                if kind == "fill_path" and flat_bbox is not None:
                     paints.append(
                         Paint(
                             index=op_match.start(),
                             kind="flat",
-                            x0=min(xs),
-                            y0=min(ys),
-                            x1=max(xs),
-                            y1=max(ys),
+                            x0=flat_bbox[0],
+                            y0=flat_bbox[1],
+                            x1=flat_bbox[2],
+                            y1=flat_bbox[3],
                             alpha=parse_alpha(op_attrs),
                             color=parse_rgb(op_attrs),
                         )
@@ -391,6 +515,7 @@ def parse_trace(trace_xml: str) -> list[PageLayout]:
                     alpha=parse_alpha(op_attrs),
                 )
             )
+        paints.extend(clipped_shade_paints(content))
         paints.sort(key=lambda paint: paint.index)
         lines = build_lines(glyphs)
         lines.extend(rotated_lines)

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -98,6 +98,31 @@ def image_op() -> str:
     )
 
 
+def clipped_shade_op(
+    x0: float,
+    y0: float,
+    x1: float,
+    y1: float,
+    alpha: float = 1.0,
+    extend: str = "1 1",
+    clip_transform: str = "1 0 0 1 0 0",
+) -> str:
+    return "\n".join(
+        [
+            f'<clip_path winding="nonzero" transform="{clip_transform}">',
+            f'<moveto x="{x0}" y="{y0}"/>',
+            f'<lineto x="{x1}" y="{y0}"/>',
+            f'<lineto x="{x1}" y="{y1}"/>',
+            f'<lineto x="{x0}" y="{y1}"/>',
+            "<closepath/>",
+            "</clip_path>",
+            f'<fill_shade alpha="{alpha}" transform="1 0 0 1 0 0" '
+            f'type="linear" extend="{extend}" start="0 0" end="1 1"/>',
+            "<pop_clip/>",
+        ]
+    )
+
+
 class PageElementTest(unittest.TestCase):
     """The ``<page>`` opening tag differs across mutool releases.
 
@@ -319,6 +344,113 @@ class MatchAndDiffTest(unittest.TestCase):
             {"label": "Slide9", "gt": "hidden", "out": "painted"},
         )
         self.assertEqual(compare_layout.audit_failures([vector]), 1)
+
+    def test_same_text_hidden_by_later_clipped_shading_reports_visibility_mismatch(self) -> None:
+        text = line_of("Covered", 72, 100)
+        shade = clipped_shade_op(60, 80, 150, 110)
+
+        vector = self.diff("\n".join([text, shade]), "\n".join([shade, text]))
+
+        self.assertEqual(vector["visibility"]["mismatch_count"], 1)
+        self.assertEqual(
+            vector["visibility"]["mismatches"][0],
+            {"label": "Covered", "gt": "hidden", "out": "painted"},
+        )
+
+    def test_translucent_clipped_shading_does_not_hide_text(self) -> None:
+        text = line_of("Tinted", 72, 100)
+        shade = clipped_shade_op(60, 80, 150, 110, alpha=0.5)
+
+        vector = self.diff("\n".join([text, shade]), "\n".join([shade, text]))
+
+        self.assertEqual(vector["visibility"]["mismatch_count"], 0)
+
+    def test_noncovering_clipped_shading_does_not_hide_text(self) -> None:
+        text = line_of("Clear", 72, 100)
+        shade = clipped_shade_op(200, 80, 300, 110)
+
+        vector = self.diff("\n".join([text, shade]), "\n".join([shade, text]))
+
+        self.assertEqual(vector["visibility"]["mismatch_count"], 0)
+
+    def test_clipped_shading_painted_before_text_does_not_hide_it(self) -> None:
+        page = "\n".join([clipped_shade_op(60, 80, 150, 110), line_of("Above", 72, 100)])
+
+        line = compare_layout.parse_trace(trace_document(page))[0].lines[0]
+
+        self.assertEqual(line.visibility, "painted")
+
+    def test_nonextended_or_rotated_clipped_shading_is_not_overclaimed(self) -> None:
+        text = line_of("Conservative", 72, 100)
+        nonextended = clipped_shade_op(60, 80, 180, 110, extend="0 0")
+        rotated = clipped_shade_op(
+            0,
+            0,
+            120,
+            30,
+            clip_transform="0.7071 0.7071 -0.7071 0.7071 75 65",
+        )
+
+        for shade in (nonextended, rotated):
+            page = "\n".join([text, shade])
+            line = compare_layout.parse_trace(trace_document(page))[0].lines[0]
+            self.assertEqual(line.visibility, "painted")
+
+    def test_bow_tie_clip_does_not_overclaim_shading_coverage(self) -> None:
+        text = line_of("Crossed", 72, 100)
+        bow_tie = """<clip_path winding="nonzero" transform="1 0 0 1 0 0">
+          <moveto x="60" y="80"/><lineto x="150" y="110"/>
+          <lineto x="150" y="80"/><lineto x="60" y="110"/><closepath/>
+        </clip_path>
+        <fill_shade alpha="1" transform="1 0 0 1 0 0"
+          type="linear" extend="1 1" start="0 0" end="1 1"/>
+        <pop_clip/>"""
+
+        line = compare_layout.parse_trace(trace_document("\n".join([text, bow_tie])))[0].lines[0]
+
+        self.assertEqual(line.visibility, "painted")
+
+    def test_multiple_clip_subpaths_do_not_overclaim_shading_coverage(self) -> None:
+        text = line_of("Subpaths", 72, 100)
+        multiple = """<clip_path winding="nonzero" transform="1 0 0 1 0 0">
+          <moveto x="60" y="80"/><lineto x="150" y="80"/>
+          <lineto x="150" y="110"/><lineto x="60" y="110"/><closepath/>
+          <moveto x="70" y="90"/><lineto x="80" y="90"/>
+          <lineto x="80" y="100"/><lineto x="70" y="100"/><closepath/>
+        </clip_path>
+        <fill_shade alpha="1" transform="1 0 0 1 0 0"
+          type="linear" extend="1 1" start="0 0" end="1 1"/>
+        <pop_clip/>"""
+
+        line = compare_layout.parse_trace(trace_document("\n".join([text, multiple])))[0].lines[0]
+
+        self.assertEqual(line.visibility, "painted")
+
+    def test_nested_shading_keeps_the_outer_clip_intersection(self) -> None:
+        text = line_of("A", 72, 100)
+        partial_outer = """<clip_path winding="nonzero" transform="1 0 0 1 0 0">
+          <moveto x="60" y="80"/><lineto x="74" y="80"/>
+          <lineto x="74" y="110"/><lineto x="60" y="110"/><closepath/>
+        </clip_path>"""
+        full_inner = clipped_shade_op(60, 80, 150, 110)
+        page = "\n".join([text, partial_outer, full_inner, "<pop_clip/>"])
+
+        line = compare_layout.parse_trace(trace_document(page))[0].lines[0]
+
+        self.assertEqual(line.visibility, "painted")
+
+    def test_unknown_outer_clip_prevents_a_nested_rectangle_from_overclaiming(self) -> None:
+        text = line_of("A", 72, 100)
+        triangular_outer = """<clip_path winding="nonzero" transform="1 0 0 1 0 0">
+          <moveto x="60" y="80"/><lineto x="150" y="80"/>
+          <lineto x="60" y="110"/><closepath/>
+        </clip_path>"""
+        full_inner = clipped_shade_op(60, 80, 150, 110)
+        page = "\n".join([text, triangular_outer, full_inner, "<pop_clip/>"])
+
+        line = compare_layout.parse_trace(trace_document(page))[0].lines[0]
+
+        self.assertEqual(line.visibility, "painted")
 
     def test_same_color_text_on_flat_fill_reports_low_contrast(self) -> None:
         background = rect_op(0, 0, 595.2, 841.92, color=".8 .8 .8")


### PR DESCRIPTION
## Summary

- Track `clip_path`, `fill_shade`, and `pop_clip` operations in trace order so the layout audit can recognize text hidden by a later opaque clipped shading.
- Intersect nested rectangular clips and deliberately decline non-rectangular, rotated, non-extended, translucent, or non-covering cases rather than overclaiming occlusion.
- Add focused coverage for paint order, opacity, coverage, transformed clips,
  nested clip scope, self-intersecting paths, and multiple subpaths.

## Related issue

Fixes #1450

## Testing

- TDD red: `python3 -m unittest scripts.tests.test_compare_layout.MatchAndDiffTest.test_same_text_hidden_by_later_clipped_shading_reports_visibility_mismatch` failed before the implementation with `AssertionError: 0 != 1`.
- `python3 -m unittest scripts.tests.test_compare_layout` (35 passed)
- `python3 -m unittest scripts.tests.test_check_visual_pr scripts.tests.test_probe_harness scripts.tests.test_check_layout_baselines scripts.tests.test_generate_layout_baselines` (118 passed)
- `python3 -m unittest discover -s scripts/tests` (275 passed)
- `python3 scripts/compare_layout.py --json GT.pdf OUTPUT.pdf` against the PR #1407 / issue #1219 two-page PDFs: page-1 `Sensitivity:Internal` changes from the false `GT hidden vs output painted` mismatch to `hidden` on both sides; page 2 remains painted on both sides. The report diff contains no other change, and the remaining layout findings stay tracked in #1409.
- `git diff --check`
- Documentation freshness audit: `PASS`

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: this changes only trace-based audit classification; office2pdf PDF generation and pixels are unchanged.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
