### PR TITLE
render: keep literal text from continuing an embedded expression

### DIFF
--- a/crates/office2pdf/src/lib_render_tests.rs
+++ b/crates/office2pdf/src/lib_render_tests.rs
@@ -24,6 +24,19 @@ fn test_render_document_single_paragraph() {
 }
 
 #[test]
+fn test_render_document_hard_linebreak_before_parenthesis() {
+    // A spreadsheet cell with a hard break before a parenthesised code, as in
+    // "New York" over "(07) Western", failed to compile at all.
+    let doc = make_simple_document("New York\n(07) Western");
+    let pdf = render_document(&doc).unwrap();
+    let text = pdf_extract::extract_text_from_mem(&pdf).unwrap();
+    assert!(
+        text.contains("(07) Western") && !text.contains(';'),
+        "text after the hard break must survive and the terminator must not render: {text}"
+    );
+}
+
+#[test]
 fn test_render_document_with_tab_leader() {
     let doc = Document {
         metadata: Metadata::default(),

--- a/crates/office2pdf/src/render/typst_gen_fixed_page_textbox_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_fixed_page_textbox_tests.rs
@@ -879,6 +879,111 @@ fn test_fixed_page_text_box_compact_list_preserves_soft_line_breaks() {
 }
 
 #[test]
+fn test_fixed_page_text_box_soft_line_break_before_parenthesis_compiles() {
+    // A Korean slide run reads "첫째 줄" over "(2) 둘째 줄". CJK keeps the run
+    // off the advance grid and it carries no formatting wrapper, so the soft
+    // break's `#linebreak()` is followed by the bare text, which Typst would
+    // otherwise read as the break's argument list.
+    let doc = make_doc(vec![make_fixed_page(
+        960.0,
+        540.0,
+        vec![FixedElement {
+            x: 100.0,
+            y: 200.0,
+            width: 320.0,
+            height: 140.0,
+            kind: FixedElementKind::TextBox(crate::ir::TextBoxData {
+                content: vec![Block::Paragraph(Paragraph {
+                    style: ParagraphStyle::default(),
+                    runs: vec![Run {
+                        text: "첫째 줄\u{000B}(2) 둘째 줄".to_string(),
+                        style: TextStyle::default(),
+                        href: None,
+                        footnote: None,
+                    }],
+                })],
+                padding: Insets::default(),
+                vertical_align: crate::ir::TextBoxVerticalAlign::Top,
+                fill: None,
+                opacity: None,
+                stroke: None,
+                shape_kind: None,
+                no_wrap: false,
+                auto_fit: false,
+                text_rotation_deg: None,
+                shape_rotation_deg: None,
+            }),
+        }],
+    )]);
+    let output = generate_typst(&doc).unwrap();
+    assert!(
+        output.source.contains("#linebreak()#[(2)"),
+        "the bare text after the soft break must be wrapped: {}",
+        output.source
+    );
+    let pdf =
+        crate::render::pdf::compile_to_pdf(&output.source, &output.images, None, &[], false, false)
+            .unwrap_or_else(|error| panic!("compile failed: {error}\n{}", output.source));
+    assert!(pdf.starts_with(b"%PDF"));
+}
+
+#[test]
+fn test_fixed_page_text_box_grid_word_before_parenthesised_run_compiles() {
+    // A styleless ASCII run is emitted as `#o2p-pptx-word(...)`, which ends
+    // in `)`; a following Korean run starting with `(` leaves the grid and
+    // would otherwise be read as that call's argument list.
+    let doc = make_doc(vec![make_fixed_page(
+        960.0,
+        540.0,
+        vec![FixedElement {
+            x: 100.0,
+            y: 200.0,
+            width: 320.0,
+            height: 140.0,
+            kind: FixedElementKind::TextBox(crate::ir::TextBoxData {
+                content: vec![Block::Paragraph(Paragraph {
+                    style: ParagraphStyle::default(),
+                    runs: vec![
+                        Run {
+                            text: "Line 1".to_string(),
+                            style: TextStyle::default(),
+                            href: None,
+                            footnote: None,
+                        },
+                        Run {
+                            text: "(2) 둘째 줄".to_string(),
+                            style: TextStyle::default(),
+                            href: None,
+                            footnote: None,
+                        },
+                    ],
+                })],
+                padding: Insets::default(),
+                vertical_align: crate::ir::TextBoxVerticalAlign::Top,
+                fill: None,
+                opacity: None,
+                stroke: None,
+                shape_kind: None,
+                no_wrap: false,
+                auto_fit: false,
+                text_rotation_deg: None,
+                shape_rotation_deg: None,
+            }),
+        }],
+    )]);
+    let output = generate_typst(&doc).unwrap();
+    assert!(
+        output.source.contains("))#[(2)"),
+        "the bare text after the grid word must be wrapped: {}",
+        output.source
+    );
+    let pdf =
+        crate::render::pdf::compile_to_pdf(&output.source, &output.images, None, &[], false, false)
+            .unwrap_or_else(|error| panic!("compile failed: {error}\n{}", output.source));
+    assert!(pdf.starts_with(b"%PDF"));
+}
+
+#[test]
 fn test_fixed_page_text_box_with_width_height() {
     let doc = make_doc(vec![make_fixed_page(
         960.0,

--- a/crates/office2pdf/src/render/typst_gen_text.rs
+++ b/crates/office2pdf/src/render/typst_gen_text.rs
@@ -4430,8 +4430,14 @@ fn write_run_content(out: &mut String, source: &str, escaped: &str, style: &Text
         return;
     }
 
+    // Markup that follows an embedded expression keeps parsing it: after a
+    // content block (`]`) or a call (`)`), a leading `(` is an argument
+    // list, `[` a trailing content argument, and `.name` a field access, so
+    // "(07) Western" after `#linebreak()` failed the whole document with
+    // "expected function, found content". A `#[...]` block ends the
+    // expression and renders the text unchanged.
     let needs_safety_wrap: bool = !escaped.is_empty()
-        && out.ends_with(']')
+        && (out.ends_with(']') || out.ends_with(')'))
         && !out.ends_with("\\]")
         && matches!(escaped.as_bytes()[0], b'(' | b'.' | b'[');
 
@@ -5118,8 +5124,12 @@ pub(super) fn escape_typst(text: &str) -> String {
             // A hard line break (`<w:br/>`, carried through the IR as '\n') must
             // force a new line. A bare newline in Typst markup collapses to a
             // space, which silently merged code lines like `echo` / `printf`
-            // (issue #176).
-            '\n' => result.push_str("#linebreak()"),
+            // (issue #176). The semicolon ends the code expression: the rest
+            // of this same string is bare markup, and a leading `(`, `[`, or
+            // `.name` in it would chain onto the break's content as a call or
+            // field access, failing the whole document with "expected
+            // function, found content".
+            '\n' => result.push_str("#linebreak();"),
             '\r' => {}
             // Word preserves literal space runs (xml:space="preserve") that
             // documents use for manual alignment and code indentation; Typst

--- a/crates/office2pdf/src/render/typst_gen_text_pipeline_tests.rs
+++ b/crates/office2pdf/src/render/typst_gen_text_pipeline_tests.rs
@@ -624,8 +624,33 @@ fn test_escape_typst_preserves_spaces_after_hard_linebreak() {
     // Code blocks carry hard breaks followed by indentation.
     let result = escape_typst("match x {\n  b\"w:p\" => 1,\n}");
     assert!(
-        result.contains("#linebreak()#\"  \";"),
+        result.contains("#linebreak();#\"  \";"),
         "post-break indentation must survive: {result}"
+    );
+}
+
+#[test]
+fn test_escape_typst_terminates_hard_linebreak_before_parenthesis() {
+    // A fee-schedule cell reads "New York" over "(07) Western". Typst parses
+    // an unterminated `#linebreak()(07)` as a call on the break's content
+    // and aborts the whole conversion with "expected function, found
+    // content".
+    let result = escape_typst("New York\n(07) Western");
+    assert!(
+        result.contains("#linebreak();(07) Western"),
+        "the break must be terminated before literal text: {result}"
+    );
+}
+
+#[test]
+fn test_escape_typst_terminates_hard_linebreak_before_field_access() {
+    // A leading `.name` would otherwise read as a field access on the break
+    // ("linebreak does not have field"). A leading `.5` is a number and
+    // never chained, so the case below is the one that failed documents.
+    let result = escape_typst("Runtime\n.NET pricing");
+    assert!(
+        result.contains("#linebreak();.NET pricing"),
+        "the break must be terminated before a leading field access: {result}"
     );
 }
 


### PR DESCRIPTION
## Summary

Typst keeps parsing an embedded code expression after its closing bracket. Markup that starts with `(` becomes an argument list, `[` a trailing content argument, and `.name` a field access. A spreadsheet cell reading "New York" over "(07) Western" produced `#linebreak()(07)` and the whole document failed with `Typst compilation failed: expected function, found content`.

Two places let bare text follow a call:

- Inside one escaped string, `escape_typst` now ends the hard break with a semicolon (`#linebreak();`), the same terminator the code-mode space strings already use.
- At a run boundary, the existing `#[...]` safety wrap in `write_run_content` only looked for a preceding `]`. It now also covers `)`, which closes `#linebreak()`, `#h(..)`, `#o2p-pptx-space()`, and the PowerPoint grid words.

## Related issue

None filed. Reproduced on a public spreadsheet (VA VALERI fee cost schedule, cell "New York\n(07) Western").

## Testing

- `cargo test -p office2pdf --lib` (2780 passed)
- `cargo fmt --all --check`, `cargo clippy -p office2pdf --all-targets` (only the pre-existing `effective_last_resort_family` dead-code warning)
- New tests: `test_escape_typst_terminates_hard_linebreak_before_parenthesis`, `test_escape_typst_terminates_hard_linebreak_before_field_access`, `test_render_document_hard_linebreak_before_parenthesis` (asserts the terminator never renders), `test_fixed_page_text_box_soft_line_break_before_parenthesis_compiles`, `test_fixed_page_text_box_grid_word_before_parenthesised_run_compiles`. All five fail on `main` and pass here.
- Verified with typst 0.15.1 that `A#linebreak().5 percent` compiles (a leading `.5` is a number), `A#linebreak().NET` fails with `linebreak does not have field "NET"`, and `A#h(1em)(07) B` fails with `expected function, found content`.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: the semicolon and the `#[...]` wrap are consumed by the parser; documents that compiled before produce byte-identical Typst layout, and documents that failed before now compile. The render test asserts no `;` reaches the text layer.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue (none observed)
