### PR TITLE
fix(harness): ignore non-painted unmatched text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,15 @@ visible-fill occlusions, and a rect census, with GT noise floors built in (`--no
 text covered by a later opaque image, single closed axis-aligned rectangle, or
 fully extended shading under such a rectangular clip is `hidden`; same-colour
 text on an opaque flat fill is `low_contrast`, and text that remains visible is
-`painted`. An `ignore_text` record is normally hidden. The harness promotes it
+`painted`. The harness retains the page media box and rectangular clip stack,
+intersects each glyph's conservative ink box with those visible bounds, and
+keeps any partially visible run auditable. A trace line proven fully hidden by
+the visibility analysis — including bounds, transparency, absent path ink, or
+later opaque paint — is still reported under
+`visibility.unmatched_hidden_*`, but when it has no counterpart it does not
+become a visual missing/extra failure. An exact counterpart remains matched so
+painted-versus-hidden differences still fail. An `ignore_text` record is
+normally hidden. The harness promotes it
 to painted geometry only when a compact, intersecting `fill_path` appeared
 since the preceding text operation and lies within half an em of the glyph's
 conservative bounding box. This trace-order heuristic recovers path-painted

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -13,11 +13,13 @@ visible ink. It then matches lines by their text and reports typed deviations:
   pitch deltas between consecutive matched lines. Horizontal text uses its
   true baseline; a rotated or skewed `fill_text` stays one visual run and uses
   the minimum fully transformed glyph x/y as its comparable anchor;
-- painted visibility from trace order: text covered by a later opaque image,
-  single closed axis-aligned rectangular fill, or fully extended shading under
-  a single closed axis-aligned rectangular clip, or painted with the same
-  colour as a flat background, is distinguished from text that remains visibly
-  painted;
+- painted visibility from the page media box, active rectangular clips, and
+  trace order: text outside the visible bounds, covered by a later opaque
+  image, single closed axis-aligned rectangular fill, or fully extended
+  shading under a single closed axis-aligned rectangular clip, or painted with
+  the same colour as a flat background, is distinguished from text that
+  remains visibly painted. Unmatched hidden trace lines are reported but do
+  not become visual missing/extra findings;
 - visible-fill occlusions: a later opaque, differently coloured rectangle
   cutting into a thin earlier rule is compared by final overlap area, colour,
   and paint order rather than by the raw rectangle count;
@@ -54,8 +56,9 @@ from spatial_match import minimum_cost_pairs
 
 # mutool 1.23.x opens a page as `<page mediabox="...">` with no `number`
 # attribute; later builds add one. Requiring it parses zero pages and reports
-# that as "no differences found" instead of as a failure.
-PAGE_RE = re.compile(r"<page\b[^>]*>(.*?)</page>", re.S)
+# that as "no differences found" instead of as a failure. Keep the attributes
+# so the media box can bound the visual text census.
+PAGE_RE = re.compile(r"<page\b([^>]*)>(.*?)</page>", re.S)
 TEXT_RE = re.compile(r"<(fill_text|ignore_text)\b([^>]*)>(.*?)</\1>", re.S)
 SPAN_RE = re.compile(r"<span\b([^>]*)>(.*?)</span>", re.S)
 GLYPH_RE = re.compile(
@@ -69,6 +72,12 @@ POP_CLIP_RE = re.compile(r"<pop_clip\s*/>")
 CLIP_SHADE_EVENT_RE = re.compile(
     r"<clip_path\b[^>]*>.*?</clip_path>|<fill_shade\b[^>]*/>|<pop_clip\s*/>", re.S
 )
+CLIP_TEXT_EVENT_RE = re.compile(
+    r"<clip_path\b[^>]*>.*?</clip_path>|"
+    r"<(?P<text_op>fill_text|ignore_text)\b[^>]*>.*?</(?P=text_op)>|"
+    r"<pop_clip\s*/>",
+    re.S,
+)
 POINT_RE = re.compile(r'<(?:moveto|lineto|curveto)[^>]*x="([-0-9.e]+)" y="([-0-9.e]+)"')
 PATH_COMMAND_RE = re.compile(
     r"<(?:(?P<point>moveto|lineto)\b(?P<attrs>[^>]*)|(?P<close>closepath)\s*)/>"
@@ -81,6 +90,7 @@ TRANSFORM_RE = re.compile(
 TRM_RE = re.compile(r'trm="([-0-9.e]+) ')
 ALPHA_RE = re.compile(r'alpha="([-0-9.e]+)"')
 COLOR_RE = re.compile(r'color="([-0-9.e ]+)"')
+MEDIABOX_RE = re.compile(r'\bmediabox="([-0-9.e ]+)"')
 
 LINE_Y_TOLERANCE_PT = 0.6
 # A normal inter-word gap is far smaller than this. Combined with a text-paint
@@ -97,6 +107,10 @@ VISIBLE_FILL_MAX_RULE_THICKNESS_PT = 2.0
 VISIBLE_FILL_MIN_RULE_LENGTH_PT = 4.0
 VISIBLE_FILL_COLOR_DELTA = 0.08
 VISIBLE_FILL_MATCH_TOLERANCE_PT = 0.5
+# MuPDF can quantise a page edge and a page-sized paint a few hundredths of a
+# point apart. This matches the established Word trace noise floor while still
+# requiring geometric coverage rather than overlap.
+PAINT_COVER_TOLERANCE_PT = 0.12
 XML_ESCAPES = {"&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&apos;": "'"}
 
 
@@ -113,6 +127,7 @@ class Glyph:
     needs_path_ink: bool = False
     paint_window_start: int = -1
     paint_window_end: int = -1
+    visible_clip: tuple[float, float, float, float] | None = None
 
 
 @dataclass(frozen=True)
@@ -199,6 +214,7 @@ class PageLayout:
     lines: list[Line]
     rects: list[Rect]
     paints: list[Paint] = field(default_factory=list)
+    media_box: tuple[float, float, float, float] | None = None
 
 
 def unescape(text: str) -> str:
@@ -319,6 +335,56 @@ def intersect_bboxes(
     if x0 >= x1 or y0 >= y1:
         return (x0, y0, x0, y0)
     return (x0, y0, x1, y1)
+
+
+def parse_media_box(attrs: str) -> tuple[float, float, float, float] | None:
+    """Return the page's device-space media box when mutool provides one."""
+    match = MEDIABOX_RE.search(attrs)
+    if match is None:
+        return None
+    values = [float(value) for value in match.group(1).split()]
+    if len(values) != 4:
+        return None
+    x0, y0, x1, y1 = values
+    return (min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1))
+
+
+def text_visible_clips(
+    content: str,
+    media_box: tuple[float, float, float, float] | None,
+) -> dict[int, tuple[float, float, float, float] | None]:
+    """Map text operation offsets to conservative active visual bounds.
+
+    A rectangular clip can prove that text outside it cannot paint. Unknown
+    clip shapes only narrow the real visible region, so retaining the last
+    known outer bound is conservative and cannot hide a visual finding.
+    """
+    active_clip = media_box
+    stack: list[tuple[float, float, float, float] | None] = []
+    clips: dict[int, tuple[float, float, float, float] | None] = {}
+
+    for event in CLIP_TEXT_EVENT_RE.finditer(content):
+        operation = event.group(0)
+        clip_match = CLIP_PATH_RE.fullmatch(operation)
+        if clip_match:
+            stack.append(active_clip)
+            bbox = axis_aligned_rect_bbox(*clip_match.groups())
+            if bbox is not None:
+                active_clip = (
+                    bbox
+                    if active_clip is None
+                    else intersect_bboxes(active_clip, bbox)
+                )
+            continue
+
+        if TEXT_RE.fullmatch(operation):
+            clips[event.start()] = active_clip
+            continue
+
+        if POP_CLIP_RE.fullmatch(operation):
+            active_clip = stack.pop() if stack else media_box
+
+    return clips
 
 
 def color_delta(
@@ -576,7 +642,9 @@ def clipped_shade_paints(content: str) -> list[Paint]:
 
 
 def paint_covers(
-    paint: Paint, bbox: tuple[float, float, float, float], tolerance: float = 0.05
+    paint: Paint,
+    bbox: tuple[float, float, float, float],
+    tolerance: float = PAINT_COVER_TOLERANCE_PT,
 ) -> bool:
     x0, y0, x1, y1 = bbox
     return (
@@ -641,12 +709,16 @@ def ignored_text_path_inks(glyph: Glyph, paints: list[Paint]) -> list[Paint]:
 def glyph_visibility(glyph: Glyph, paints: list[Paint]) -> str:
     if glyph.alpha <= INVISIBLE_ALPHA:
         return "hidden"
+    bbox = glyph_bbox(glyph)
+    if glyph.visible_clip is not None:
+        bbox = intersect_bboxes(bbox, glyph.visible_clip)
+        if bbox[0] >= bbox[2] or bbox[1] >= bbox[3]:
+            return "hidden"
     own_path_inks = (
         ignored_text_path_inks(glyph, paints) if glyph.needs_path_ink else []
     )
     if glyph.needs_path_ink and not own_path_inks:
         return "hidden"
-    bbox = glyph_bbox(glyph)
     if any(
         paint.kind in {"flat", "image", "shade"}
         and paint.index > glyph.paint_index
@@ -699,7 +771,9 @@ def classify_line_visibility(line: Line, paints: list[Paint]) -> str:
 def parse_trace(trace_xml: str) -> list[PageLayout]:
     pages: list[PageLayout] = []
     for page_match in PAGE_RE.finditer(trace_xml):
-        content = page_match.group(1)
+        page_attrs, content = page_match.groups()
+        media_box = parse_media_box(page_attrs)
+        visible_clips = text_visible_clips(content, media_box)
         glyphs: list[Glyph] = []
         rotated_lines: list[Line] = []
         text_operations = list(TEXT_RE.finditer(content))
@@ -738,6 +812,7 @@ def parse_trace(trace_xml: str) -> list[PageLayout]:
                             needs_path_ink=op_kind == "ignore_text",
                             paint_window_start=paint_window_start,
                             paint_window_end=paint_window_end,
+                            visible_clip=visible_clips.get(op_match.start(), media_box),
                         )
                     )
             if not transformed_run:
@@ -837,7 +912,14 @@ def parse_trace(trace_xml: str) -> list[PageLayout]:
         for line in lines:
             line.visibility = classify_line_visibility(line, paints)
         lines.sort(key=lambda line: (line.y, line.x0))
-        pages.append(PageLayout(lines=lines, rects=rects, paints=paints))
+        pages.append(
+            PageLayout(
+                lines=lines,
+                rects=rects,
+                paints=paints,
+                media_box=media_box,
+            )
+        )
     return pages
 
 
@@ -1053,6 +1135,10 @@ def diff_page(
     fine_shift: float | None = None,
 ) -> dict:
     exact_matches, missing, extra = match_lines(gt.lines, out.lines)
+    hidden_missing = [line for line in missing if line.visibility == "hidden"]
+    hidden_extra = [line for line in extra if line.visibility == "hidden"]
+    missing = [line for line in missing if line.visibility != "hidden"]
+    extra = [line for line in extra if line.visibility != "hidden"]
     topology_groups, topology, missing, extra = take_topology_equivalents(missing, extra)
     topology_matches = [pair for group in topology_groups for pair in group]
     for gt_line, out_line in topology_matches:
@@ -1217,6 +1303,14 @@ def diff_page(
         "visibility": {
             "mismatch_count": len(visibility_mismatches),
             "mismatches": visibility_mismatches,
+            "unmatched_hidden_gt": len(hidden_missing),
+            "unmatched_hidden_out": len(hidden_extra),
+            "unmatched_hidden_gt_text": [
+                line.key[:60] for line in hidden_missing[:5]
+            ],
+            "unmatched_hidden_out_text": [
+                line.key[:60] for line in hidden_extra[:5]
+            ],
         },
         "visible_fills": {
             "mismatch_count": len(visible_fill_mismatches),
@@ -1307,6 +1401,14 @@ def render_reading(vectors: list[dict]) -> str:
                 f"{vector['visibility']['mismatch_count']} matched text instance(s) differ in "
                 f"painted visibility: {examples}. Check z-order, opacity, or foreground/background "
                 "contrast"
+            )
+        hidden_gt = vector["visibility"].get("unmatched_hidden_gt", 0)
+        hidden_out = vector["visibility"].get("unmatched_hidden_out", 0)
+        if hidden_gt or hidden_out:
+            page_notes.append(
+                f"{hidden_gt} GT and {hidden_out} output unmatched trace line(s) are "
+                "proven non-painted by the trace visibility analysis and "
+                "excluded from visual missing/extra findings"
             )
         if vector["visible_fills"]["mismatch_count"]:
             examples = "; ".join(

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -21,16 +21,21 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import compare_layout
 
 
-def trace_document(*pages: str, numbered: bool = False) -> str:
+def trace_document(
+    *pages: str,
+    numbered: bool = False,
+    mediabox: str = "0 0 595.2 841.92",
+) -> str:
     """Wrap page bodies in a trace document.
 
     Defaults to the numberless `<page mediabox="...">` mutool 1.23.x emits, so
     the shared fixtures exercise the shape the parser actually meets. Pass
-    ``numbered=True`` for the attribute later builds add.
+    ``numbered=True`` for the attribute later builds add, or override
+    ``mediabox`` for a fixture with different page geometry.
     """
     body = "\n".join(
-        "<page {}mediabox=\"0 0 595.2 841.92\">\n{}\n</page>".format(
-            f'number="{i + 1}" ' if numbered else "", content
+        "<page {}mediabox=\"{}\">\n{}\n</page>".format(
+            f'number="{i + 1}" ' if numbered else "", mediabox, content
         )
         for i, content in enumerate(pages)
     )
@@ -137,6 +142,29 @@ def clipped_shade_op(
     )
 
 
+def clipped_text_op(
+    content: str,
+    x0: float,
+    y0: float,
+    x1: float,
+    y1: float,
+) -> str:
+    """Wrap text in one rectangular device-space clip."""
+    return "\n".join(
+        [
+            '<clip_path winding="nonzero" transform="1 0 0 1 0 0">',
+            f'<moveto x="{x0}" y="{y0}"/>',
+            f'<lineto x="{x1}" y="{y0}"/>',
+            f'<lineto x="{x1}" y="{y1}"/>',
+            f'<lineto x="{x0}" y="{y1}"/>',
+            "<closepath/>",
+            "</clip_path>",
+            content,
+            "<pop_clip/>",
+        ]
+    )
+
+
 class PageElementTest(unittest.TestCase):
     """The ``<page>`` opening tag differs across mutool releases.
 
@@ -150,6 +178,7 @@ class PageElementTest(unittest.TestCase):
             trace_document(text_op([("A", 72.0)], baseline_y=100.0))
         )
         self.assertEqual(len(pages), 1)
+        self.assertEqual(pages[0].media_box, (0.0, 0.0, 595.2, 841.92))
         self.assertEqual(pages[0].lines[0].text, "A")
 
     def test_pages_without_number_keep_document_order(self) -> None:
@@ -395,7 +424,13 @@ class MatchAndDiffTest(unittest.TestCase):
             ]
         )
 
-        vector = self.diff(gt, out)
+        gt_page = compare_layout.parse_trace(
+            trace_document(gt, mediabox="0 0 960 540")
+        )[0]
+        out_page = compare_layout.parse_trace(
+            trace_document(out, mediabox="0 0 960 540")
+        )[0]
+        vector = compare_layout.diff_page(gt_page, out_page)
 
         self.assertEqual(vector["lines"]["missing"], 0)
         self.assertEqual(vector["lines"]["extra"], 0)
@@ -531,6 +566,82 @@ class MatchAndDiffTest(unittest.TestCase):
         self.assertEqual(vector["lines"]["extra"], 1)
         self.assertIn("Sensitivity:Internal", vector["lines"]["extra_text"])
         self.assertEqual(compare_layout.audit_failures([vector]), 1)
+
+    def test_unmatched_text_fully_below_media_box_is_not_a_visual_finding(self) -> None:
+        vector = self.diff(line_of("Outside", 72, 860), "")
+
+        self.assertEqual(vector["lines"]["missing"], 0)
+        self.assertEqual(vector["visibility"]["unmatched_hidden_gt"], 1)
+        self.assertEqual(
+            vector["visibility"]["unmatched_hidden_gt_text"], ["Outside"]
+        )
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
+    def test_unmatched_text_partly_inside_media_box_remains_a_finding(self) -> None:
+        vector = self.diff(line_of("A", -3, 100), "")
+
+        self.assertEqual(vector["lines"]["missing"], 1)
+        self.assertIn("A", vector["lines"]["missing_text"])
+
+    def test_unmatched_text_fully_outside_active_clip_is_not_a_visual_finding(
+        self,
+    ) -> None:
+        gt = clipped_text_op(line_of("Outside clip", 72, 150), 60, 80, 200, 110)
+
+        vector = self.diff(gt, "")
+
+        self.assertEqual(vector["lines"]["missing"], 0)
+        self.assertEqual(vector["visibility"]["unmatched_hidden_gt"], 1)
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
+    def test_unmatched_text_partly_inside_active_clip_remains_a_finding(self) -> None:
+        gt = clipped_text_op(
+            line_of("Clipped overflow", 72, 100), 60, 95, 200, 102
+        )
+
+        vector = self.diff(gt, "")
+
+        self.assertEqual(vector["lines"]["missing"], 1)
+        self.assertIn("Clippedoverflow", vector["lines"]["missing_text"])
+
+    def test_page_clipped_text_covered_in_its_visible_area_is_not_missing(self) -> None:
+        # Mirrors issue #1416: the baseline extends below the page, while a
+        # later page-sized image hides the only area that could paint.
+        gt = "\n".join([line_of("Internal", 72, 846), image_op()])
+
+        vector = self.diff(gt, image_op())
+
+        self.assertEqual(vector["lines"]["missing"], 0)
+        self.assertEqual(vector["visibility"]["unmatched_hidden_gt"], 1)
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
+    def test_unmatched_hidden_output_text_is_not_a_visual_finding(self) -> None:
+        out = "\n".join([line_of("Covered", 72, 100), image_op()])
+
+        vector = self.diff(image_op(), out)
+
+        self.assertEqual(vector["lines"]["extra"], 0)
+        self.assertEqual(vector["visibility"]["unmatched_hidden_out"], 1)
+        self.assertEqual(
+            vector["visibility"]["unmatched_hidden_out_text"], ["Covered"]
+        )
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
+    def test_pop_clip_restores_page_bounds_for_following_text(self) -> None:
+        gt = "\n".join(
+            [
+                clipped_text_op(
+                    line_of("Outside clip", 72, 150), 60, 80, 200, 110
+                ),
+                line_of("Visible", 72, 200),
+            ]
+        )
+
+        vector = self.diff(gt, line_of("Visible", 72, 200))
+
+        self.assertEqual(vector["lines"]["matched"], 1)
+        self.assertEqual(vector["lines"]["missing"], 0)
+        self.assertEqual(vector["visibility"]["unmatched_hidden_gt"], 1)
 
     def test_reordered_content_is_classified_reflow_not_loss(self) -> None:
         # A table row whose cells share one baseline in GT but split across two
@@ -961,6 +1072,17 @@ class ReadingTest(unittest.TestCase):
 
         self.assertIn("line splits/joins", reading)
         self.assertIn("position-audited", reading)
+
+    def test_reading_explains_unmatched_hidden_trace_lines(self) -> None:
+        gt = compare_layout.parse_trace(
+            trace_document(line_of("Outside", 72, 860))
+        )[0]
+        out = compare_layout.parse_trace(trace_document(""))[0]
+
+        reading = compare_layout.render_reading([compare_layout.diff_page(gt, out)])
+
+        self.assertIn("1 GT and 0 output unmatched trace line", reading)
+        self.assertIn("excluded from visual missing/extra findings", reading)
 
 
 class CompareLayoutCliTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- retain each traced page media box and the active rectangular clip stack for text visibility analysis
- intersect conservative glyph bounds with visible page/clip bounds before later-paint and contrast checks
- report unmatched hidden trace lines explicitly without treating them as visual missing/extra findings, while preserving matched visibility failures and partially visible overflow findings
- tolerate sub-0.12pt MuPDF quantization at page-sized paint edges

## Related issue

Fixes #1416

## Testing

- red-first focused tests initially failed for fully off-page text, fully outside-clip text, and page-clipped text whose visible portion was later covered
- python3 -m unittest discover -s scripts/tests (344 passed)
- python3 -m py_compile scripts/compare_layout.py scripts/tests/test_compare_layout.py
- cargo fmt --all -- --check
- git diff --check
- mandatory documentation freshness review: PASS

Fresh #1220 fixture audit on page 9:

- GT 11 lines, output 9, matched 9
- missing 0, extra 0, wraps 0, reflow 0, large shifts 0
- informational unmatched hidden GT lines: Sensitivity: and Internal
- the remaining slide-number visibility finding is the LibreOffice-only discrepancy already disposed in #1421; native PowerPoint and office2pdf both paint the 9

A 15-page old/new harness differential moved only proven non-painted footer lines from missing findings to the new informational fields on pages 1, 3, 9, 10, 13, 14, and 15. Extra, wrap, reflow, large-shift, and matched-visibility results were otherwise unchanged.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: this changes only the trace-based comparison harness, tests, and its documentation. Conversion and PDF rendering code are untouched; the current-main fixture PDF remains byte-identical.

## Checklist

- [x] Commit includes a Signed-off-by line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each have a disposition (#1418, #1421)