### PR TITLE
fix(harness): gate fine-detail text drift

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,10 +28,12 @@
 - Renderer and DPI: <!-- e.g. pdftoppm, 150 DPI -->
 - Evidence mode: `fix` <!-- `fix` requires gt/before/after; `defect` requires compare -->
 - Layout audit report: `assets/bugfixes/issue-<!-- N -->/layout-audit.json` <!-- fix mode only -->
+- Fine-detail threshold: <!-- e.g. 0.5pt; must match compare_layout.py --fine-shift -->
 - Layout audit page count: <!-- Pass, or #N references when the report differs -->
 - Layout audit text flow: <!-- Pass, or #N references for missing/extra/reflow, changed-wrap, or painted-text visibility findings -->
 - Layout audit visible fills: <!-- Pass, or #N references for visible-fill occlusions -->
 - Layout audit large shifts: <!-- Pass, or #N references for shifts above the report threshold -->
+- Layout audit fine shifts: <!-- Pass, or #N references for shifts above the fine-detail threshold -->
 - New follow-up issues found in this audit: <!-- #N, #N or None; create issues before completing the audit -->
 - Model vision findings: <!-- Describe what Codex/Claude saw in the full pages, diff, and crops. Numeric output is insufficient. -->
 - GT: `assets/bugfixes/issue-<!-- N -->/gt.jpg`
@@ -59,7 +61,7 @@
 - [ ] Stored progressive JPEG quality 86 assets with metadata stripped
 - [ ] Used Codex/Claude vision to inspect the full GT/output pages, diff, and matched crops
 - [ ] Inspected matched region crops at full resolution
-- [ ] Ran compare_layout.py --audit and dispositioned every large text-instance shift, painted-text visibility mismatch, and visible-fill occlusion
+- [ ] Ran compare_layout.py --audit --fine-shift PT and dispositioned every fine/large text-instance shift, painted-text visibility mismatch, and visible-fill occlusion
 - [ ] Ran the 5% fuzz pixel-difference sweep
 - [ ] Inventoried hairlines and border dash styles
 - [ ] Inventoried font weight, italic, and underline emphasis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ This project follows a **6-month rolling MSRV policy** (aligned with [tokio](htt
 
 ## Visual Comparison Workflow
 
-- For visual bug fixes tied to an issue, keep `assets/bugfixes/issue-<number>/gt.jpg`, `before.jpg`, `after.jpg`, and `layout-audit.json` from the same fixture, page set, renderer, and resolution; `before.jpg` captures the pre-fix output, while `after.jpg` and the layout report use the current output. Every fix PR with a raster change must change `after.jpg` and `layout-audit.json`. Generate the report from the same GT and current-output PDFs used for `gt.jpg` and `after.jpg` with `compare_layout.py --json --audit`; classify page-count, missing/extra/reflow or changed-wrap, painted-text visibility, visible-fill occlusion, and large-shift failures with open issues in the PR's `Visual audit` category fields and matching `Remaining:` rows. Use progressive JPEG quality 86 with metadata stripped, preserve the source pixel dimensions, and verify text and images remain legible for direct GitHub links. Strip first, then re-set the density (`-strip -density 150 -units PixelsPerInch`): the contract check rejects evidence recording under 150 DPI, which stripping alone removes.
+- For visual bug fixes tied to an issue, keep `assets/bugfixes/issue-<number>/gt.jpg`, `before.jpg`, `after.jpg`, and `layout-audit.json` from the same fixture, page set, renderer, and resolution; `before.jpg` captures the pre-fix output, while `after.jpg` and the layout report use the current output. Every fix PR with a raster change must change `after.jpg` and `layout-audit.json`. Generate the report from the same GT and current-output PDFs used for `gt.jpg` and `after.jpg` with `compare_layout.py --json --audit --fine-shift PT`; record the same fine-detail threshold in the PR and classify page-count, missing/extra/reflow or changed-wrap, painted-text visibility, visible-fill occlusion, and fine/large-shift failures with open issues in the `Visual audit` fields and matching `Remaining:` rows. Use progressive JPEG quality 86 with metadata stripped, preserve the source pixel dimensions, and verify text and images remain legible for direct GitHub links. Strip first, then re-set the density (`-strip -density 150 -units PixelsPerInch`): the contract check rejects evidence recording under 150 DPI, which stripping alone removes.
 - A text-layer-only fix may correctly produce byte- and pixel-identical `before.jpg` and `after.jpg`. Regenerate and verify the current `after.jpg` without adding annotations; it need not appear in the diff when the render is unchanged. Set `Text-layer-only: Yes` and `Pixel delta: 0` in the PR's `Visual audit`, change `layout-audit.json`, and require that report to show the missing/extra searchable-text finding resolved. The contract requires both evidence files and uses ImageMagick's exact decoded-pixel comparison to verify that the declared zero delta is true.
 - **When filing a visual defect issue, attach a side-by-side image (GT left, office2pdf output at filing time right)** rendered from the same page and resolution, committed as `assets/bugfixes/issue-<number>/compare.jpg` (same JPEG rules as above) and embedded in the issue body via a commit-pinned raw URL. For classified fixtures, confirm with the user before publishing the image; the surrounding issue text must still follow the Confidentiality rules.
 
@@ -146,8 +146,8 @@ just the pages a screenshot shows.
 2. **Run all four axes**, not one: `compare_layout.py` (geometry, per page),
    `compare_text_layer.py` (what a reader can select), `compare_render.py`
    (colour and pixels), and a page-by-page visual at >=150 DPI.
-   Run the geometry axis with `--audit`; every large text-instance shift or
-   painted-text visibility mismatch or visible-fill occlusion it names must be fixed or recorded as a
+   Run the geometry axis with `--audit --fine-shift PT`; every fine/large
+   text-instance shift, painted-text visibility mismatch, or visible-fill occlusion it names must be fixed or recorded as a
    remaining deviation with an open issue.
    Do not classify the pixel diff as antialiasing while this audit is failing.
    Source/XML inspection and numeric reports only route attention; they never
@@ -173,15 +173,15 @@ produces no new finding.
 Run `python3 scripts/compare_render.py <GT.pdf> <output.pdf> [--page N]` before
 judging a rendered difference. It reports geometry, colour histogram, and pixel
 difference together, then states what the combination means.
-For a visual audit, also pass `--artifacts-dir <directory>`: for the page chosen
-by `--page`, it preserves the full GT/output pages, their side-by-side image,
-the 5% pixel diff, and a matched GT/output crop for every large text-instance
-shift on that page. Run it once for every compared page, using a distinct
+For a visual audit, also pass `--fine-shift PT --artifacts-dir <directory>`: for
+the page chosen by `--page`, it preserves the full GT/output pages, their side-by-side image,
+the 5% pixel diff, and a matched GT/output crop for every text-instance shift
+past the active fine or coarse gate on that page. Run it once for every compared page, using a distinct
 directory per page. It fails if ImageMagick is unavailable rather than silently
 omitting evidence. Open every emitted path with Codex/Claude image vision;
 producing the files is not itself inspection.
 
-For layout defects, run `python3 scripts/compare_layout.py <GT.pdf> <output.pdf> --audit`
+For layout defects, run `python3 scripts/compare_layout.py <GT.pdf> <output.pdf> --audit --fine-shift PT`
 first: it matches text lines from `mutool` traces and reports missing/extra/
 re-wrapped lines, spatial-anchor dy, pitch and width drift, painted-text visibility,
 visible-fill occlusions, and a rect census, with GT noise floors built in (`--noise-floor 0.12` Word,
@@ -204,11 +204,15 @@ one visual run and uses the minimum fully transformed glyph x/y as its
 comparable anchor. Its numbers are assertable; pixel counts are only a
 tripwire. Repeated strings are matched as separate spatial instances: a chart
 title and legend both named `Sales` appear as `Sales [1/2]` and `Sales [2/2]`,
-with their own `dx`/`dy`. The audit exits nonzero when any instance moves more
-than 5pt (override with `--large-shift PT` for a justified fixture-specific
-threshold), or when a matched line changes between painted and hidden/low
-contrast; inspect and track every named instance before marking alignment or
-text flow as matching.
+with their own `dx`/`dy`. The coarse audit exits nonzero when any instance moves
+more than 5pt (override with `--large-shift PT` for a justified fixture-specific
+threshold). Add `--fine-shift PT` for high-DPI evidence; it keeps that coarse
+report and also fails on matched text beyond the recorded fine tolerance. The
+fine threshold must be at least the trace noise floor. Raster-only edge or
+colour changes may be font antialiasing, but trace-derived x/y anchor movement
+is geometry and must be fixed or tracked. Painted versus hidden/low-contrast
+changes also fail; inspect and track every named instance before marking
+alignment or text flow as matching.
 
 **Its width column trims leading and trailing whitespace glyphs.** Their
 advances position no visible ink and previously invented large width deltas

--- a/assets/bugfixes/README.md
+++ b/assets/bugfixes/README.md
@@ -34,20 +34,20 @@ comparison; the declaration cannot bypass a raster-changing fix.
 Generate the machine-readable layout report from those same GT and after PDFs:
 
 ```sh
-python3 scripts/compare_layout.py --json --audit gt.pdf after.pdf \
+python3 scripts/compare_layout.py --json --audit --fine-shift 0.5 gt.pdf after.pdf \
   > assets/bugfixes/issue-<number>/layout-audit.json
 ```
 
 The command exits nonzero when material findings remain but still writes the
 report. Change both `after.jpg` and `layout-audit.json` in a raster-changing fix
 pull request; use the text-layer-only exception above when the current render is
-byte-identical. In the PR's `Visual audit` section, mark each layout-audit category
-field as `Pass` or list the open issues that classify it. Those issue references
-must also appear in `Remaining:` deviation rows. The gate rejects a claimed pass
-when the report contains a page-count
+byte-identical. Record the same `Fine-detail threshold` in the PR's `Visual
+audit`, then mark each layout-audit category as `Pass` or list the open issues
+that classify it. Those references must also appear in `Remaining:` deviation
+rows. The gate rejects a claimed pass when the report contains a page-count
 difference, missing/extra/reflowed text, changed wraps, a painted-text visibility
-mismatch, a visible-fill occlusion, or a text shift above the configured
-large-shift threshold.
+mismatch, a visible-fill occlusion, or a text shift above the configured fine or
+large threshold.
 
 ## Evidence mode: `defect`
 

--- a/scripts/check_visual_pr.py
+++ b/scripts/check_visual_pr.py
@@ -49,8 +49,8 @@ INSPECTION_ITEMS = (
     "Stored progressive JPEG quality 86 assets with metadata stripped",
     "Used Codex/Claude vision to inspect the full GT/output pages, diff, and matched crops",
     "Inspected matched region crops at full resolution",
-    "Ran compare_layout.py --audit and dispositioned every large text-instance "
-    "shift, painted-text visibility mismatch, and visible-fill occlusion",
+    "Ran compare_layout.py --audit --fine-shift PT and dispositioned every fine/large "
+    "text-instance shift, painted-text visibility mismatch, and visible-fill occlusion",
     "Ran the 5% fuzz pixel-difference sweep",
     "Inventoried hairlines and border dash styles",
     "Inventoried font weight, italic, and underline emphasis",
@@ -284,6 +284,7 @@ def layout_audit_categories(report: object) -> dict[str, bool]:
     has_text_flow_findings = False
     has_visible_fill_findings = False
     has_large_shifts = False
+    has_fine_shifts = False
     for page_number, page in enumerate(pages, start=1):
         if not isinstance(page, dict):
             raise ValueError(f"page {page_number} must be an object")
@@ -304,22 +305,50 @@ def layout_audit_categories(report: object) -> dict[str, bool]:
             )
             visible_fill_count = visible_fills["mismatch_count"]
             large_shift_count = instances["large_shift_count"]
+            fine_shift_count = instances["fine_shift_count"]
         except (KeyError, TypeError) as exc:
             raise ValueError(f"page {page_number} is missing compare_layout fields") from exc
-        counts = (*text_flow_counts, visible_fill_count, large_shift_count)
+        counts = (*text_flow_counts, visible_fill_count, large_shift_count, fine_shift_count)
         if any(type(count) is not int or count < 0 for count in counts):
             raise ValueError(f"page {page_number} finding counts must be non-negative integers")
 
         has_text_flow_findings |= any(text_flow_counts)
         has_visible_fill_findings |= visible_fill_count > 0
         has_large_shifts |= large_shift_count > 0
+        has_fine_shifts |= fine_shift_count > 0
 
     return {
         "page count": gt_pages != out_pages,
         "text flow": has_text_flow_findings,
         "visible fills": has_visible_fill_findings,
         "large shifts": has_large_shifts,
+        "fine shifts": has_fine_shifts,
     }
+
+
+def layout_audit_fine_shift_threshold(report: object) -> float:
+    """Return the single positive fine-detail threshold recorded on every page."""
+
+    if not isinstance(report, dict) or not isinstance(report.get("pages"), list):
+        raise ValueError("the report must contain page vectors")
+    thresholds: list[float] = []
+    for page_number, page in enumerate(report["pages"], start=1):
+        try:
+            threshold = page["instances"]["fine_shift_threshold"]
+        except (KeyError, TypeError) as exc:
+            raise ValueError(
+                f"page {page_number} is missing the fine-detail threshold"
+            ) from exc
+        if isinstance(threshold, bool) or not isinstance(threshold, (int, float)):
+            raise ValueError(f"page {page_number} fine-detail threshold must be numeric")
+        if threshold <= 0:
+            raise ValueError(f"page {page_number} fine-detail threshold must be positive")
+        thresholds.append(float(threshold))
+    if not thresholds:
+        raise ValueError("the report has no fine-detail threshold")
+    if any(abs(threshold - thresholds[0]) > 1e-9 for threshold in thresholds[1:]):
+        raise ValueError("fine-detail threshold differs between pages")
+    return thresholds[0]
 
 
 def disposition_issue_numbers(value: str | None) -> set[int] | None:
@@ -417,9 +446,22 @@ def validate_layout_audit(body: str, changed_paths: list[str], root: Path) -> li
     try:
         report = json.loads(report_path.read_text(encoding="utf-8"))
         findings = layout_audit_categories(report)
+        report_fine_shift_threshold = layout_audit_fine_shift_threshold(report)
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         errors.append(f"{expected_path}: invalid layout audit report: {exc}.")
         return errors
+
+    threshold_value = field(audit, "Fine-detail threshold")
+    threshold_match = re.fullmatch(r"(\d+(?:\.\d+)?)\s*pt", threshold_value or "", re.I)
+    if not threshold_match:
+        errors.append(
+            "Visual audit > Fine-detail threshold is required in points, for example `0.5pt`."
+        )
+    elif abs(float(threshold_match.group(1)) - report_fine_shift_threshold) > 1e-9:
+        errors.append(
+            "Visual audit > Fine-detail threshold must match the layout report's "
+            f"{report_fine_shift_threshold:g}pt threshold."
+        )
 
     remaining_issues = remaining_issue_numbers(body)
     fields = {
@@ -427,6 +469,7 @@ def validate_layout_audit(body: str, changed_paths: list[str], root: Path) -> li
         "text flow": "Layout audit text flow",
         "visible fills": "Layout audit visible fills",
         "large shifts": "Layout audit large shifts",
+        "fine shifts": "Layout audit fine shifts",
     }
     for category, has_findings in findings.items():
         field_name = fields[category]

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -33,7 +33,8 @@ position, size, pitch, wrap, and element presence, which is what actually
 changes when a layout defect is fixed.
 
 Usage:
-    compare_layout.py GT.pdf OUTPUT.pdf [--page N] [--noise-floor PT] [--audit]
+    compare_layout.py GT.pdf OUTPUT.pdf [--page N] [--noise-floor PT]
+        [--fine-shift PT] [--audit]
 """
 
 from __future__ import annotations
@@ -943,6 +944,7 @@ def diff_page(
     out: PageLayout,
     noise_floor: float = 0.12,
     large_shift: float = 5.0,
+    fine_shift: float | None = None,
 ) -> dict:
     matches, missing, extra = match_lines(gt.lines, out.lines)
     wraps, missing, extra = take_wrap_differences(missing, extra)
@@ -1006,6 +1008,15 @@ def diff_page(
         for instance in instances
         if abs(instance["dx"]) > large_shift or abs(instance["dy"]) > large_shift
     ]
+    fine_shifts = (
+        [
+            instance
+            for instance in instances
+            if abs(instance["dx"]) > fine_shift or abs(instance["dy"]) > fine_shift
+        ]
+        if fine_shift is not None
+        else []
+    )
 
     pitch_deltas: list[float] = []
     matched_gt = {id(gt_line) for gt_line, _ in matches}
@@ -1074,6 +1085,9 @@ def diff_page(
             "large_shift_threshold": large_shift,
             "large_shift_count": len(large_shifts),
             "large_shifts": large_shifts,
+            "fine_shift_threshold": fine_shift,
+            "fine_shift_count": len(fine_shifts),
+            "fine_shifts": fine_shifts,
         },
         "visibility": {
             "mismatch_count": len(visibility_mismatches),
@@ -1137,6 +1151,21 @@ def render_reading(vectors: list[dict]) -> str:
                 f"past {vector['instances']['large_shift_threshold']:.2f}pt: {examples}. "
                 "These are layout differences, not antialiasing; inspect and track each one"
             )
+        if vector["instances"]["fine_shift_count"]:
+            examples = "; ".join(
+                f"'{item['label']}' dx {item['dx']:+.2f}pt, dy {item['dy']:+.2f}pt"
+                for item in sorted(
+                    vector["instances"]["fine_shifts"],
+                    key=lambda value: max(abs(value["dx"]), abs(value["dy"])),
+                    reverse=True,
+                )
+            )
+            page_notes.append(
+                f"{vector['instances']['fine_shift_count']} matched text instance(s) move "
+                f"past the fine-detail {vector['instances']['fine_shift_threshold']:.2f}pt "
+                f"tolerance: {examples}. Trace-derived anchor movement is geometry, not "
+                "font antialiasing; inspect and track each one"
+            )
         if vector["visibility"]["mismatch_count"]:
             examples = "; ".join(
                 f"'{item['label']}' GT {item['gt']} vs output {item['out']}"
@@ -1177,7 +1206,11 @@ def render_reading(vectors: list[dict]) -> str:
 def audit_failures(vectors: list[dict]) -> int:
     """Count material layout or paint findings that require visual disposition."""
     return sum(
-        vector["instances"]["large_shift_count"]
+        (
+            vector["instances"]["fine_shift_count"]
+            if vector["instances"]["fine_shift_threshold"] is not None
+            else vector["instances"]["large_shift_count"]
+        )
         + vector["visibility"]["mismatch_count"]
         + vector["visible_fills"]["mismatch_count"]
         + vector["lines"]["missing"]
@@ -1220,15 +1253,28 @@ def main() -> int:
         help="flag any matched text instance whose x or y moves by more than this (default: 5pt)",
     )
     parser.add_argument(
+        "--fine-shift",
+        type=float,
+        metavar="PT",
+        help=(
+            "enable the fine-detail audit gate and flag matched text whose x or y "
+            "moves by more than PT; does not replace the 5pt coarse summary"
+        ),
+    )
+    parser.add_argument(
         "--audit",
         action="store_true",
         help=(
             "exit nonzero on missing/extra/reflowed text, changed wraps, "
-            "a text/fill visibility mismatch, a large instance shift, or a page-count mismatch"
+            "a text/fill visibility mismatch, an active fine/coarse instance "
+            "shift, or a page-count mismatch"
         ),
     )
     parser.add_argument("--json", action="store_true", help="emit the deviation vectors as JSON")
     args = parser.parse_args()
+
+    if args.fine_shift is not None and args.fine_shift < args.noise_floor:
+        parser.error("--fine-shift must be at least --noise-floor")
 
     gt_pages = parse_trace(run_mutool(args.gt))
     out_pages = parse_trace(run_mutool(args.output))
@@ -1251,6 +1297,7 @@ def main() -> int:
             out_pages[i],
             noise_floor=args.noise_floor,
             large_shift=args.large_shift,
+            fine_shift=args.fine_shift,
         )
         for i in range(count)
     ]
@@ -1270,6 +1317,11 @@ def main() -> int:
         print(f"PAGE COUNT MISMATCH: GT {len(gt_pages)} vs output {len(out_pages)}\n")
     for index, vector in enumerate(vectors, start=1):
         line_info = vector["lines"]
+        fine_shift_summary = (
+            f"fine shifts {vector['instances']['fine_shift_count']} | "
+            if vector["instances"]["fine_shift_threshold"] is not None
+            else ""
+        )
         print(
             f"page {index}: {line_info['matched']} matched "
             f"({line_info['missing']} missing, {line_info['extra']} extra, "
@@ -1279,6 +1331,7 @@ def main() -> int:
             f"pitch worst {vector['pitch']['worst_delta']:.2f}pt | "
             f"width worst {vector['width']['worst_pct']:.1f}% | "
             f"large shifts {vector['instances']['large_shift_count']} | "
+            f"{fine_shift_summary}"
             f"visibility {vector['visibility']['mismatch_count']} | "
             f"visible fills {vector['visible_fills']['mismatch_count']} | "
             f"rects {vector['rects']['gt_count']}/{vector['rects']['out_count']}"

--- a/scripts/compare_render.py
+++ b/scripts/compare_render.py
@@ -27,7 +27,8 @@ histogram flat has moved something without changing what is drawn, which is
 usually exactly what a positioning fix should do.
 
 Usage:
-    compare_render.py GT.pdf OUTPUT.pdf [--page N] [--dpi 150] [--audit]
+    compare_render.py GT.pdf OUTPUT.pdf [--page N] [--dpi 150]
+        [--fine-shift PT] [--audit]
 """
 
 from __future__ import annotations
@@ -341,7 +342,11 @@ def page_text_lines(pdf: Path, page: int) -> list[TextLine]:
 
 
 def report_geometry(
-    gt: Path, other: Path, page: int = 1, large_shift: float = 5.0
+    gt: Path,
+    other: Path,
+    page: int = 1,
+    large_shift: float = 5.0,
+    fine_shift: float | None = None,
 ) -> dict[str, float]:
     """Vertical and horizontal drift of spatially matched text instances."""
     gt_text_lines = page_text_lines(gt, page)
@@ -377,6 +382,15 @@ def report_geometry(
     large_matches = [
         match for match in matches if abs(match.dx) > large_shift or abs(match.dy) > large_shift
     ]
+    fine_matches = (
+        [
+            match
+            for match in matches
+            if abs(match.dx) > fine_shift or abs(match.dy) > fine_shift
+        ]
+        if fine_shift is not None
+        else []
+    )
     print(f"  matched instances  {len(dy)} of {len(gt_text_lines)} "
           f"({coverage * 100:.0f}% of the GT's text lines)")
     print(
@@ -395,9 +409,18 @@ def report_geometry(
             f"    page {match.reference.page + 1}: {match.label[:52]}  "
             f"dx {match.dx:+.2f}pt  dy {match.dy:+.2f}pt"
         )
+    if fine_shift is not None:
+        print(f"  fine-detail instance shifts (>{fine_shift:.2f}pt): {len(fine_matches)}")
+        for match in sorted(
+            fine_matches, key=lambda item: max(abs(item.dx), abs(item.dy)), reverse=True
+        ):
+            print(
+                f"    page {match.reference.page + 1}: {match.label[:52]}  "
+                f"dx {match.dx:+.2f}pt  dy {match.dy:+.2f}pt"
+            )
     if page_mismatch:
         print(f"  on a different page: {page_mismatch} line(s) — pagination differs")
-    return {
+    result = {
         "mad_y": mad_y,
         "mad_x": mad_x,
         "page_mismatch": float(page_mismatch),
@@ -408,6 +431,14 @@ def report_geometry(
         "large_shift_count": float(len(large_matches)),
         "large_shift_threshold": large_shift,
     }
+    if fine_shift is not None:
+        result.update(
+            {
+                "fine_shift_count": float(len(fine_matches)),
+                "fine_shift_threshold": fine_shift,
+            }
+        )
+    return result
 
 
 def histogram(png: Path) -> tuple[list[int], int]:
@@ -838,6 +869,8 @@ def diagnose(
     ink_delta: float = histogram_result.get("ink_delta", 0.0)
     large_shift_count = int(geometry.get("large_shift_count", 0.0))
     large_shift_threshold = geometry.get("large_shift_threshold", 5.0)
+    fine_shift_count = int(geometry.get("fine_shift_count", 0.0))
+    fine_shift_threshold = geometry.get("fine_shift_threshold")
 
     # Thresholds are deliberately loose: they route attention, they do not
     # decide correctness. A point of drift is invisible; ten is not.
@@ -852,6 +885,13 @@ def diagnose(
     ink_differs: bool = colour_measured and abs(ink_delta) > 0.2
 
     findings: list[str] = []
+    if fine_shift_count and fine_shift_threshold is not None:
+        findings.append(
+            f"{fine_shift_count} matched text instance(s) move more than the "
+            f"fine-detail {fine_shift_threshold:.2f}pt tolerance. Trace-derived "
+            "anchor movement is geometry, not font antialiasing; inspect and track "
+            "each named instance above."
+        )
     if large_shift_count:
         findings.append(
             f"{large_shift_count} matched text instance(s) move more than "
@@ -978,14 +1018,23 @@ def main() -> None:
         help="flag any matched text instance whose x or y moves by more than this (default: 5pt)",
     )
     parser.add_argument(
+        "--fine-shift",
+        type=float,
+        metavar="PT",
+        help=(
+            "enable the fine-detail audit gate and flag matched text whose x or y "
+            "moves by more than PT; does not replace the 5pt coarse summary"
+        ),
+    )
+    parser.add_argument(
         "--audit",
         action="store_true",
-        help="exit nonzero when a large per-instance text shift is found",
+        help="exit nonzero when the enabled per-instance text-shift gate finds movement",
     )
     parser.add_argument(
         "--artifacts-dir",
         type=Path,
-        help="preserve full GT/output pages, 5%% diff, and large-shift crops for model vision",
+        help="preserve full GT/output pages, 5%% diff, and gated-shift crops for model vision",
     )
     parser.add_argument(
         "--lines",
@@ -997,6 +1046,8 @@ def main() -> None:
 
     if args.dpi < 150:
         raise SystemExit("--dpi must be at least 150; hairlines vanish below that")
+    if args.fine_shift is not None and args.fine_shift <= 0:
+        parser.error("--fine-shift must be greater than zero")
     require_vision_artifact_dependencies(args.artifacts_dir)
 
     print(f"GT     {args.gt}")
@@ -1004,7 +1055,11 @@ def main() -> None:
     print(f"page {args.page} at {args.dpi} DPI\n")
 
     geometry = report_geometry(
-        args.gt, args.output, page=args.page, large_shift=args.large_shift
+        args.gt,
+        args.output,
+        page=args.page,
+        large_shift=args.large_shift,
+        fine_shift=args.fine_shift,
     )
     print()
     if args.lines:
@@ -1031,8 +1086,8 @@ def main() -> None:
                 page_matches = [
                     match
                     for match in matches
-                    if abs(match.dx) > args.large_shift
-                    or abs(match.dy) > args.large_shift
+                    if abs(match.dx) > (args.fine_shift or args.large_shift)
+                    or abs(match.dy) > (args.fine_shift or args.large_shift)
                 ]
                 print()
                 preserve_vision_artifacts(
@@ -1050,11 +1105,16 @@ def main() -> None:
         print("  is on PATH. Install `imagemagick` to measure colour and ink.")
     print()
     diagnose(geometry, histogram_result, clusters)
-    if args.audit and geometry.get("large_shift_count", 0.0):
+    audit_shift_count = (
+        geometry.get("fine_shift_count", 0.0)
+        if args.fine_shift is not None
+        else geometry.get("large_shift_count", 0.0)
+    )
+    if args.audit and audit_shift_count:
         print()
         print(
-            "AUDIT FAILED: large text-instance shifts are layout differences, not "
-            "antialiasing; inspect and track every line above."
+            "AUDIT FAILED: text-instance shifts past the active gate are layout "
+            "differences, not antialiasing; inspect and track every line above."
         )
         raise SystemExit(1)
 

--- a/scripts/issue_loop_prompt.md
+++ b/scripts/issue_loop_prompt.md
@@ -10,9 +10,10 @@ replace those documents.
 - Delegate the read-only documentation freshness audit and wait for `PASS:` before
   **every** commit, not only the one that opens the pull request.
 - Layout and rendering claims need measurement, not inspection: use
-  `scripts/compare_layout.py --audit`, `scripts/compare_render.py --artifacts-dir`,
-  and `scripts/compare_text_layer.py`, and look at the emitted images. A numeric report
-  alone is not a visual pass.
+  `scripts/compare_layout.py --audit --fine-shift PT`,
+  `scripts/compare_render.py --fine-shift PT --artifacts-dir`, and
+  `scripts/compare_text_layer.py`, and look at the emitted images. A numeric
+  report alone is not a visual pass.
 - Settle an unclear native-application rule with `scripts/probe_harness.py` (one factor
   per variant) rather than by arguing from the corpus.
 - A visual defect fix owes the evidence contract in `CLAUDE.md`:

--- a/scripts/tests/test_check_visual_pr.py
+++ b/scripts/tests/test_check_visual_pr.py
@@ -54,10 +54,12 @@ def visual_body(result_overrides=None, include_previews=True):
 - Renderer and DPI: pdftoppm, 150 DPI
 - Evidence mode: `fix`
 - Layout audit report: `assets/bugfixes/issue-186/layout-audit.json`
+- Fine-detail threshold: 0.5pt
 - Layout audit page count: Pass
 - Layout audit text flow: Pass
 - Layout audit visible fills: Pass
 - Layout audit large shifts: Pass
+- Layout audit fine shifts: Pass
 - New follow-up issues found in this audit: {follow_up_value}
 - Model vision findings: Full pages, pixel diff, and matched crops were opened; no untracked visual deviation remains.
 - GT: `assets/bugfixes/issue-186/gt.jpg`
@@ -87,6 +89,8 @@ def layout_report(
     reflow_gt=0,
     reflow_out=0,
     large_shifts=0,
+    fine_shifts=0,
+    fine_threshold=0.5,
     visibility=0,
     visible_fills=0,
 ):
@@ -96,7 +100,11 @@ def layout_report(
                 "lines": {"missing": missing, "extra": extra},
                 "wraps": {"count": wraps},
                 "reflow": {"gt_lines": reflow_gt, "out_lines": reflow_out},
-                "instances": {"large_shift_count": large_shifts},
+                "instances": {
+                    "large_shift_count": large_shifts,
+                    "fine_shift_count": fine_shifts,
+                    "fine_shift_threshold": fine_threshold,
+                },
                 "visibility": {"mismatch_count": visibility},
                 "visible_fills": {"mismatch_count": visible_fills},
             }
@@ -169,8 +177,8 @@ class PullRequestBodyTests(unittest.TestCase):
 
     def test_visual_audit_requires_layout_finding_disposition(self):
         required = (
-            "- [x] Ran compare_layout.py --audit and dispositioned every "
-            "large text-instance shift, painted-text visibility mismatch, and "
+            "- [x] Ran compare_layout.py --audit --fine-shift PT and dispositioned every "
+            "fine/large text-instance shift, painted-text visibility mismatch, and "
             "visible-fill occlusion"
         )
         errors = validate_pr_body(
@@ -311,6 +319,40 @@ class LayoutAuditTests(unittest.TestCase):
             layout_report(large_shifts=5),
         )
         self.assertTrue(any("large shifts" in error and "issue reference" in error for error in errors))
+
+    def test_fine_shift_failure_rejects_pass_disposition(self):
+        errors = validate_report(
+            visual_body(),
+            layout_report(fine_shifts=2),
+        )
+        self.assertTrue(any("fine shifts" in error and "issue reference" in error for error in errors))
+
+    def test_fine_shift_failure_accepts_tracked_position_issue(self):
+        body = visual_body({"Position/size": "Remaining: #328"}).replace(
+            "Layout audit fine shifts: Pass",
+            "Layout audit fine shifts: #328",
+        )
+        self.assertEqual(validate_report(body, layout_report(fine_shifts=2)), [])
+
+    def test_fine_detail_threshold_is_required_in_pr_metadata(self):
+        body = visual_body().replace("- Fine-detail threshold: 0.5pt\n", "")
+        errors = validate_report(body, layout_report())
+        self.assertTrue(any("Fine-detail threshold" in error and "required" in error for error in errors))
+
+    def test_fine_detail_threshold_must_match_machine_report(self):
+        body = visual_body().replace(
+            "Fine-detail threshold: 0.5pt",
+            "Fine-detail threshold: 0.75pt",
+        )
+        errors = validate_report(body, layout_report())
+        self.assertTrue(any("Fine-detail threshold" in error and "0.5" in error for error in errors))
+
+    def test_machine_report_must_record_fine_detail_threshold(self):
+        errors = validate_report(
+            visual_body(),
+            layout_report(fine_threshold=None),
+        )
+        self.assertTrue(any("fine-detail threshold" in error.lower() for error in errors))
 
     def test_visibility_failure_rejects_pass_text_flow_disposition(self):
         errors = validate_report(

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -332,6 +332,29 @@ class MatchAndDiffTest(unittest.TestCase):
         # The raw statistic still carries the measurement.
         self.assertGreater(vector["baseline"]["worst_dy"], 0.0)
 
+    def test_fine_shift_gate_ignores_trace_noise_but_fails_visible_movement(self) -> None:
+        gt = "\n".join([line_of("noise", 72, 100), line_of("moved", 72, 120)])
+        out = "\n".join([line_of("noise", 72, 100.12), line_of("moved", 72, 120.75)])
+
+        vector = self.diff(gt, out, fine_shift=0.5)
+
+        self.assertEqual(vector["instances"]["large_shift_count"], 0)
+        self.assertEqual(vector["instances"]["fine_shift_threshold"], 0.5)
+        self.assertEqual(vector["instances"]["fine_shift_count"], 1)
+        self.assertEqual(vector["instances"]["fine_shifts"][0]["label"], "moved")
+        self.assertEqual(compare_layout.audit_failures([vector]), 1)
+
+    def test_coarse_audit_stays_clean_without_fine_shift_mode(self) -> None:
+        gt = line_of("moved", 72, 120)
+        out = line_of("moved", 72, 121.1)
+
+        vector = self.diff(gt, out, large_shift=5.0)
+
+        self.assertEqual(vector["instances"]["large_shift_threshold"], 5.0)
+        self.assertEqual(vector["instances"]["large_shift_count"], 0)
+        self.assertIsNone(vector["instances"]["fine_shift_threshold"])
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
     def test_missing_and_extra_lines_are_counted(self) -> None:
         gt = "\n".join([line_of("alpha", 72, 100), line_of("beta", 72, 112)])
         out = line_of("alpha", 72, 100)
@@ -803,6 +826,36 @@ class CompareLayoutCliTest(unittest.TestCase):
         report = json.loads(stdout.getvalue())
         self.assertEqual(result, 1)
         self.assertEqual(report["pages"][0]["visible_fills"]["mismatch_count"], 1)
+
+    def test_fine_shift_mode_makes_json_audit_fail_below_coarse_threshold(self) -> None:
+        traces = [
+            trace_document(line_of("moved", 72, 100)),
+            trace_document(line_of("moved", 72, 100.75)),
+        ]
+        stdout = io.StringIO()
+        with (
+            patch.object(compare_layout, "run_mutool", side_effect=traces),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "compare_layout.py",
+                    "gt.pdf",
+                    "output.pdf",
+                    "--json",
+                    "--audit",
+                    "--fine-shift",
+                    "0.5",
+                ],
+            ),
+            patch("sys.stdout", stdout),
+        ):
+            result = compare_layout.main()
+
+        report = json.loads(stdout.getvalue())
+        self.assertEqual(result, 1)
+        self.assertEqual(report["pages"][0]["instances"]["large_shift_count"], 0)
+        self.assertEqual(report["pages"][0]["instances"]["fine_shift_count"], 1)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_compare_render.py
+++ b/scripts/tests/test_compare_render.py
@@ -232,6 +232,24 @@ class RepeatedTextGeometryTest(unittest.TestCase):
         self.assertIn("Sales [1/2]", output.getvalue())
         self.assertIn("+120.00pt", output.getvalue())
 
+    def test_report_keeps_coarse_summary_and_adds_fine_shift_gate(self) -> None:
+        gt_lines = [compare_render.TextLine(0, 10.0, 20.0, "Fine detail")]
+        output_lines = [compare_render.TextLine(0, 10.0, 20.75, "Fine detail")]
+        with mock.patch.object(
+            compare_render, "text_lines", side_effect=[gt_lines, output_lines]
+        ):
+            result = compare_render.report_geometry(
+                Path("gt.pdf"),
+                Path("output.pdf"),
+                large_shift=5.0,
+                fine_shift=0.5,
+            )
+
+        self.assertEqual(result["large_shift_count"], 0.0)
+        self.assertEqual(result["large_shift_threshold"], 5.0)
+        self.assertEqual(result["fine_shift_count"], 1.0)
+        self.assertEqual(result["fine_shift_threshold"], 0.5)
+
     def test_report_scopes_geometry_to_the_requested_page(self) -> None:
         gt_lines = [
             compare_render.TextLine(0, 10.0, 20.0, "First page"),


### PR DESCRIPTION
## Summary

- Adds opt-in `--fine-shift PT` gates to both layout and render audits while retaining the existing 5pt coarse `--large-shift` report.
- Requires visual-fix JSON evidence and PR metadata to record the same fine-detail threshold and disposition fine-shift findings.
- Updates the visual workflow, evidence guide, unattended prompt, and regression coverage.

## Why

The exact PR #1407 invitation comparison had visible 0.52–1.07pt baseline drift at high DPI, but the default 5pt audit exited clean. Fine-detail evidence now has a separately named, trace-derived gate without changing coarse triage semantics.

## Validation

- `python3 -m unittest discover -s scripts/tests` — 305 passed
- `python3 -m py_compile scripts/compare_layout.py scripts/compare_render.py scripts/check_visual_pr.py`
- `git diff --check`
- Exact #1219 / PR #1407 replay with `--audit --fine-shift 0.5`: coarse large shifts 0, fine shifts 6 on page 1, exit 1; the remaining baseline defect is tracked in #1479.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Changes only comparison harnesses, their tests, documentation, and PR metadata validation.

Related: #1480
