### PR TITLE
fix(harness): trim terminal whitespace from line extents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,12 +210,11 @@ threshold), or when a matched line changes between painted and hidden/low
 contrast; inspect and track every named instance before marking alignment or
 text flow as matching.
 
-**Its width column measures origin-to-origin and so counts invisible trailing
-glyphs.** Word emits a trailing space after a paragraph's last character where
-we emit none, which reads as a width deficit even when every visible glyph
-agrees: a footer's reported "17% narrower" (#725) and a centred line's 79.37pt
-against 68.87pt (#728) were both entirely that one space. Compare per-glyph
-advances before believing a width delta.
+**Its width column trims leading and trailing whitespace glyphs.** Their
+advances position no visible ink and previously invented large width deltas
+when only one exporter retained a terminal space (#1482). Internal spaces still
+contribute through the following glyph's origin. Compare per-glyph advances
+before attributing a remaining width delta to the font.
 
 **Install `mupdf-tools` first** (`brew install mupdf-tools`). Without `mutool`
 the geometry axis falls back to `pdftotext -bbox`, whose `yMin` is each glyph's

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -165,12 +165,23 @@ class Line:
         return "".join(g.unicode for g in self.glyphs if not g.unicode.isspace())
 
     @property
+    def visible_glyphs(self) -> list[Glyph]:
+        """Glyphs whose ink defines the line's comparable visual extent.
+
+        Native exporters and Typst disagree about terminal space glyphs. Their
+        advances position no later ink, so including them invents a width or
+        left-edge delta while every painted glyph agrees (issue #1482).
+        Internal spaces still contribute through the following glyph's origin.
+        """
+        return [glyph for glyph in self.glyphs if not glyph.unicode.isspace()]
+
+    @property
     def x0(self) -> float:
-        return min(glyph.x for glyph in self.glyphs)
+        return min(glyph.x for glyph in self.visible_glyphs)
 
     @property
     def x1(self) -> float:
-        return max(glyph.x + glyph.advance for glyph in self.glyphs)
+        return max(glyph.x + glyph.advance for glyph in self.visible_glyphs)
 
     @property
     def width(self) -> float:
@@ -816,7 +827,7 @@ def parse_trace(trace_xml: str) -> list[PageLayout]:
         paints.extend(clipped_shade_paints(content))
         paints.sort(key=lambda paint: paint.index)
         lines = build_lines(glyphs)
-        lines.extend(rotated_lines)
+        lines.extend(line for line in rotated_lines if line.key)
         for line in lines:
             line.visibility = classify_line_visibility(line, paints)
         lines.sort(key=lambda line: (line.y, line.x0))
@@ -839,8 +850,9 @@ def build_lines(glyphs: list[Glyph], y_tolerance: float = LINE_Y_TOLERANCE_PT) -
     for line in lines:
         line.glyphs.sort(key=lambda g: g.x)
         line.y = statistics.median(g.y for g in line.glyphs)
+    lines = [line for line in lines if line.key]
     lines.sort(key=lambda line: (line.y, line.x0))
-    return [line for line in lines if line.key]
+    return lines
 
 
 def match_lines(

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -265,6 +265,17 @@ class ParseTraceTest(unittest.TestCase):
         self.assertAlmostEqual(lines[0].x0, 45.0)
         self.assertAlmostEqual(lines[0].y, 64.0)
 
+    def test_rotated_whitespace_only_run_remains_excluded(self) -> None:
+        page = """<fill_text transform="1 2 3 4 5 6">
+          <span font="AAAAAA+ArialMT" trm="10 0 0 10">
+            <g unicode=" " glyph="space" x="7" y="11" adv=".5"/>
+          </span>
+        </fill_text>"""
+
+        lines = compare_layout.parse_trace(trace_document(page))[0].lines
+
+        self.assertEqual(lines, [])
+
     def test_rect_bbox_uses_the_full_affine_transform(self) -> None:
         page = """<fill_path transform="1 2 3 4 5 6">
           <moveto x="7" y="11"/>
@@ -371,6 +382,36 @@ class MatchAndDiffTest(unittest.TestCase):
         out = line_of("wide", 72, 100, pitch=6.3)
         vector = self.diff(gt, out)
         self.assertGreater(vector["width"]["worst_pct"], 3.0)
+
+    def test_trailing_spaces_do_not_inflate_visible_width(self) -> None:
+        gt = line_of("ALL", 72, 100)
+        out = line_of("ALL  ", 72, 100)
+
+        vector = self.diff(gt, out)
+
+        self.assertEqual(vector["lines"]["matched"], 1)
+        self.assertAlmostEqual(vector["width"]["worst_pct"], 0.0, places=6)
+
+    def test_leading_spaces_do_not_move_the_visible_start(self) -> None:
+        gt = line_of("ALL", 72, 100)
+        out = line_of("  ALL", 60, 100)
+
+        vector = self.diff(gt, out)
+
+        self.assertEqual(vector["lines"]["matched"], 1)
+        self.assertAlmostEqual(vector["dx0"]["worst"], 0.0, places=6)
+
+    def test_internal_spaces_still_contribute_to_visible_width(self) -> None:
+        page = line_of("A B", 72, 100)
+        line = compare_layout.parse_trace(trace_document(page))[0].lines[0]
+
+        self.assertAlmostEqual(line.width, 17.28, places=3)
+
+    def test_whitespace_only_line_remains_excluded(self) -> None:
+        page = line_of("   ", 72, 100)
+        lines = compare_layout.parse_trace(trace_document(page))[0].lines
+
+        self.assertEqual(lines, [])
 
     def test_rect_census_reports_count_delta(self) -> None:
         gt = "\n".join([rect_op(70, 90, 300, 91), rect_op(70, 110, 300, 111, "stroke_path")])


### PR DESCRIPTION
## Summary

- measure line start and width from painted non-whitespace glyphs so leading and trailing spaces cannot create false geometry drift
- preserve internal-space advances through the following glyph origin and keep whitespace-only horizontal and rotated runs excluded
- update the visual-audit documentation and add focused regressions for leading, trailing, internal, horizontal, and rotated whitespace cases

## Related issue

Fixes #1482

## Testing

- `python3 -m unittest discover -s scripts/tests` — 296 passed
- `python3 -m unittest scripts.tests.test_compare_layout` — 52 passed
- `python3 -m py_compile scripts/compare_layout.py scripts/tests/test_compare_layout.py`
- `git diff --check`
- exact #1219 / PR #1407 replay: page-1 reported worst width drift fell from 13.3265% to 0.2680%; `ALL` and `AGES` now have identical visible GT/output widths while their raw output text retains the diagnostic terminal space
- required documentation freshness audit: `PASS:` width/x-anchor behavior, whitespace exclusions, CLI defaults, and documentation agree

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: This changes trace-analysis geometry, tests, and documentation only; no converter or raster output changes.
