### PR TITLE
render: stop re-indexing host fonts per fallback measurement

### DIFF
--- a/crates/office2pdf/src/render/font_context.rs
+++ b/crates/office2pdf/src/render/font_context.rs
@@ -230,16 +230,46 @@ const SCRIPT_PROBES: [(TextScript, char); 5] = [
     (TextScript::Chinese, '漢'),
 ];
 
+// Test-only probe counting full context resolutions, so the contract that a
+// default-path lookup never re-indexes the host's fonts is assertable: one
+// resolution parses every face on the host, and the fallback metric path
+// once paid that per measured run. (A regular comment: rustc discards doc
+// comments attached to macro invocations.)
+#[cfg(test)]
+thread_local! {
+    pub(super) static FONT_CONTEXT_RESOLUTIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
+/// The Office application font directories a conversion searches on top of
+/// the system fonts when the caller supplied no font path: the bundles under
+/// `/Applications` and `~/Applications` on macOS, nothing elsewhere.
+///
+/// [`resolve_font_search_context`] with no user paths yields these same paths
+/// but also indexes every face on the host, which is far too slow to repeat
+/// per measured run. This is at most six directory probes, done once per
+/// process: an Office installed after the first conversion is seen by the
+/// next process.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn default_font_search_paths() -> &'static [PathBuf] {
+    static PATHS: std::sync::LazyLock<Vec<PathBuf>> = std::sync::LazyLock::new(|| {
+        if cfg!(target_os = "macos") {
+            discover_default_macos_office_font_paths()
+        } else {
+            Vec::new()
+        }
+    });
+    &PATHS
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn resolve_font_search_context(user_font_paths: &[PathBuf]) -> FontSearchContext {
-    let office_paths = if cfg!(target_os = "macos") {
-        discover_default_macos_office_font_paths()
-    } else {
-        Vec::new()
-    };
+    #[cfg(test)]
+    FONT_CONTEXT_RESOLUTIONS.with(|count| count.set(count.get() + 1));
+    let office_paths: &[PathBuf] = default_font_search_paths();
     let user_paths = canonicalize_existing_dirs(user_font_paths.iter().cloned());
-    let search_paths = merge_prioritized_paths(&office_paths, &user_paths);
-    let office_families = available_families_from_paths(&office_paths, false);
+    let search_paths = merge_prioritized_paths(office_paths, &user_paths);
+    let office_families = available_families_from_paths(office_paths, false);
     let user_families = available_families_from_paths(&user_paths, false);
     let FamilyIndex {
         available_families,

--- a/crates/office2pdf/src/render/pdf.rs
+++ b/crates/office2pdf/src/render/pdf.rs
@@ -404,14 +404,7 @@ pub(crate) fn compiled_text_runs(
 
     // The same font set the conversion pipeline compiles with, so a probe sees
     // the faces `font_hhea_ascender_em` measured rather than a substitute.
-    // Resolving it rescans the font directories, which dominates a probe's
-    // runtime, so the paths are resolved once for the whole test process.
-    static PROBE_FONT_PATHS: OnceLock<Vec<PathBuf>> = OnceLock::new();
-    let font_paths: &Vec<PathBuf> = PROBE_FONT_PATHS.get_or_init(|| {
-        super::font_context::resolve_font_search_context(&[])
-            .search_paths()
-            .to_vec()
-    });
+    let font_paths: &[PathBuf] = super::font_context::default_font_search_paths();
     let world = MinimalWorld::new(typst_source, &[], font_paths);
     let warned = typst::compile::<typst::layout::PagedDocument>(&world);
     let document = warned.output.map_err(|errors| {
@@ -957,11 +950,8 @@ fn best_face(family: &str) -> Option<typst::text::Font> {
         return Some(font);
     }
 
-    let search_paths = super::font_subst::active_font_search_paths().unwrap_or_else(|| {
-        super::font_context::resolve_font_search_context(&[])
-            .search_paths()
-            .to_vec()
-    });
+    let search_paths = super::font_subst::active_font_search_paths()
+        .unwrap_or_else(|| super::font_context::default_font_search_paths().to_vec());
     let data = get_fonts_for_extra_paths(&search_paths);
     super::font_subst::family_candidates(family)
         .iter()
@@ -1298,8 +1288,7 @@ fn face_advance_em(
 
     // Use the same font set the compiler will use (system + discovered
     // Office font dirs); this also primes the compile-time cache.
-    let search_context = super::font_context::resolve_font_search_context(&[]);
-    let data = get_fonts_for_extra_paths(search_context.search_paths());
+    let data = get_fonts_for_extra_paths(super::font_context::default_font_search_paths());
     let advance: Option<f64> = super::font_subst::family_candidates(family)
         .iter()
         .find_map(|candidate| {
@@ -1387,8 +1376,8 @@ pub(crate) fn glyph_advances_em(family: &str, bold: bool, text: &str) -> Option<
             None => {
                 // Use the same font set the compiler will use (system + discovered
                 // Office font dirs); this also primes the compile-time cache.
-                let search_context = super::font_context::resolve_font_search_context(&[]);
-                let data = get_fonts_for_extra_paths(search_context.search_paths());
+                let data =
+                    get_fonts_for_extra_paths(super::font_context::default_font_search_paths());
                 let resolved: Option<typst::text::Font> =
                     super::font_subst::family_candidates(family)
                         .iter()
@@ -1431,11 +1420,8 @@ pub(crate) fn glyph_advances_em_with_typst_fallback(
 
     #[cfg(not(target_arch = "wasm32"))]
     let native_data = {
-        let search_paths = super::font_subst::active_font_search_paths().unwrap_or_else(|| {
-            super::font_context::resolve_font_search_context(&[])
-                .search_paths()
-                .to_vec()
-        });
+        let search_paths = super::font_subst::active_font_search_paths()
+            .unwrap_or_else(|| super::font_context::default_font_search_paths().to_vec());
         get_fonts_for_extra_paths(&search_paths)
     };
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/office2pdf/src/render/pdf_tests.rs
+++ b/crates/office2pdf/src/render/pdf_tests.rs
@@ -34,6 +34,35 @@ fn typst_cache_state_defers_eviction_while_compilations_overlap() {
 use crate::test_support::make_test_svg;
 
 #[test]
+fn test_default_font_search_paths_match_the_resolved_context() {
+    // Every measurement site substitutes the memoized paths for a resolved
+    // context's search paths, so the two must stay the same font set or the
+    // metrics are taken against faces the compiler never sees.
+    let resolved = crate::render::font_context::resolve_font_search_context(&[]);
+    assert_eq!(
+        crate::render::font_context::default_font_search_paths(),
+        resolved.search_paths()
+    );
+}
+
+#[test]
+fn test_fallback_glyph_advances_do_not_resolve_a_font_context() {
+    // Each resolution of a full font search context parses every face on
+    // the host, and the fallback metric runs once per measured run: a
+    // 35-page report spent 111 s of a 112 s conversion re-indexing fonts.
+    // Outside an active context the lookup needs only the default paths.
+    let families: Vec<String> = vec!["Calibri".to_string()];
+    crate::render::font_context::FONT_CONTEXT_RESOLUTIONS.with(|count| count.set(0));
+    let _ = glyph_advances_em_with_typst_fallback(&families, false, "overlong-token");
+    let resolutions: usize =
+        crate::render::font_context::FONT_CONTEXT_RESOLUTIONS.with(|count| count.get());
+    assert_eq!(
+        resolutions, 0,
+        "a default-path lookup must not re-index the host's fonts"
+    );
+}
+
+#[test]
 fn test_compile_simple_text() {
     let result = compile_to_pdf("Hello, World!", &[], None, &[], false, false).unwrap();
     assert!(!result.is_empty(), "PDF bytes should not be empty");


### PR DESCRIPTION
## Summary

`glyph_advances_em_with_typst_fallback`, `best_face`, and the two cached advance lookups obtained the default font search paths by calling `resolve_font_search_context(&[])`, which indexes every face on the host. Outside an active font context that ran once per measured run. On a 35-page DOCX with many overlong tokens, `sample` attributed 111 s of a 112 s conversion to `index_families_from_paths` under `glyph_advances_em_with_typst_fallback`; v0.6.7 converts the same file in 1.7 s.

`default_font_search_paths` now memoizes the paths (at most six directory probes, once per process) in a `LazyLock`, every site uses it, and `resolve_font_search_context` reads the same slice. The `--metrics` codegen stage on that file drops from 111 s to 0.3 s; the full lib test suite drops from 234 s to 28 s on this machine because the tests hit the same path.

## Related issue

None filed. The per-run resolution arrived with #1456 (Related: #1454), which added the overlong-token measurement; v0.6.7 predates it. Numbers measured on an Apple M4 Pro, macOS 26.6, with Microsoft Office fonts present.

## Testing

- `cargo test -p office2pdf --lib` (2777 passed)
- `cargo fmt --all --check`, `cargo clippy -p office2pdf --all-targets` (only the pre-existing `effective_last_resort_family` dead-code warning)
- New tests: `test_default_font_search_paths_match_the_resolved_context` pins the memoized paths to `resolve_font_search_context(&[]).search_paths()`; `test_fallback_glyph_advances_do_not_resolve_a_font_context` uses a test-only counter (same pattern as `AUTO_ROW_FRAME_ESTIMATE_CALLS`) and fails on `main` with 1 resolution per call.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: the memoized paths equal the previously resolved search paths (pinned by test), so every measurement and compile sees the same font set.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue (none observed)

