### PR TITLE
fix: report printed PDF pages in conversion metrics

### DIFF
--- a/crates/office2pdf/src/lib_pipeline.rs
+++ b/crates/office2pdf/src/lib_pipeline.rs
@@ -233,7 +233,6 @@ pub(super) fn convert_bytes(
         }
     };
     let parse_duration = parse_start.elapsed();
-    let page_count = doc.pages.len() as u32;
     extend_document_fonts(&mut additional_fonts, &doc);
 
     #[cfg(target_arch = "wasm32")]
@@ -314,7 +313,7 @@ pub(super) fn convert_bytes(
 
     let compile_start: Instant = Instant::now();
     #[cfg(not(target_arch = "wasm32"))]
-    let pdf = render::pdf::compile_to_pdf_with_fonts(
+    let (pdf, page_count) = render::pdf::compile_to_pdf_with_fonts_counted(
         &output.source,
         &output.images,
         options.pdf_standard,
@@ -327,7 +326,7 @@ pub(super) fn convert_bytes(
         options.pdf_ua,
     )?;
     #[cfg(target_arch = "wasm32")]
-    let pdf = render::pdf::compile_to_pdf_with_fonts(
+    let (pdf, page_count) = render::pdf::compile_to_pdf_with_fonts_counted(
         &output.source,
         &output.images,
         options.pdf_standard,
@@ -417,7 +416,7 @@ fn convert_bytes_streaming_xlsx(
             options,
             font_context.as_ref(),
         )?;
-        let pdf = render::pdf::compile_to_pdf_with_fonts(
+        let (pdf, page_count) = render::pdf::compile_to_pdf_with_fonts_counted(
             &output.source,
             &output.images,
             options.pdf_standard,
@@ -430,6 +429,7 @@ fn convert_bytes_streaming_xlsx(
             options.pdf_ua,
         )?;
         let total_duration = total_start.elapsed();
+        let output_size_bytes = pdf.len() as u64;
         return Ok(build_convert_result(
             pdf,
             warnings,
@@ -439,8 +439,8 @@ fn convert_bytes_streaming_xlsx(
                 compile_duration: std::time::Duration::ZERO,
                 total_duration,
                 input_size_bytes,
-                output_size_bytes: 0,
-                page_count: 0,
+                output_size_bytes,
+                page_count,
             }),
         ));
     }
@@ -451,8 +451,6 @@ fn convert_bytes_streaming_xlsx(
     let mut total_page_count: u32 = 0;
 
     for chunk_doc in chunk_docs {
-        total_page_count += chunk_doc.pages.len() as u32;
-
         if let Some(font_context) = font_context.as_ref() {
             warnings.extend(
                 render::font_subst::detect_missing_font_fallbacks_with_context(
@@ -477,7 +475,7 @@ fn convert_bytes_streaming_xlsx(
         codegen_duration_total += codegen_start.elapsed();
 
         let compile_start: Instant = Instant::now();
-        let pdf = render::pdf::compile_to_pdf_with_fonts(
+        let (pdf, chunk_pages) = render::pdf::compile_to_pdf_with_fonts_counted(
             &output.source,
             &output.images,
             options.pdf_standard,
@@ -489,6 +487,7 @@ fn convert_bytes_streaming_xlsx(
             options.tagged,
             options.pdf_ua,
         )?;
+        total_page_count += chunk_pages;
         compile_duration_total += compile_start.elapsed();
 
         all_pdfs.push(pdf);

--- a/crates/office2pdf/src/lib_pipeline_tests.rs
+++ b/crates/office2pdf/src/lib_pipeline_tests.rs
@@ -416,6 +416,34 @@ fn test_convert_bytes_returns_populated_metrics() {
     assert!(metrics.page_count >= 1, "should have at least 1 page");
 }
 
+/// `ConvertMetrics::page_count` answers for the produced PDF, not for the IR.
+/// This fixture has one flow section however long it runs, so reporting the IR
+/// length told every caller "1 page" after Typst broke it across many.
+#[test]
+#[cfg(feature = "pdf-ops")]
+fn test_metrics_page_count_counts_printed_pages() {
+    let mut docx = docx_rs::Docx::new();
+    for index in 0..400 {
+        docx = docx.add_paragraph(
+            docx_rs::Paragraph::new()
+                .add_run(docx_rs::Run::new().add_text(format!("Paragraph {index}"))),
+        );
+    }
+    let mut cursor = std::io::Cursor::new(Vec::new());
+    docx.build().pack(&mut cursor).unwrap();
+    let data = cursor.into_inner();
+
+    let result = convert_bytes(&data, Format::Docx, &ConvertOptions::default()).unwrap();
+    let metrics = result.metrics.expect("convert_bytes should return metrics");
+    let printed = crate::pdf_ops::page_count(&result.pdf).expect("the output PDF should load");
+
+    assert!(printed > 1, "400 paragraphs should not fit one page");
+    assert_eq!(
+        metrics.page_count, printed,
+        "reported page_count should match the pages in the PDF"
+    );
+}
+
 #[test]
 fn test_metrics_total_ge_sum_of_stages() {
     let data = make_test_docx_bytes();

--- a/crates/office2pdf/src/render/pdf.rs
+++ b/crates/office2pdf/src/render/pdf.rs
@@ -250,7 +250,7 @@ pub fn compile_to_pdf(
     pdf_ua: bool,
 ) -> Result<Vec<u8>, ConvertError> {
     let world = MinimalWorld::new(typst_source, images, font_paths);
-    compile_to_pdf_inner(&world, pdf_standard, tagged, pdf_ua)
+    compile_to_pdf_inner(&world, pdf_standard, tagged, pdf_ua).map(|(pdf, _pages)| pdf)
 }
 
 /// Compile Typst markup to PDF bytes (WASM target).
@@ -280,6 +280,33 @@ pub(crate) fn compile_to_pdf_with_fonts(
     tagged: bool,
     pdf_ua: bool,
 ) -> Result<Vec<u8>, ConvertError> {
+    compile_to_pdf_with_fonts_counted(
+        typst_source,
+        images,
+        pdf_standard,
+        font_paths,
+        in_memory_fonts,
+        tagged,
+        pdf_ua,
+    )
+    .map(|(pdf, _pages)| pdf)
+}
+
+/// Compile as `compile_to_pdf_with_fonts` does, also reporting how many pages
+/// the layout produced.
+///
+/// The count comes from the laid-out document rather than the source IR: a
+/// source page, including a DOCX flow section, may lay out across multiple PDF
+/// pages. Callers reporting `ConvertMetrics::page_count` need the PDF count.
+pub(crate) fn compile_to_pdf_with_fonts_counted(
+    typst_source: &str,
+    images: &[ImageAsset],
+    pdf_standard: Option<PdfStandard>,
+    font_paths: &[std::path::PathBuf],
+    in_memory_fonts: &[Font],
+    tagged: bool,
+    pdf_ua: bool,
+) -> Result<(Vec<u8>, u32), ConvertError> {
     #[cfg(not(target_arch = "wasm32"))]
     let world =
         MinimalWorld::new_with_in_memory_fonts(typst_source, images, font_paths, in_memory_fonts);
@@ -296,7 +323,7 @@ fn compile_to_pdf_inner(
     pdf_standard: Option<PdfStandard>,
     tagged: bool,
     pdf_ua: bool,
-) -> Result<Vec<u8>, ConvertError> {
+) -> Result<(Vec<u8>, u32), ConvertError> {
     // Typst's memoized layout results are process-global, while each
     // `MinimalWorld` here is an independent Office document. Age that cache at
     // a bounded document interval so long-running processes do not retain
@@ -342,10 +369,12 @@ fn compile_to_pdf_inner(
         tagged: enable_tagged,
         ..Default::default()
     };
-    typst_pdf::pdf(&document, &options).map_err(|errors| {
+    let page_count = document.pages.len() as u32;
+    let pdf = typst_pdf::pdf(&document, &options).map_err(|errors| {
         let messages: Vec<String> = errors.iter().map(|e| e.message.to_string()).collect();
         ConvertError::Render(format!("PDF export failed: {}", messages.join("; ")))
-    })
+    })?;
+    Ok((pdf, page_count))
 }
 
 /// One shaped text run as the layout engine actually placed it.


### PR DESCRIPTION
## Problem

`ConvertMetrics::page_count` is documented in `error.rs` as "Number of pages in the output PDF". Both conversion paths set it from the IR instead:

- `lib_pipeline.rs` batch path used `doc.pages.len()`.
- `lib_pipeline.rs` streaming path summed `chunk_doc.pages.len()`.

An `ir::Page` is a sheet, a slide, or one flowing DOCX body. Typst breaks any of those across as many printed pages as the content needs, so the reported number was the count of sheets and slides rather than pages.

## Reproduction

A 20000-row, 8-column single-sheet XLSX, converted at `fae8b84`:

```text
$ office2pdf big.xlsx -o batch.pdf --metrics
  Pages:   1
$ python3 -c "import re; print(len(re.findall(rb'/Type\\s*/Page[^s]', open('batch.pdf','rb').read())))"
527
```

The same file with `--streaming` reported `Pages: 20` against 540 real pages.

`server.rs` feeds this value into the pages histogram, so those buckets carried the same error.

## Fix

The compiled `PagedDocument` already holds the laid-out pages. `compile_to_pdf_inner` now returns that count with the bytes, and `compile_to_pdf_with_fonts_counted` exposes it to the pipeline. The existing byte-only wrappers keep their signatures. No new dependency, and the count is available on wasm too.

The streaming empty-workbook branch also reported `output_size_bytes: 0` for a PDF it had just produced. It reports the real length now.

After the fix, on the same file:

```text
$ office2pdf big.xlsx -o batch.pdf --metrics
  Pages:   527
$ office2pdf big.xlsx -o stream.pdf --streaming --metrics
  Pages:   540
```

Both match the PDFs.

## Related issue

Related: #1512

## Testing

`test_metrics_page_count_counts_printed_pages` in `lib_pipeline_tests.rs` converts a 400-paragraph DOCX and asserts `metrics.page_count` equals `pdf_ops::page_count` of the produced bytes. On `main` it fails with `left: 1, right: 8`.

```text
$ cargo test -p office2pdf --features pdf-ops --lib page_count
test result: ok. 6 passed; 0 failed

$ cargo test -p office2pdf --features pdf-ops --lib streaming
test result: ok. 19 passed; 0 failed

$ cargo test -p office2pdf --features pdf-ops --lib metrics
test result: ok. 14 passed; 0 failed

$ cargo test -p office2pdf --features pdf-ops --lib render::pdf
test result: ok. 52 passed; 0 failed
```

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: The change reports the existing compiled page count alongside the same generated PDF bytes; it does not alter parsing, layout, styling, or PDF export.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue
