### PR TITLE
Detect visible fill occlusions in layout audits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,7 +29,8 @@
 - Evidence mode: `fix` <!-- `fix` requires gt/before/after; `defect` requires compare -->
 - Layout audit report: `assets/bugfixes/issue-<!-- N -->/layout-audit.json` <!-- fix mode only -->
 - Layout audit page count: <!-- Pass, or #N references when the report differs -->
-- Layout audit text flow: <!-- Pass, or #N references for missing/extra/reflow, changed-wrap, or painted-visibility findings -->
+- Layout audit text flow: <!-- Pass, or #N references for missing/extra/reflow, changed-wrap, or painted-text visibility findings -->
+- Layout audit visible fills: <!-- Pass, or #N references for visible-fill occlusions -->
 - Layout audit large shifts: <!-- Pass, or #N references for shifts above the report threshold -->
 - New follow-up issues found in this audit: <!-- #N, #N or None; create issues before completing the audit -->
 - Model vision findings: <!-- Describe what Codex/Claude saw in the full pages, diff, and crops. Numeric output is insufficient. -->
@@ -58,7 +59,7 @@
 - [ ] Stored progressive JPEG quality 86 assets with metadata stripped
 - [ ] Used Codex/Claude vision to inspect the full GT/output pages, diff, and matched crops
 - [ ] Inspected matched region crops at full resolution
-- [ ] Ran compare_layout.py --audit and dispositioned every large text-instance shift and painted-visibility mismatch
+- [ ] Ran compare_layout.py --audit and dispositioned every large text-instance shift, painted-text visibility mismatch, and visible-fill occlusion
 - [ ] Ran the 5% fuzz pixel-difference sweep
 - [ ] Inventoried hairlines and border dash styles
 - [ ] Inventoried font weight, italic, and underline emphasis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ This project follows a **6-month rolling MSRV policy** (aligned with [tokio](htt
 
 ## Visual Comparison Workflow
 
-- For visual bug fixes tied to an issue, keep `assets/bugfixes/issue-<number>/gt.jpg`, `before.jpg`, `after.jpg`, and `layout-audit.json` from the same fixture, page set, renderer, and resolution; `before.jpg` captures the pre-fix output, while `after.jpg` and the layout report use the current output. Every fix PR with a raster change must change `after.jpg` and `layout-audit.json`. Generate the report from the same GT and current-output PDFs used for `gt.jpg` and `after.jpg` with `compare_layout.py --json --audit`; classify page-count, missing/extra/reflow or changed-wrap, painted-visibility, and large-shift failures with open issues in the PR's `Visual audit` category fields and matching `Remaining:` rows. Use progressive JPEG quality 86 with metadata stripped, preserve the source pixel dimensions, and verify text and images remain legible for direct GitHub links. Strip first, then re-set the density (`-strip -density 150 -units PixelsPerInch`): the contract check rejects evidence recording under 150 DPI, which stripping alone removes.
+- For visual bug fixes tied to an issue, keep `assets/bugfixes/issue-<number>/gt.jpg`, `before.jpg`, `after.jpg`, and `layout-audit.json` from the same fixture, page set, renderer, and resolution; `before.jpg` captures the pre-fix output, while `after.jpg` and the layout report use the current output. Every fix PR with a raster change must change `after.jpg` and `layout-audit.json`. Generate the report from the same GT and current-output PDFs used for `gt.jpg` and `after.jpg` with `compare_layout.py --json --audit`; classify page-count, missing/extra/reflow or changed-wrap, painted-text visibility, visible-fill occlusion, and large-shift failures with open issues in the PR's `Visual audit` category fields and matching `Remaining:` rows. Use progressive JPEG quality 86 with metadata stripped, preserve the source pixel dimensions, and verify text and images remain legible for direct GitHub links. Strip first, then re-set the density (`-strip -density 150 -units PixelsPerInch`): the contract check rejects evidence recording under 150 DPI, which stripping alone removes.
 - A text-layer-only fix may correctly produce byte- and pixel-identical `before.jpg` and `after.jpg`. Regenerate and verify the current `after.jpg` without adding annotations; it need not appear in the diff when the render is unchanged. Set `Text-layer-only: Yes` and `Pixel delta: 0` in the PR's `Visual audit`, change `layout-audit.json`, and require that report to show the missing/extra searchable-text finding resolved. The contract requires both evidence files and uses ImageMagick's exact decoded-pixel comparison to verify that the declared zero delta is true.
 - **When filing a visual defect issue, attach a side-by-side image (GT left, office2pdf output at filing time right)** rendered from the same page and resolution, committed as `assets/bugfixes/issue-<number>/compare.jpg` (same JPEG rules as above) and embedded in the issue body via a commit-pinned raw URL. For classified fixtures, confirm with the user before publishing the image; the surrounding issue text must still follow the Confidentiality rules.
 
@@ -147,7 +147,7 @@ just the pages a screenshot shows.
    `compare_text_layer.py` (what a reader can select), `compare_render.py`
    (colour and pixels), and a page-by-page visual at >=150 DPI.
    Run the geometry axis with `--audit`; every large text-instance shift or
-   painted-visibility mismatch it names must be fixed or recorded as a
+   painted-text visibility mismatch or visible-fill occlusion it names must be fixed or recorded as a
    remaining deviation with an open issue.
    Do not classify the pixel diff as antialiasing while this audit is failing.
    Source/XML inspection and numeric reports only route attention; they never
@@ -183,8 +183,8 @@ producing the files is not itself inspection.
 
 For layout defects, run `python3 scripts/compare_layout.py <GT.pdf> <output.pdf> --audit`
 first: it matches text lines from `mutool` traces and reports missing/extra/
-re-wrapped lines, spatial-anchor dy, pitch and width drift, painted visibility,
-and a rect census, with GT noise floors built in (`--noise-floor 0.12` Word,
+re-wrapped lines, spatial-anchor dy, pitch and width drift, painted-text visibility,
+visible-fill occlusions, and a rect census, with GT noise floors built in (`--noise-floor 0.12` Word,
 `0.5` Excel). Painted visibility uses trace order and flat-background contrast:
 text covered by a later opaque image, single closed axis-aligned rectangle, or
 fully extended shading under such a rectangular clip is `hidden`; same-colour
@@ -195,7 +195,10 @@ since the preceding text operation and lies within half an em of the glyph's
 conservative bounding box. This trace-order heuristic recovers path-painted
 text seen in issue #1407 without claiming to identify a Type3 program;
 pathless invisible/OCR text stays hidden, and ambiguous cases still require
-the pixel-difference and visual-inspection passes.
+the pixel-difference and visual-inspection passes. Visible-fill analysis compares
+paint order and final overlap colour where a later opaque rectangle cuts into a
+thin earlier rule. Point and area floors reject trace slivers, and same-colour
+operation splitting is ignored.
 Horizontal text uses its true baseline; a rotated or skewed `fill_text` stays
 one visual run and uses the minimum fully transformed glyph x/y as its
 comparable anchor. Its numbers are assertable; pixel counts are only a

--- a/assets/bugfixes/README.md
+++ b/assets/bugfixes/README.md
@@ -45,8 +45,9 @@ byte-identical. In the PR's `Visual audit` section, mark each layout-audit categ
 field as `Pass` or list the open issues that classify it. Those issue references
 must also appear in `Remaining:` deviation rows. The gate rejects a claimed pass
 when the report contains a page-count
-difference, missing/extra/reflowed text, changed wraps, a painted-visibility
-mismatch, or a text shift above the configured large-shift threshold.
+difference, missing/extra/reflowed text, changed wraps, a painted-text visibility
+mismatch, a visible-fill occlusion, or a text shift above the configured
+large-shift threshold.
 
 ## Evidence mode: `defect`
 

--- a/scripts/check_layout_baselines.py
+++ b/scripts/check_layout_baselines.py
@@ -17,8 +17,8 @@ on deltas smaller than the GT's own lattice):
   cases (the Quartz export rounds every advance to a whole point);
 - width percentages move materially only past 0.5%;
 - counts (missing/extra lines, wraps, reflows, deviant lines, large shifts,
-  painted-visibility mismatches, rect census gap, page parity gap) compare
-  exactly — any increase is a regression.
+  painted-text visibility mismatches, visible-fill occlusions, rect census
+  gap, page parity gap) compare exactly — any increase is a regression.
 
 Exit status is nonzero only when a regression is found; improvements alone
 exit zero so a fix PR can paste the report as its acceptance evidence.
@@ -52,6 +52,7 @@ COUNT_METRICS = (
     ("reflow", "gt_lines"),
     ("instances", "large_shift_count"),
     ("visibility", "mismatch_count"),
+    ("visible_fills", "mismatch_count"),
 )
 PT_METRICS = (
     ("baseline", "mean_abs_dy"),
@@ -109,9 +110,10 @@ def compare_page(
 ) -> list[dict]:
     findings: list[dict] = []
     for section, key in COUNT_METRICS:
-        # Visibility was added additively to schema v2. Baselines recorded by
-        # an older generator carry no section and conservatively mean zero
-        # known mismatches; a fresh finding therefore surfaces as a regression.
+        # Visibility checks were added additively to schema v2. Baselines
+        # recorded by an older generator carry no section and conservatively
+        # mean zero known mismatches; a fresh finding therefore surfaces as a
+        # regression.
         stored_count = int(stored_vector.get(section, {}).get(key, 0))
         fresh_count = int(fresh_vector.get(section, {}).get(key, 0))
         if fresh_count != stored_count:

--- a/scripts/check_visual_pr.py
+++ b/scripts/check_visual_pr.py
@@ -49,7 +49,8 @@ INSPECTION_ITEMS = (
     "Stored progressive JPEG quality 86 assets with metadata stripped",
     "Used Codex/Claude vision to inspect the full GT/output pages, diff, and matched crops",
     "Inspected matched region crops at full resolution",
-    "Ran compare_layout.py --audit and dispositioned every large text-instance shift and painted-visibility mismatch",
+    "Ran compare_layout.py --audit and dispositioned every large text-instance "
+    "shift, painted-text visibility mismatch, and visible-fill occlusion",
     "Ran the 5% fuzz pixel-difference sweep",
     "Inventoried hairlines and border dash styles",
     "Inventoried font weight, italic, and underline emphasis",
@@ -281,6 +282,7 @@ def layout_audit_categories(report: object) -> dict[str, bool]:
         raise ValueError("page vectors must cover every comparable page")
 
     has_text_flow_findings = False
+    has_visible_fill_findings = False
     has_large_shifts = False
     for page_number, page in enumerate(pages, start=1):
         if not isinstance(page, dict):
@@ -291,26 +293,31 @@ def layout_audit_categories(report: object) -> dict[str, bool]:
             reflow = page["reflow"]
             instances = page["instances"]
             visibility = page.get("visibility", {"mismatch_count": 0})
-            counts = (
+            visible_fills = page.get("visible_fills", {"mismatch_count": 0})
+            text_flow_counts = (
                 line_counts["missing"],
                 line_counts["extra"],
                 wraps["count"],
                 reflow["gt_lines"],
                 reflow["out_lines"],
                 visibility["mismatch_count"],
-                instances["large_shift_count"],
             )
+            visible_fill_count = visible_fills["mismatch_count"]
+            large_shift_count = instances["large_shift_count"]
         except (KeyError, TypeError) as exc:
             raise ValueError(f"page {page_number} is missing compare_layout fields") from exc
+        counts = (*text_flow_counts, visible_fill_count, large_shift_count)
         if any(type(count) is not int or count < 0 for count in counts):
             raise ValueError(f"page {page_number} finding counts must be non-negative integers")
 
-        has_text_flow_findings |= any(counts[:6])
-        has_large_shifts |= counts[6] > 0
+        has_text_flow_findings |= any(text_flow_counts)
+        has_visible_fill_findings |= visible_fill_count > 0
+        has_large_shifts |= large_shift_count > 0
 
     return {
         "page count": gt_pages != out_pages,
         "text flow": has_text_flow_findings,
+        "visible fills": has_visible_fill_findings,
         "large shifts": has_large_shifts,
     }
 
@@ -418,6 +425,7 @@ def validate_layout_audit(body: str, changed_paths: list[str], root: Path) -> li
     fields = {
         "page count": "Layout audit page count",
         "text flow": "Layout audit text flow",
+        "visible fills": "Layout audit visible fills",
         "large shifts": "Layout audit large shifts",
     }
     for category, has_findings in findings.items():

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -17,6 +17,9 @@ visible ink. It then matches lines by their text and reports typed deviations:
   a single closed axis-aligned rectangular clip, or painted with the same
   colour as a flat background, is distinguished from text that remains visibly
   painted;
+- visible-fill occlusions: a later opaque, differently coloured rectangle
+  cutting into a thin earlier rule is compared by final overlap area, colour,
+  and paint order rather than by the raw rectangle count;
 - a fill/stroke rect census with nearest-match position deltas.
 
 A noise floor (default 0.12pt — native Word exports quantise coordinates to a
@@ -82,6 +85,12 @@ RECT_MATCH_RADIUS_PT = 6.0
 OPAQUE_ALPHA = 0.98
 INVISIBLE_ALPHA = 0.02
 LOW_CONTRAST_CHANNEL_DELTA = 0.04
+VISIBLE_FILL_MIN_EDGE_PT = 0.5
+VISIBLE_FILL_MIN_AREA_PT2 = 0.5
+VISIBLE_FILL_MAX_RULE_THICKNESS_PT = 2.0
+VISIBLE_FILL_MIN_RULE_LENGTH_PT = 4.0
+VISIBLE_FILL_COLOR_DELTA = 0.08
+VISIBLE_FILL_MATCH_TOLERANCE_PT = 0.5
 XML_ESCAPES = {"&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&apos;": "'"}
 
 
@@ -125,6 +134,19 @@ class Rect:
     @property
     def center(self) -> tuple[float, float]:
         return ((self.x0 + self.x1) / 2, (self.y0 + self.y1) / 2)
+
+
+@dataclass(frozen=True)
+class VisibleFillOcclusion:
+    """A later flat fill that changes a thin earlier rule's visible colour."""
+
+    bbox: tuple[float, float, float, float]
+    under_color: tuple[float, float, float]
+    over_color: tuple[float, float, float]
+
+    @property
+    def area(self) -> float:
+        return (self.bbox[2] - self.bbox[0]) * (self.bbox[3] - self.bbox[1])
 
 
 @dataclass
@@ -280,6 +302,207 @@ def intersect_bboxes(
     if x0 >= x1 or y0 >= y1:
         return (x0, y0, x0, y0)
     return (x0, y0, x1, y1)
+
+
+def color_delta(
+    first: tuple[float, float, float], second: tuple[float, float, float]
+) -> float:
+    return max(abs(channel - other) for channel, other in zip(first, second))
+
+
+def merge_visible_fill_occlusions(
+    occlusions: list[VisibleFillOcclusion],
+) -> list[VisibleFillOcclusion]:
+    """Union adjacent cells without preserving harmless operation splits."""
+
+    coordinate_tolerance = 1e-6
+    merged = list(occlusions)
+    changed = True
+    while changed:
+        changed = False
+        for first_index, first in enumerate(merged):
+            for second_index in range(first_index + 1, len(merged)):
+                second = merged[second_index]
+                if (
+                    color_delta(first.under_color, second.under_color)
+                    > coordinate_tolerance
+                    or color_delta(first.over_color, second.over_color)
+                    > coordinate_tolerance
+                ):
+                    continue
+                same_y_span = (
+                    abs(first.bbox[1] - second.bbox[1]) <= coordinate_tolerance
+                    and abs(first.bbox[3] - second.bbox[3]) <= coordinate_tolerance
+                )
+                same_x_span = (
+                    abs(first.bbox[0] - second.bbox[0]) <= coordinate_tolerance
+                    and abs(first.bbox[2] - second.bbox[2]) <= coordinate_tolerance
+                )
+                x_connected = (
+                    first.bbox[0] <= second.bbox[2] + coordinate_tolerance
+                    and second.bbox[0] <= first.bbox[2] + coordinate_tolerance
+                )
+                y_connected = (
+                    first.bbox[1] <= second.bbox[3] + coordinate_tolerance
+                    and second.bbox[1] <= first.bbox[3] + coordinate_tolerance
+                )
+                if not (
+                    (same_y_span and x_connected) or (same_x_span and y_connected)
+                ):
+                    continue
+                merged[first_index] = VisibleFillOcclusion(
+                    bbox=(
+                        min(first.bbox[0], second.bbox[0]),
+                        min(first.bbox[1], second.bbox[1]),
+                        max(first.bbox[2], second.bbox[2]),
+                        max(first.bbox[3], second.bbox[3]),
+                    ),
+                    under_color=first.under_color,
+                    over_color=first.over_color,
+                )
+                del merged[second_index]
+                changed = True
+                break
+            if changed:
+                break
+    return merged
+
+
+def visible_fill_occlusions(paints: list[Paint]) -> list[VisibleFillOcclusion]:
+    """Return material later-fill intrusions into thin earlier rules.
+
+    Mutool records vector geometry before raster antialiasing, so point and
+    area floors can reject trace slivers without depending on DPI. Restricting
+    the earlier paint to a long, thin rule also avoids treating ordinary
+    stacked cell backgrounds as border damage. Same-colour operation splitting
+    has no final visible-colour change and is ignored (issue #1476).
+    """
+
+    opaque_flat_fills = [
+        paint
+        for paint in paints
+        if paint.kind == "flat"
+        and paint.alpha >= OPAQUE_ALPHA
+        and paint.color is not None
+    ]
+    occlusion_cells: list[VisibleFillOcclusion] = []
+    for earlier in opaque_flat_fills:
+        earlier_width = earlier.x1 - earlier.x0
+        earlier_height = earlier.y1 - earlier.y0
+        if (
+            min(earlier_width, earlier_height) > VISIBLE_FILL_MAX_RULE_THICKNESS_PT
+            or max(earlier_width, earlier_height) < VISIBLE_FILL_MIN_RULE_LENGTH_PT
+        ):
+            continue
+        assert earlier.color is not None
+        earlier_bbox = (earlier.x0, earlier.y0, earlier.x1, earlier.y1)
+        later_fills = [
+            paint
+            for paint in opaque_flat_fills
+            if paint.index > earlier.index
+            and bboxes_overlap(
+                earlier_bbox,
+                (paint.x0, paint.y0, paint.x1, paint.y1),
+            )
+        ]
+        if not later_fills:
+            continue
+
+        clipped_overlaps = [
+            intersect_bboxes(
+                earlier_bbox,
+                (paint.x0, paint.y0, paint.x1, paint.y1),
+            )
+            for paint in later_fills
+        ]
+        x_coordinates = sorted(
+            {earlier.x0, earlier.x1}
+            | {coordinate for bbox in clipped_overlaps for coordinate in (bbox[0], bbox[2])}
+        )
+        y_coordinates = sorted(
+            {earlier.y0, earlier.y1}
+            | {coordinate for bbox in clipped_overlaps for coordinate in (bbox[1], bbox[3])}
+        )
+        for x0, x1 in zip(x_coordinates, x_coordinates[1:]):
+            for y0, y1 in zip(y_coordinates, y_coordinates[1:]):
+                if x0 >= x1 or y0 >= y1:
+                    continue
+                midpoint = ((x0 + x1) / 2, (y0 + y1) / 2)
+                covering_fills = [
+                    paint
+                    for paint in later_fills
+                    if paint.x0 <= midpoint[0] <= paint.x1
+                    and paint.y0 <= midpoint[1] <= paint.y1
+                ]
+                if not covering_fills:
+                    continue
+                top_fill = max(covering_fills, key=lambda paint: paint.index)
+                assert top_fill.color is not None
+                if color_delta(earlier.color, top_fill.color) < VISIBLE_FILL_COLOR_DELTA:
+                    continue
+                occlusion_cells.append(
+                    VisibleFillOcclusion(
+                        bbox=(x0, y0, x1, y1),
+                        under_color=earlier.color,
+                        over_color=top_fill.color,
+                    )
+                )
+
+    return [
+        occlusion
+        for occlusion in merge_visible_fill_occlusions(occlusion_cells)
+        if min(
+            occlusion.bbox[2] - occlusion.bbox[0],
+            occlusion.bbox[3] - occlusion.bbox[1],
+        )
+        >= VISIBLE_FILL_MIN_EDGE_PT
+        and occlusion.area >= VISIBLE_FILL_MIN_AREA_PT2
+    ]
+
+
+def visible_fill_occlusion_mismatches(
+    gt_paints: list[Paint], out_paints: list[Paint]
+) -> list[dict]:
+    """Pair equivalent occlusions and report only final-coverage differences."""
+
+    gt_occlusions = visible_fill_occlusions(gt_paints)
+    out_occlusions = visible_fill_occlusions(out_paints)
+    unclaimed_output = list(out_occlusions)
+    mismatches: list[tuple[str, VisibleFillOcclusion]] = []
+    for gt_occlusion in gt_occlusions:
+        best: VisibleFillOcclusion | None = None
+        best_distance = VISIBLE_FILL_MATCH_TOLERANCE_PT
+        for candidate in unclaimed_output:
+            if (
+                color_delta(gt_occlusion.under_color, candidate.under_color)
+                > LOW_CONTRAST_CHANNEL_DELTA
+                or color_delta(gt_occlusion.over_color, candidate.over_color)
+                > LOW_CONTRAST_CHANNEL_DELTA
+            ):
+                continue
+            distance = max(
+                abs(gt_value - out_value)
+                for gt_value, out_value in zip(gt_occlusion.bbox, candidate.bbox)
+            )
+            if distance <= best_distance:
+                best = candidate
+                best_distance = distance
+        if best is None:
+            mismatches.append(("ground_truth", gt_occlusion))
+        else:
+            unclaimed_output.remove(best)
+    mismatches.extend(("output", occlusion) for occlusion in unclaimed_output)
+
+    def report(side: str, occlusion: VisibleFillOcclusion) -> dict:
+        return {
+            "side": side,
+            "bbox": [round(value, 6) for value in occlusion.bbox],
+            "area": round(occlusion.area, 6),
+            "under_color": [round(value, 6) for value in occlusion.under_color],
+            "over_color": [round(value, 6) for value in occlusion.over_color],
+        }
+
+    return [report(side, occlusion) for side, occlusion in mismatches]
 
 
 def clipped_shade_paints(content: str) -> list[Paint]:
@@ -765,6 +988,7 @@ def diff_page(
         for gt_line, out_line in matches
         if (gt_line.visibility == "painted") != (out_line.visibility == "painted")
     ]
+    visible_fill_mismatches = visible_fill_occlusion_mismatches(gt.paints, out.paints)
     large_shifts = [
         instance
         for instance in instances
@@ -843,6 +1067,10 @@ def diff_page(
             "mismatch_count": len(visibility_mismatches),
             "mismatches": visibility_mismatches,
         },
+        "visible_fills": {
+            "mismatch_count": len(visible_fill_mismatches),
+            "mismatches": visible_fill_mismatches,
+        },
         "pitch": {"pairs": len(pitch_deltas), "worst_delta": abs(stats(pitch_deltas)["worst"])},
         "wraps": {"count": len(wraps), "samples": wraps[:5]},
         "reflow": reflow,
@@ -907,6 +1135,15 @@ def render_reading(vectors: list[dict]) -> str:
                 f"painted visibility: {examples}. Check z-order, opacity, or foreground/background "
                 "contrast"
             )
+        if vector["visible_fills"]["mismatch_count"]:
+            examples = "; ".join(
+                f"{item['side']} bbox {item['bbox']} {item['under_color']} -> {item['over_color']}"
+                for item in vector["visible_fills"]["mismatches"][:3]
+            )
+            page_notes.append(
+                f"{vector['visible_fills']['mismatch_count']} visible fill occlusion(s) "
+                f"differ after paint order: {examples}. Check border/fill z-order"
+            )
         if vector["pitch"]["worst_delta"] > vector["noise_floor"]:
             page_notes.append(
                 f"line pitch drifts up to {vector['pitch']['worst_delta']:.2f}pt — "
@@ -926,10 +1163,11 @@ def render_reading(vectors: list[dict]) -> str:
 
 
 def audit_failures(vectors: list[dict]) -> int:
-    """Count material text findings that require visual disposition."""
+    """Count material layout or paint findings that require visual disposition."""
     return sum(
         vector["instances"]["large_shift_count"]
         + vector["visibility"]["mismatch_count"]
+        + vector["visible_fills"]["mismatch_count"]
         + vector["lines"]["missing"]
         + vector["lines"]["extra"]
         + vector["wraps"]["count"]
@@ -974,7 +1212,7 @@ def main() -> int:
         action="store_true",
         help=(
             "exit nonzero on missing/extra/reflowed text, changed wraps, "
-            "a painted-visibility mismatch, a large instance shift, or a page-count mismatch"
+            "a text/fill visibility mismatch, a large instance shift, or a page-count mismatch"
         ),
     )
     parser.add_argument("--json", action="store_true", help="emit the deviation vectors as JSON")
@@ -1030,6 +1268,7 @@ def main() -> int:
             f"width worst {vector['width']['worst_pct']:.1f}% | "
             f"large shifts {vector['instances']['large_shift_count']} | "
             f"visibility {vector['visibility']['mismatch_count']} | "
+            f"visible fills {vector['visible_fills']['mismatch_count']} | "
             f"rects {vector['rects']['gt_count']}/{vector['rects']['out_count']}"
         )
     print()
@@ -1038,7 +1277,7 @@ def main() -> int:
     if args.audit and (failures or len(gt_pages) != len(out_pages)):
         print()
         print(
-            f"AUDIT FAILED: {failures} unresolved text-layout finding(s) require visual "
+            f"AUDIT FAILED: {failures} unresolved layout/paint finding(s) require visual "
             "inspection and an issue reference before the audit can be marked as matching."
         )
         return 1

--- a/scripts/generate_layout_baselines.py
+++ b/scripts/generate_layout_baselines.py
@@ -11,8 +11,9 @@ For every case in ``tests/golden_mocks/business/manifest.json`` this pipeline:
    ``compare_layout`` deviation vector for every page, using the per-format
    noise floor (0.12pt for Word/PowerPoint GT, whose exports quantise to a
    0.24pt grid; 0.5pt for Excel GT, whose Quartz export rounds every advance
-   to a whole point), including painted-visibility mismatches caused by
-   z-order or flat-background contrast.
+   to a whole point), including painted-text visibility mismatches caused by
+   z-order or flat-background contrast, plus visible-fill occlusions where a
+   later opaque, differently coloured rectangle cuts into a thin rule.
 
 A trace that parses to zero pages is a hard failure, never an empty vector: on
 mutool 1.23.x that state used to look exactly like a perfect comparison
@@ -161,6 +162,10 @@ def build_baseline_document(
             vector.get("visibility", {"mismatch_count": 0})["mismatch_count"]
             for vector in pages
         ),
+        "visible_fill_mismatches": sum(
+            vector.get("visible_fills", {"mismatch_count": 0})["mismatch_count"]
+            for vector in pages
+        ),
     }
     return {
         "schema_version": SCHEMA_VERSION,
@@ -239,12 +244,19 @@ def main() -> int:
                     vector.get("visibility", {"mismatch_count": 0})["mismatch_count"]
                     for vector in record["pages"]
                 )
+                visible_fill_mismatches = sum(
+                    vector.get("visible_fills", {"mismatch_count": 0})[
+                        "mismatch_count"
+                    ]
+                    for vector in record["pages"]
+                )
                 print(
                     f"{record['id']}: {record['out_pages']}/{record['gt_pages']} pages, "
                     f"{sum(v['lines']['missing'] for v in record['pages'])} missing, "
                     f"{sum(v['instances']['large_shift_count'] for v in record['pages'])} "
                     "large shifts, "
-                    f"{visibility_mismatches} visibility mismatches"
+                    f"{visibility_mismatches} text visibility mismatches, "
+                    f"{visible_fill_mismatches} visible fill mismatches"
                 )
     except BaselineError as error:
         print(f"baseline generation failed: {error}", file=sys.stderr)

--- a/scripts/tests/test_check_layout_baselines.py
+++ b/scripts/tests/test_check_layout_baselines.py
@@ -43,6 +43,7 @@ def page_vector(**overrides: object) -> dict:
             "large_shifts": [],
         },
         "visibility": {"mismatch_count": 0, "mismatches": []},
+        "visible_fills": {"mismatch_count": 0, "mismatches": []},
         "pitch": {"pairs": 9, "worst_delta": 0.3},
         "wraps": {"count": 0, "samples": []},
         "reflow": {"gt_lines": 0, "out_lines": 0, "samples": []},
@@ -167,6 +168,28 @@ class CountTests(unittest.TestCase):
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0]["kind"], "regression")
         self.assertEqual(findings[0]["metric"], "visibility.mismatch_count")
+
+    def test_visible_fill_mismatch_increase_is_a_regression(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["pages"][0]["visible_fills"]["mismatch_count"] = 1
+        findings = checker.compare_baselines(stored, fresh)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["kind"], "regression")
+        self.assertEqual(findings[0]["metric"], "visible_fills.mismatch_count")
+
+    def test_older_baseline_without_visible_fills_treats_new_finding_as_regression(
+        self,
+    ) -> None:
+        stored = baseline_document()
+        del stored["cases"][0]["pages"][0]["visible_fills"]
+        fresh = baseline_document()
+        fresh["cases"][0]["pages"][0]["visible_fills"]["mismatch_count"] = 1
+
+        findings = checker.compare_baselines(stored, fresh)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["metric"], "visible_fills.mismatch_count")
 
     def test_rect_census_gap_widening_is_a_regression(self) -> None:
         stored = baseline_document()

--- a/scripts/tests/test_check_visual_pr.py
+++ b/scripts/tests/test_check_visual_pr.py
@@ -56,6 +56,7 @@ def visual_body(result_overrides=None, include_previews=True):
 - Layout audit report: `assets/bugfixes/issue-186/layout-audit.json`
 - Layout audit page count: Pass
 - Layout audit text flow: Pass
+- Layout audit visible fills: Pass
 - Layout audit large shifts: Pass
 - New follow-up issues found in this audit: {follow_up_value}
 - Model vision findings: Full pages, pixel diff, and matched crops were opened; no untracked visual deviation remains.
@@ -87,6 +88,7 @@ def layout_report(
     reflow_out=0,
     large_shifts=0,
     visibility=0,
+    visible_fills=0,
 ):
     return {
         "pages": [
@@ -96,6 +98,7 @@ def layout_report(
                 "reflow": {"gt_lines": reflow_gt, "out_lines": reflow_out},
                 "instances": {"large_shift_count": large_shifts},
                 "visibility": {"mismatch_count": visibility},
+                "visible_fills": {"mismatch_count": visible_fills},
             }
         ],
         "gt_pages": gt_pages,
@@ -167,13 +170,14 @@ class PullRequestBodyTests(unittest.TestCase):
     def test_visual_audit_requires_layout_finding_disposition(self):
         required = (
             "- [x] Ran compare_layout.py --audit and dispositioned every "
-            "large text-instance shift and painted-visibility mismatch"
+            "large text-instance shift, painted-text visibility mismatch, and "
+            "visible-fill occlusion"
         )
         errors = validate_pr_body(
             visual_body().replace(required, required.replace("[x]", "[ ]")),
             ["assets/bugfixes/issue-186/after.jpg"],
         )
-        self.assertTrue(any("painted-visibility mismatch" in error for error in errors))
+        self.assertTrue(any("painted-text visibility mismatch" in error for error in errors))
 
     def test_visual_audit_requires_model_vision_inspection(self):
         required = (
@@ -316,6 +320,22 @@ class LayoutAuditTests(unittest.TestCase):
         self.assertTrue(
             any("text flow" in error and "issue reference" in error for error in errors)
         )
+
+    def test_visible_fill_failure_rejects_pass_visible_fill_disposition(self):
+        errors = validate_report(
+            visual_body(),
+            layout_report(visible_fills=1),
+        )
+        self.assertTrue(
+            any("visible fills" in error and "issue reference" in error for error in errors)
+        )
+
+    def test_visible_fill_failure_accepts_remaining_fill_issue(self):
+        body = visual_body({"Fill": "Remaining: #328"}).replace(
+            "Layout audit visible fills: Pass",
+            "Layout audit visible fills: #328",
+        )
+        self.assertEqual(validate_report(body, layout_report(visible_fills=1)), [])
 
     def test_failed_categories_accept_remaining_issue_references(self):
         body = visual_body(

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -9,9 +9,12 @@ mutool.
 
 from __future__ import annotations
 
+import io
+import json
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -376,6 +379,120 @@ class MatchAndDiffTest(unittest.TestCase):
         self.assertEqual(vector["rects"]["gt_count"], 2)
         self.assertEqual(vector["rects"]["out_count"], 1)
 
+    def test_later_different_fill_cutting_rule_reports_visible_fill_occlusion(
+        self,
+    ) -> None:
+        # Issue #1475: a pale body-cell fill starts 1pt too high and is painted
+        # after the long rose title rule. Every constituent rectangle exists,
+        # so a rect census cannot reveal the wrong final visible colour.
+        rose_rule = rect_op(
+            50.0,
+            143.75,
+            474.0,
+            145.0,
+            color=".85490199 .7137255 .7294118",
+        )
+        native_body = rect_op(
+            452.75,
+            145.0,
+            454.0,
+            184.0,
+            color=".972549 .9372549 .9411765",
+        )
+        overpainting_body = rect_op(
+            452.75,
+            144.0,
+            454.0,
+            184.0,
+            color=".972549 .9372549 .9411765",
+        )
+
+        vector = self.diff(
+            "\n".join([rose_rule, native_body]),
+            "\n".join([rose_rule, overpainting_body]),
+        )
+
+        self.assertEqual(vector["visible_fills"]["mismatch_count"], 1)
+        self.assertEqual(
+            vector["visible_fills"]["mismatches"][0],
+            {
+                "side": "output",
+                "bbox": [452.75, 144.0, 454.0, 145.0],
+                "area": 1.25,
+                "under_color": [0.854902, 0.713726, 0.729412],
+                "over_color": [0.972549, 0.937255, 0.941176],
+            },
+        )
+        self.assertEqual(compare_layout.audit_failures([vector]), 1)
+        self.assertIn("visible fill", compare_layout.render_reading([vector]).lower())
+
+    def test_same_color_operation_splitting_is_not_a_visible_fill_mismatch(self) -> None:
+        rule_color = ".85490199 .7137255 .7294118"
+        cover_color = ".972549 .9372549 .9411765"
+        rule = rect_op(50.0, 143.75, 474.0, 145.0, color=rule_color)
+        gt = "\n".join(
+            [rule, rect_op(452.75, 144.0, 454.0, 184.0, color=cover_color)]
+        )
+        output = "\n".join(
+            [
+                rule,
+                rect_op(452.75, 144.0, 453.25, 184.0, color=cover_color),
+                rect_op(453.25, 144.0, 454.0, 184.0, color=cover_color),
+            ]
+        )
+
+        vector = self.diff(gt, output)
+
+        self.assertEqual(vector["visible_fills"]["mismatch_count"], 0)
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
+    def test_repainting_rule_color_restores_final_visible_fill(self) -> None:
+        rule = rect_op(10.0, 20.0, 110.0, 21.0, color=".8 .2 .2")
+        different_cover = rect_op(50.0, 20.0, 51.0, 21.0, color=".2 .8 .2")
+        restored_rule = rect_op(50.0, 20.0, 51.0, 21.0, color=".8 .2 .2")
+
+        vector = self.diff(rule, "\n".join([rule, different_cover, restored_rule]))
+
+        self.assertEqual(vector["visible_fills"]["mismatch_count"], 0)
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
+    def test_subthreshold_fill_overlap_is_ignored_as_vector_noise(self) -> None:
+        rule = rect_op(10.0, 20.0, 110.0, 21.0, color=".8 .2 .2")
+        tiny_overlap = rect_op(50.0, 20.8, 50.2, 40.0, color=".2 .8 .2")
+
+        vector = self.diff(rule, "\n".join([rule, tiny_overlap]))
+
+        self.assertEqual(vector["visible_fills"]["mismatch_count"], 0)
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
+    def test_low_color_delta_overlap_is_ignored_as_trace_noise(self) -> None:
+        rule = rect_op(10.0, 20.0, 110.0, 21.0, color=".80 .20 .20")
+        near_same_cover = rect_op(50.0, 20.0, 51.0, 40.0, color=".84 .23 .24")
+
+        vector = self.diff(rule, "\n".join([rule, near_same_cover]))
+
+        self.assertEqual(vector["visible_fills"]["mismatch_count"], 0)
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
+    def test_duplicate_cover_operations_do_not_duplicate_visible_coverage(self) -> None:
+        rule = rect_op(10.0, 20.0, 110.0, 21.0, color=".8 .2 .2")
+        cover = rect_op(50.0, 20.0, 51.0, 40.0, color=".2 .8 .2")
+
+        vector = self.diff("\n".join([rule, cover]), "\n".join([rule, cover, cover]))
+
+        self.assertEqual(vector["visible_fills"]["mismatch_count"], 0)
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
+    def test_matching_different_color_occlusion_is_not_a_mismatch(self) -> None:
+        rule = rect_op(10.0, 20.0, 110.0, 21.0, color=".8 .2 .2")
+        intentional_cover = rect_op(50.0, 20.0, 51.0, 40.0, color=".2 .8 .2")
+        page = "\n".join([rule, intentional_cover])
+
+        vector = self.diff(page, page)
+
+        self.assertEqual(vector["visible_fills"]["mismatch_count"], 0)
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
     def test_repeated_labels_are_spatially_matched_and_large_shifts_are_named(self) -> None:
         gt = "\n".join(
             [line_of("Sales", 337, 133), line_of("Sales", 553, 286)]
@@ -600,6 +717,51 @@ class ReadingTest(unittest.TestCase):
 
         self.assertIn("Sales [1/2]", reading)
         self.assertIn("+120.00pt", reading)
+
+
+class CompareLayoutCliTest(unittest.TestCase):
+    def test_audit_exits_nonzero_for_issue_1475_visible_fill_occlusion(self) -> None:
+        rose_rule = rect_op(
+            50.0,
+            143.75,
+            474.0,
+            145.0,
+            color=".85490199 .7137255 .7294118",
+        )
+        native_body = rect_op(
+            452.75,
+            145.0,
+            454.0,
+            184.0,
+            color=".972549 .9372549 .9411765",
+        )
+        overpainting_body = rect_op(
+            452.75,
+            144.0,
+            454.0,
+            184.0,
+            color=".972549 .9372549 .9411765",
+        )
+        traces = [
+            trace_document("\n".join([rose_rule, native_body])),
+            trace_document("\n".join([rose_rule, overpainting_body])),
+        ]
+
+        stdout = io.StringIO()
+        with (
+            patch.object(compare_layout, "run_mutool", side_effect=traces),
+            patch.object(
+                sys,
+                "argv",
+                ["compare_layout.py", "gt.pdf", "output.pdf", "--json", "--audit"],
+            ),
+            patch("sys.stdout", stdout),
+        ):
+            result = compare_layout.main()
+
+        report = json.loads(stdout.getvalue())
+        self.assertEqual(result, 1)
+        self.assertEqual(report["pages"][0]["visible_fills"]["mismatch_count"], 1)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_generate_layout_baselines.py
+++ b/scripts/tests/test_generate_layout_baselines.py
@@ -181,6 +181,7 @@ class DocumentTests(unittest.TestCase):
                     "lines": {"missing": 1, "extra": 0, "matched": 5, "deviant": 2},
                     "instances": {"large_shift_count": 1},
                     "visibility": {"mismatch_count": 2},
+                    "visible_fills": {"mismatch_count": 3},
                 }
             ],
         }
@@ -199,6 +200,7 @@ class DocumentTests(unittest.TestCase):
         self.assertEqual(summary["missing_lines"], 1)
         self.assertEqual(summary["large_shifts"], 1)
         self.assertEqual(summary["visibility_mismatches"], 2)
+        self.assertEqual(summary["visible_fill_mismatches"], 3)
 
     def test_serialisation_is_deterministic(self) -> None:
         record = {

--- a/tests/golden_mocks/business/README.md
+++ b/tests/golden_mocks/business/README.md
@@ -137,8 +137,9 @@ The `Business Golden Contract` CI job runs both checks on every push and pull re
 `baselines/layout.json` stores the `compare_layout.py` deviation vector for
 every page of every case (matched/missing/extra lines, baseline dy statistics,
 line-width drift, pitch deltas, wrap and reflow counts, large instance shifts,
-and the rect census), measured against the native GT with the per-format noise
-floor (0.12pt Word/PowerPoint, 0.5pt Excel). Regenerate it with a local build:
+painted-text visibility mismatches, visible-fill occlusions, and the rect
+census), measured against the native GT with the per-format noise floor
+(0.12pt Word/PowerPoint, 0.5pt Excel). Regenerate it with a local build:
 
 ```sh
 cargo build -p office2pdf-cli


### PR DESCRIPTION
## Summary

- compare final visible coverage where later opaque, differently coloured rectangle fills cut into thin rules
- report output/ground-truth side, bounding box, area, and both paint colours, and make unresolved findings fail `--audit`
- normalize duplicate, split, and later-restored paints so operation decomposition does not create false findings
- add a distinct visible-fill disposition to the visual PR contract and business layout baseline checks
- document the point, area, opacity, colour, and operation-splitting policy

## Related issue

Fixes #1476

## Testing

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 291 passed
- `python3 -m unittest scripts.tests.test_compare_layout scripts.tests.test_check_visual_pr scripts.tests.test_check_layout_baselines scripts.tests.test_generate_layout_baselines` — 123 passed
- `python3 scripts/check_layout_baselines.py --fresh tests/golden_mocks/business/baselines/layout.json` — no material change
- `python3 -m compileall -q scripts`
- `git diff --check`
- replayed the exact #1475 page-1 trace with only the native body-fill boundary restored; the audit reported one output-only mismatch at `[452.75, 144.0, 454.0, 145.0]`, area `1.25`, with the expected rose and pale colours
- required documentation freshness audit: `PASS:` implementation, CLI/help, PR gate, baseline tooling, and documentation agree

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: This changes trace analysis, audit enforcement, tests, and documentation only; no renderer code or visual evidence image changed.
