### PR TITLE
fix(harness): audit rectangle geometry

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,6 +33,7 @@
 - Layout audit page count: <!-- Pass, or #N references when the report differs -->
 - Layout audit text flow: <!-- Pass, or #N references for missing/extra/reflow, changed-wrap, or painted-text visibility findings -->
 - Layout audit visible fills: <!-- Pass, or #N references for visible-fill occlusions -->
+- Layout audit rectangle geometry: <!-- Pass, or #N references for matched rectangle position/size/edge findings -->
 - Layout audit large shifts: <!-- Pass, or #N references for shifts above the report threshold -->
 - Layout audit fine shifts: <!-- Pass, or #N references for shifts above the fine-detail threshold -->
 - New follow-up issues found in this audit: <!-- #N, #N or None; create issues before completing the audit -->
@@ -62,7 +63,7 @@
 - [ ] Stored progressive JPEG quality 86 assets with metadata stripped
 - [ ] Used Codex/Claude vision to inspect the full GT/output pages, diff, and matched crops
 - [ ] Inspected matched region crops at full resolution
-- [ ] Ran compare_layout.py --audit --fine-shift PT and dispositioned every fine/large text-instance shift, painted-text visibility mismatch, and visible-fill occlusion
+- [ ] Ran compare_layout.py --audit --fine-shift PT and dispositioned every fine/large text-instance shift, rectangle geometry deviation, painted-text visibility mismatch, and visible-fill occlusion
 - [ ] Ran compare_render.py --cluster-report PATH --strict-clusters and dispositioned every material 5% fuzz diff cluster by explicit ID
 - [ ] Inventoried hairlines and border dash styles
 - [ ] Inventoried font weight, italic, and underline emphasis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ This project follows a **6-month rolling MSRV policy** (aligned with [tokio](htt
 
 ## Visual Comparison Workflow
 
-- For visual bug fixes tied to an issue, keep `assets/bugfixes/issue-<number>/gt.jpg`, `before.jpg`, `after.jpg`, `layout-audit.json`, and one `render-clusters-page-<page>.json` per compared page from the same fixture, page set, renderer, and resolution; `before.jpg` captures the pre-fix output, while `after.jpg` and the reports use the current output. Every fix PR with a raster change must change `after.jpg`, `layout-audit.json`, and every page's strict cluster report. Generate the layout report from the same GT and current-output PDFs used for `gt.jpg` and `after.jpg` with `compare_layout.py --json --audit --fine-shift PT`; record the same fine-detail threshold in the PR and classify page-count, missing/extra/reflow or changed-wrap, painted-text visibility, visible-fill occlusion, and fine/large-shift failures with open issues in the `Visual audit` fields and matching `Remaining:` rows. A reported safe split/join `topology` group is informational rather than a text-flow failure, but each recovered fragment's position and visibility findings remain auditable. Generate each render report with `compare_render.py --cluster-report PATH --cluster-dispositions PATH --strict-clusters`; every cluster ID must map to an accepted renderer class or an open issue, and all report paths must be listed in `Visual audit`. Use progressive JPEG quality 86 with metadata stripped, preserve the source pixel dimensions, and verify text and images remain legible for direct GitHub links. Strip first, then re-set the density (`-strip -density 150 -units PixelsPerInch`): the contract check rejects evidence recording under 150 DPI, which stripping alone removes.
+- For visual bug fixes tied to an issue, keep `assets/bugfixes/issue-<number>/gt.jpg`, `before.jpg`, `after.jpg`, `layout-audit.json`, and one `render-clusters-page-<page>.json` per compared page from the same fixture, page set, renderer, and resolution; `before.jpg` captures the pre-fix output, while `after.jpg` and the reports use the current output. Every fix PR with a raster change must change `after.jpg`, `layout-audit.json`, and every page's strict cluster report. Generate the layout report from the same GT and current-output PDFs used for `gt.jpg` and `after.jpg` with `compare_layout.py --json --audit --fine-shift PT`; record the same fine-detail threshold in the PR and classify page-count, missing/extra/reflow or changed-wrap, painted-text visibility, visible-fill occlusion, rectangle geometry, and fine/large-shift failures with open issues in the `Visual audit` fields and matching `Remaining:` rows. A reported safe split/join `topology` group is informational rather than a text-flow failure, but each recovered fragment's position and visibility findings remain auditable. Generate each render report with `compare_render.py --cluster-report PATH --cluster-dispositions PATH --strict-clusters`; every cluster ID must map to an accepted renderer class or an open issue, and all report paths must be listed in `Visual audit`. Use progressive JPEG quality 86 with metadata stripped, preserve the source pixel dimensions, and verify text and images remain legible for direct GitHub links. Strip first, then re-set the density (`-strip -density 150 -units PixelsPerInch`): the contract check rejects evidence recording under 150 DPI, which stripping alone removes.
 - A text-layer-only fix may correctly produce byte- and pixel-identical `before.jpg` and `after.jpg`. Regenerate and verify the current `after.jpg` without adding annotations; it need not appear in the diff when the render is unchanged. Set `Text-layer-only: Yes` and `Pixel delta: 0` in the PR's `Visual audit`, change `layout-audit.json`, and require that report to show the missing/extra searchable-text finding resolved. The contract requires both evidence files and uses ImageMagick's exact decoded-pixel comparison to verify that the declared zero delta is true.
 - **When filing a visual defect issue, attach a side-by-side image (GT left, office2pdf output at filing time right)** rendered from the same page and resolution, committed as `assets/bugfixes/issue-<number>/compare.jpg` (same JPEG rules as above) and embedded in the issue body via a commit-pinned raw URL. For classified fixtures, confirm with the user before publishing the image; the surrounding issue text must still follow the Confidentiality rules.
 
@@ -147,7 +147,8 @@ just the pages a screenshot shows.
    `compare_text_layer.py` (what a reader can select), `compare_render.py`
    (colour and pixels), and a page-by-page visual at >=150 DPI.
    Run the geometry axis with `--audit --fine-shift PT`; every fine/large
-   text-instance shift, painted-text visibility mismatch, or visible-fill occlusion it names must be fixed or recorded as a
+   text-instance shift, rectangle geometry deviation, painted-text visibility
+   mismatch, or visible-fill occlusion it names must be fixed or recorded as a
    remaining deviation with an open issue.
    Do not classify the pixel diff as antialiasing while this audit is failing.
    Source/XML inspection and numeric reports only route attention; they never
@@ -193,7 +194,8 @@ For layout defects, run `python3 scripts/compare_layout.py <GT.pdf> <output.pdf>
 first: it matches text lines from `mutool` traces and reports missing/extra/
 re-wrapped lines, informational safe split/join topology groups, spatial-anchor
 dy, pitch and width drift, painted-text visibility,
-visible-fill occlusions, and a rect census, with GT noise floors built in (`--noise-floor 0.12` Word,
+visible-fill occlusions, and geometry-aware axis-aligned rectangle/line
+x/y/size/edge deltas, with GT noise floors built in (`--noise-floor 0.12` Word,
 `0.5` Excel). Painted visibility uses trace order and flat-background contrast:
 text covered by a later opaque image, single closed axis-aligned rectangle, or
 fully extended shading under such a rectangular clip is `hidden`; same-colour
@@ -216,6 +218,10 @@ the pixel-difference and visual-inspection passes. Visible-fill analysis compare
 paint order and final overlap colour where a later opaque rectangle cuts into a
 thin earlier rule. Point and area floors reject trace slivers, and same-colour
 operation splitting is ignored.
+Touching same-paint rectangle/line operations are merged before geometry
+matching; non-rectangular path bounds and raw draw counts remain informational.
+Matched position, size, and edge deltas use the active fine or coarse shift
+threshold and fail the audit.
 Horizontal text uses its true baseline; a rotated or skewed `fill_text` stays
 one visual run and uses the minimum fully transformed glyph x/y as its
 comparable anchor. Its numbers are assertable; pixel counts are only a

--- a/assets/bugfixes/README.md
+++ b/assets/bugfixes/README.md
@@ -47,8 +47,8 @@ audit`, then mark each layout-audit category as `Pass` or list the open issues
 that classify it. Those references must also appear in `Remaining:` deviation
 rows. The gate rejects a claimed pass when the report contains a page-count
 difference, missing/extra/reflowed text, changed wraps, a painted-text visibility
-mismatch, a visible-fill occlusion, or a text shift above the configured fine or
-large threshold.
+mismatch, a visible-fill occlusion, or a text or rectangle geometry shift above
+the configured fine or large threshold.
 
 Generate the cluster IDs once without strict mode, inspect every cluster in the
 full-resolution diff and matched crops, then create a disposition file whose

--- a/scripts/check_layout_baselines.py
+++ b/scripts/check_layout_baselines.py
@@ -17,8 +17,9 @@ on deltas smaller than the GT's own lattice):
   cases (the Quartz export rounds every advance to a whole point);
 - width percentages move materially only past 0.5%;
 - counts (missing/extra lines, wraps, reflows, deviant lines, large shifts,
-  painted-text visibility mismatches, visible-fill occlusions, rect census
-  gap, page parity gap) compare exactly — any increase is a regression.
+  painted-text visibility mismatches, visible-fill occlusions, rectangle
+  geometry mismatches, rect census gap, page parity gap) compare exactly — any
+  increase is a regression.
 
 Safe split/join topology groups are informational and therefore are not a
 count regression. Their recovered fragments still contribute to the position,
@@ -57,6 +58,7 @@ COUNT_METRICS = (
     ("instances", "large_shift_count"),
     ("visibility", "mismatch_count"),
     ("visible_fills", "mismatch_count"),
+    ("rects", "geometry_mismatch_count"),
 )
 PT_METRICS = (
     ("baseline", "mean_abs_dy"),
@@ -114,10 +116,9 @@ def compare_page(
 ) -> list[dict]:
     findings: list[dict] = []
     for section, key in COUNT_METRICS:
-        # Visibility checks were added additively to schema v2. Baselines
-        # recorded by an older generator carry no section and conservatively
-        # mean zero known mismatches; a fresh finding therefore surfaces as a
-        # regression.
+        # Material checks are added compatibly within schema v2. An older
+        # baseline without one of these counts means zero recorded findings;
+        # a fresh finding therefore surfaces as a regression.
         stored_count = int(stored_vector.get(section, {}).get(key, 0))
         fresh_count = int(fresh_vector.get(section, {}).get(key, 0))
         if fresh_count != stored_count:

--- a/scripts/check_visual_pr.py
+++ b/scripts/check_visual_pr.py
@@ -54,7 +54,8 @@ INSPECTION_ITEMS = (
     "Used Codex/Claude vision to inspect the full GT/output pages, diff, and matched crops",
     "Inspected matched region crops at full resolution",
     "Ran compare_layout.py --audit --fine-shift PT and dispositioned every fine/large "
-    "text-instance shift, painted-text visibility mismatch, and visible-fill occlusion",
+    "text-instance shift, rectangle geometry deviation, painted-text visibility mismatch, "
+    "and visible-fill occlusion",
     "Ran compare_render.py --cluster-report PATH --strict-clusters and dispositioned "
     "every material 5% fuzz diff cluster by explicit ID",
     "Inventoried hairlines and border dash styles",
@@ -296,6 +297,7 @@ def layout_audit_categories(report: object) -> dict[str, bool]:
 
     has_text_flow_findings = False
     has_visible_fill_findings = False
+    has_rect_geometry_findings = False
     has_large_shifts = False
     has_fine_shifts = False
     for page_number, page in enumerate(pages, start=1):
@@ -308,6 +310,7 @@ def layout_audit_categories(report: object) -> dict[str, bool]:
             instances = page["instances"]
             visibility = page.get("visibility", {"mismatch_count": 0})
             visible_fills = page.get("visible_fills", {"mismatch_count": 0})
+            rects = page.get("rects", {"geometry_mismatch_count": 0})
             text_flow_counts = (
                 line_counts["missing"],
                 line_counts["extra"],
@@ -317,16 +320,24 @@ def layout_audit_categories(report: object) -> dict[str, bool]:
                 visibility["mismatch_count"],
             )
             visible_fill_count = visible_fills["mismatch_count"]
+            rect_geometry_count = rects.get("geometry_mismatch_count", 0)
             large_shift_count = instances["large_shift_count"]
             fine_shift_count = instances["fine_shift_count"]
         except (KeyError, TypeError) as exc:
             raise ValueError(f"page {page_number} is missing compare_layout fields") from exc
-        counts = (*text_flow_counts, visible_fill_count, large_shift_count, fine_shift_count)
+        counts = (
+            *text_flow_counts,
+            visible_fill_count,
+            rect_geometry_count,
+            large_shift_count,
+            fine_shift_count,
+        )
         if any(type(count) is not int or count < 0 for count in counts):
             raise ValueError(f"page {page_number} finding counts must be non-negative integers")
 
         has_text_flow_findings |= any(text_flow_counts)
         has_visible_fill_findings |= visible_fill_count > 0
+        has_rect_geometry_findings |= rect_geometry_count > 0
         has_large_shifts |= large_shift_count > 0
         has_fine_shifts |= fine_shift_count > 0
 
@@ -334,6 +345,7 @@ def layout_audit_categories(report: object) -> dict[str, bool]:
         "page count": gt_pages != out_pages,
         "text flow": has_text_flow_findings,
         "visible fills": has_visible_fill_findings,
+        "rectangle geometry": has_rect_geometry_findings,
         "large shifts": has_large_shifts,
         "fine shifts": has_fine_shifts,
     }
@@ -481,6 +493,7 @@ def validate_layout_audit(body: str, changed_paths: list[str], root: Path) -> li
         "page count": "Layout audit page count",
         "text flow": "Layout audit text flow",
         "visible fills": "Layout audit visible fills",
+        "rectangle geometry": "Layout audit rectangle geometry",
         "large shifts": "Layout audit large shifts",
         "fine shifts": "Layout audit fine shifts",
     }

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -23,7 +23,9 @@ visible ink. It then matches lines by their text and reports typed deviations:
 - visible-fill occlusions: a later opaque, differently coloured rectangle
   cutting into a thin earlier rule is compared by final overlap area, colour,
   and paint order rather than by the raw rectangle count;
-- a fill/stroke rect census with nearest-match position deltas.
+- a fill/stroke path census plus geometry-aware x/y/size/edge deltas for
+  axis-aligned rectangles and straight lines. Touching same-paint operation
+  splits are merged before matching while raw counts stay visible.
 
 A noise floor (default 0.12pt — native Word exports quantise coordinates to a
 0.24pt grid; use 0.5 for Excel GT, whose Quartz export rounds every advance to
@@ -97,7 +99,12 @@ LINE_Y_TOLERANCE_PT = 0.6
 # operation boundary, this isolates independently positioned chart/table text
 # that mutool happens to merge only because the objects share a baseline.
 SAFE_TOPOLOGY_GAP_PT = 24.0
-RECT_MATCH_RADIUS_PT = 6.0
+# Unequal rectangle groups contain unmatched operations by definition. Limit
+# their pair candidates so a nearby rule cannot be assigned to an unrelated
+# shape elsewhere on the page. Equal-cardinality groups remain fully paired so
+# a large translation is reported as geometry instead of disappearing.
+RECT_AMBIGUOUS_MATCH_RADIUS_PT = 24.0
+RECT_SAMPLE_LIMIT = 5
 OPAQUE_ALPHA = 0.98
 INVISIBLE_ALPHA = 0.02
 LOW_CONTRAST_CHANNEL_DELTA = 0.04
@@ -147,14 +154,35 @@ class Paint:
 @dataclass(frozen=True)
 class Rect:
     kind: str  # "fill" | "stroke"
+    geometry_kind: str  # "rectangle" | "line" | "other"
     x0: float
     y0: float
     x1: float
     y1: float
+    color: tuple[float, float, float] | None = None
+    alpha: float = 1.0
 
     @property
     def center(self) -> tuple[float, float]:
         return ((self.x0 + self.x1) / 2, (self.y0 + self.y1) / 2)
+
+    @property
+    def width(self) -> float:
+        return self.x1 - self.x0
+
+    @property
+    def height(self) -> float:
+        return self.y1 - self.y0
+
+    @property
+    def bbox(self) -> list[float]:
+        return [self.x0, self.y0, self.x1, self.y1]
+
+
+@dataclass(frozen=True)
+class CanonicalRect:
+    rect: Rect
+    source_indices: tuple[int, ...]
 
 
 @dataclass(frozen=True)
@@ -322,6 +350,50 @@ def axis_aligned_rect_bbox(
         if same_x == same_y:
             return None
     return transformed_bbox((1, 0, 0, 1, 0, 0), transformed)
+
+
+def axis_aligned_line_bbox(
+    attrs: str, body: str
+) -> tuple[float, float, float, float] | None:
+    """Return the bbox for one straight horizontal or vertical path."""
+    points: list[tuple[float, float]] = []
+    cursor = 0
+    saw_move = False
+    for match in PATH_COMMAND_RE.finditer(body):
+        if body[cursor : match.start()].strip():
+            return None
+        cursor = match.end()
+        if match.group("close"):
+            continue
+        command = match.group("point")
+        if command == "moveto":
+            if saw_move:
+                return None
+            saw_move = True
+        elif not saw_move:
+            return None
+        point_attrs = match.group("attrs")
+        x_match = X_RE.search(point_attrs)
+        y_match = Y_RE.search(point_attrs)
+        if not x_match or not y_match:
+            return None
+        points.append((float(x_match.group(1)), float(y_match.group(1))))
+    if body[cursor:].strip() or not saw_move:
+        return None
+
+    transform = parse_transform(attrs) or (1, 0, 0, 1, 0, 0)
+    a, b, c, d, e, f = transform
+    transformed = {
+        (round(a * x + c * y + e, 6), round(b * x + d * y + f, 6))
+        for x, y in points
+    }
+    if len(transformed) < 2:
+        return None
+    xs = {point[0] for point in transformed}
+    ys = {point[1] for point in transformed}
+    if (len(xs) == 1) == (len(ys) == 1):
+        return None
+    return transformed_bbox((1, 0, 0, 1, 0, 0), list(transformed))
 
 
 def intersect_bboxes(
@@ -845,13 +917,29 @@ def parse_trace(trace_xml: str) -> list[PageLayout]:
                 ys.append(b * point_x + d * point_y + f)
             if xs:
                 bbox = (min(xs), min(ys), max(xs), max(ys))
+                flat_bbox = axis_aligned_rect_bbox(op_attrs, op_body)
+                line_bbox = (
+                    axis_aligned_line_bbox(op_attrs, op_body)
+                    if kind == "stroke_path"
+                    else None
+                )
+                geometry_kind = (
+                    "rectangle"
+                    if flat_bbox is not None
+                    else "line"
+                    if line_bbox is not None
+                    else "other"
+                )
                 rects.append(
                     Rect(
                         kind="fill" if kind == "fill_path" else "stroke",
+                        geometry_kind=geometry_kind,
                         x0=bbox[0],
                         y0=bbox[1],
                         x1=bbox[2],
                         y1=bbox[3],
+                        color=parse_rgb(op_attrs),
+                        alpha=parse_alpha(op_attrs),
                     )
                 )
                 if kind == "fill_path":
@@ -867,7 +955,6 @@ def parse_trace(trace_xml: str) -> list[PageLayout]:
                             color=parse_rgb(op_attrs),
                         )
                     )
-                flat_bbox = axis_aligned_rect_bbox(op_attrs, op_body)
                 if kind == "fill_path" and flat_bbox is not None:
                     paints.append(
                         Paint(
@@ -1127,6 +1214,151 @@ def take_reflows(missing: list[Line], extra: list[Line]) -> tuple[dict, list[Lin
     return {"gt_lines": 0, "out_lines": 0, "samples": []}, missing, extra
 
 
+def same_rect_paint(first: Rect, second: Rect) -> bool:
+    if (
+        first.kind != second.kind
+        or first.geometry_kind != second.geometry_kind
+        or abs(first.alpha - second.alpha) > 1e-6
+    ):
+        return False
+    if first.color is None or second.color is None:
+        return first.color is second.color
+    return all(
+        abs(left - right) <= 1e-6
+        for left, right in zip(first.color, second.color)
+    )
+
+
+def merge_rect_groups(
+    groups: list[CanonicalRect], *, horizontal: bool, tolerance: float
+) -> list[CanonicalRect]:
+    """Merge collinear same-paint pieces without filling an L-shaped gap."""
+
+    def can_merge(first: Rect, second: Rect) -> bool:
+        if not same_rect_paint(first, second):
+            return False
+        same_bbox = all(
+            abs(left - right) <= tolerance
+            for left, right in zip(first.bbox, second.bbox)
+        )
+        if same_bbox:
+            return True
+        if horizontal:
+            same_band = (
+                abs(first.y0 - second.y0) <= tolerance
+                and abs(first.y1 - second.y1) <= tolerance
+            )
+            intervals_touch = (
+                abs(first.x1 - second.x0) <= tolerance
+                or abs(second.x1 - first.x0) <= tolerance
+            )
+        else:
+            same_band = (
+                abs(first.x0 - second.x0) <= tolerance
+                and abs(first.x1 - second.x1) <= tolerance
+            )
+            intervals_touch = (
+                abs(first.y1 - second.y0) <= tolerance
+                or abs(second.y1 - first.y0) <= tolerance
+            )
+        return same_band and intervals_touch
+
+    ordered = sorted(
+        groups,
+        key=lambda group: (
+            group.rect.kind,
+            group.rect.y0 if horizontal else group.rect.x0,
+            group.rect.y1 if horizontal else group.rect.x1,
+            group.rect.x0 if horizontal else group.rect.y0,
+        ),
+    )
+    merged: list[CanonicalRect] = []
+    for group in ordered:
+        target_index = next(
+            (
+                index
+                for index, existing in enumerate(merged)
+                if can_merge(existing.rect, group.rect)
+            ),
+            None,
+        )
+        if target_index is None:
+            merged.append(group)
+            continue
+        existing = merged[target_index]
+        merged[target_index] = CanonicalRect(
+            rect=Rect(
+                kind=existing.rect.kind,
+                geometry_kind=existing.rect.geometry_kind,
+                x0=min(existing.rect.x0, group.rect.x0),
+                y0=min(existing.rect.y0, group.rect.y0),
+                x1=max(existing.rect.x1, group.rect.x1),
+                y1=max(existing.rect.y1, group.rect.y1),
+                color=existing.rect.color,
+                alpha=existing.rect.alpha,
+            ),
+            source_indices=tuple(sorted(existing.source_indices + group.source_indices)),
+        )
+    return merged
+
+
+def canonical_rects(rects: list[Rect], tolerance: float) -> list[CanonicalRect]:
+    groups = [
+        CanonicalRect(rect=rect, source_indices=(index,))
+        for index, rect in enumerate(rects)
+        if rect.geometry_kind != "other"
+    ]
+    groups = merge_rect_groups(groups, horizontal=True, tolerance=tolerance)
+    groups = merge_rect_groups(groups, horizontal=False, tolerance=tolerance)
+    return sorted(
+        groups,
+        key=lambda group: (
+            group.rect.kind,
+            group.rect.y0,
+            group.rect.x0,
+            group.rect.height,
+            group.rect.width,
+        ),
+    )
+
+
+def rect_feature(rect: Rect) -> tuple[float, float, float, float]:
+    """Represent both placement and extent for minimum-cost assignment."""
+    return (rect.center[0], rect.center[1], rect.width / 2, rect.height / 2)
+
+
+def rect_sample(gt_group: CanonicalRect, out_group: CanonicalRect) -> dict:
+    gt_rect = gt_group.rect
+    out_rect = out_group.rect
+    dx = out_rect.x0 - gt_rect.x0
+    dy = out_rect.y0 - gt_rect.y0
+    dwidth = out_rect.width - gt_rect.width
+    dheight = out_rect.height - gt_rect.height
+    edges = {
+        "left": dx,
+        "top": dy,
+        "right": out_rect.x1 - gt_rect.x1,
+        "bottom": out_rect.y1 - gt_rect.y1,
+    }
+    deltas = [dx, dy, dwidth, dheight, *edges.values()]
+    return {
+        "kind": gt_rect.kind,
+        "geometry_kind": gt_rect.geometry_kind,
+        "gt_indices": list(gt_group.source_indices),
+        "out_indices": list(out_group.source_indices),
+        "gt_bbox": gt_rect.bbox,
+        "out_bbox": out_rect.bbox,
+        "dx": dx,
+        "dy": dy,
+        "dwidth": dwidth,
+        "dheight": dheight,
+        "edges": edges,
+        "center_dx": out_rect.center[0] - gt_rect.center[0],
+        "center_dy": out_rect.center[1] - gt_rect.center[1],
+        "max_abs_delta": max(abs(delta) for delta in deltas),
+    }
+
+
 def diff_page(
     gt: PageLayout,
     out: PageLayout,
@@ -1238,26 +1470,6 @@ def diff_page(
 
     worst_dy_index = max(range(len(dys)), key=lambda i: abs(dys[i]), default=None)
 
-    rect_pairs = 0
-    rect_center_deltas: list[float] = []
-    unclaimed = list(out.rects)
-    for gt_rect in gt.rects:
-        best = None
-        best_distance = RECT_MATCH_RADIUS_PT
-        for candidate in unclaimed:
-            if candidate.kind != gt_rect.kind:
-                continue
-            distance = max(
-                abs(candidate.center[0] - gt_rect.center[0]),
-                abs(candidate.center[1] - gt_rect.center[1]),
-            )
-            if distance <= best_distance:
-                best, best_distance = candidate, distance
-        if best is not None:
-            unclaimed.remove(best)
-            rect_pairs += 1
-            rect_center_deltas.append(best_distance)
-
     def stats(values: list[float]) -> dict:
         if not values:
             return {"mean_abs": 0.0, "worst": 0.0}
@@ -1265,6 +1477,62 @@ def diff_page(
             "mean_abs": sum(abs(v) for v in values) / len(values),
             "worst": max(values, key=abs),
         }
+
+    canonical_gt_rects = canonical_rects(gt.rects, noise_floor)
+    canonical_out_rects = canonical_rects(out.rects, noise_floor)
+    rect_matches: list[tuple[CanonicalRect, CanonicalRect]] = []
+    for kind, geometry_kind in (
+        ("fill", "rectangle"),
+        ("stroke", "rectangle"),
+        ("stroke", "line"),
+    ):
+        references = [
+            group
+            for group in canonical_gt_rects
+            if (group.rect.kind, group.rect.geometry_kind) == (kind, geometry_kind)
+        ]
+        candidates = [
+            group
+            for group in canonical_out_rects
+            if (group.rect.kind, group.rect.geometry_kind) == (kind, geometry_kind)
+        ]
+        has_equal_cardinality = len(references) == len(candidates)
+        for reference_index, candidate_index in minimum_cost_pairs(
+            [rect_feature(group.rect) for group in references],
+            [rect_feature(group.rect) for group in candidates],
+        ):
+            reference = references[reference_index]
+            candidate = candidates[candidate_index]
+            center_delta = max(
+                abs(candidate.rect.center[0] - reference.rect.center[0]),
+                abs(candidate.rect.center[1] - reference.rect.center[1]),
+            )
+            if (
+                not has_equal_cardinality
+                and center_delta > RECT_AMBIGUOUS_MATCH_RADIUS_PT
+            ):
+                continue
+            rect_matches.append((reference, candidate))
+
+    rect_samples = [
+        rect_sample(reference, candidate) for reference, candidate in rect_matches
+    ]
+    rect_samples.sort(
+        key=lambda sample: (-sample["max_abs_delta"], sample["gt_indices"])
+    )
+    rect_geometry_threshold = fine_shift if fine_shift is not None else large_shift
+    rect_geometry_mismatches = [
+        sample
+        for sample in rect_samples
+        if sample["max_abs_delta"] > rect_geometry_threshold
+    ]
+    rect_center_deltas = [
+        max(abs(sample["center_dx"]), abs(sample["center_dy"]))
+        for sample in rect_samples
+    ]
+
+    rect_gt_ids = {id(reference) for reference, _ in rect_matches}
+    rect_out_ids = {id(candidate) for _, candidate in rect_matches}
 
     dy_stats = stats(dys)
     return {
@@ -1323,8 +1591,28 @@ def diff_page(
         "rects": {
             "gt_count": len(gt.rects),
             "out_count": len(out.rects),
-            "matched": rect_pairs,
+            "canonical_gt_count": len(canonical_gt_rects),
+            "canonical_out_count": len(canonical_out_rects),
+            "matched": len(rect_matches),
+            "unmatched_gt": sum(
+                id(group) not in rect_gt_ids for group in canonical_gt_rects
+            ),
+            "unmatched_out": sum(
+                id(group) not in rect_out_ids for group in canonical_out_rects
+            ),
             "mean_center_delta": stats(rect_center_deltas)["mean_abs"],
+            "geometry_threshold": rect_geometry_threshold,
+            "geometry_mismatch_count": len(rect_geometry_mismatches),
+            "geometry_mismatch_samples": rect_geometry_mismatches[:RECT_SAMPLE_LIMIT],
+            "samples": rect_samples[:RECT_SAMPLE_LIMIT],
+            "x": stats([sample["dx"] for sample in rect_samples]),
+            "y": stats([sample["dy"] for sample in rect_samples]),
+            "width": stats([sample["dwidth"] for sample in rect_samples]),
+            "height": stats([sample["dheight"] for sample in rect_samples]),
+            "edges": {
+                edge: stats([sample["edges"][edge] for sample in rect_samples])
+                for edge in ("left", "top", "right", "bottom")
+            },
         },
         "noise_floor": noise_floor,
     }
@@ -1427,9 +1715,26 @@ def render_reading(vectors: list[dict]) -> str:
         if vector["rects"]["gt_count"] != vector["rects"]["out_count"]:
             page_notes.append(
                 f"rect census differs: GT {vector['rects']['gt_count']} vs "
-                f"output {vector['rects']['out_count']} draw ops — can be op-splitting "
-                "(per-cell border segments vs one merged stroke), so confirm visually "
-                "before reading it as missing ink"
+                f"output {vector['rects']['out_count']} raw draw ops; touching same-paint "
+                "axis-aligned same-paint normalization yields "
+                f"{vector['rects']['canonical_gt_count']} vs "
+                f"{vector['rects']['canonical_out_count']} comparable rectangle/line "
+                "primitives. Raw count differences can be non-rectangular paths or "
+                "operation splitting, so confirm unmatched geometry visually before "
+                "reading it as missing ink"
+            )
+        if vector["rects"]["geometry_mismatch_count"]:
+            examples = "; ".join(
+                f"{item['kind']} GT {item['gt_bbox']} -> output {item['out_bbox']} "
+                f"(dx {item['dx']:+.2f}, dy {item['dy']:+.2f}, "
+                f"dw {item['dwidth']:+.2f}, dh {item['dheight']:+.2f}pt)"
+                for item in vector["rects"]["geometry_mismatch_samples"]
+            )
+            page_notes.append(
+                f"{vector['rects']['geometry_mismatch_count']} matched rectangle geometry "
+                f"deviation(s) exceed {vector['rects']['geometry_threshold']:.2f}pt: "
+                f"{examples}. Inspect the recorded source operation indices and corresponding "
+                "render cluster"
             )
         if not page_notes:
             page_notes.append("no deviation past the noise floor")
@@ -1447,6 +1752,7 @@ def audit_failures(vectors: list[dict]) -> int:
         )
         + vector["visibility"]["mismatch_count"]
         + vector["visible_fills"]["mismatch_count"]
+        + vector["rects"]["geometry_mismatch_count"]
         + vector["lines"]["missing"]
         + vector["lines"]["extra"]
         + vector["wraps"]["count"]
@@ -1484,15 +1790,18 @@ def main() -> int:
         type=float,
         default=5.0,
         metavar="PT",
-        help="flag any matched text instance whose x or y moves by more than this (default: 5pt)",
+        help=(
+            "flag any matched text instance or rectangle geometry component that moves "
+            "by more than this (default: 5pt)"
+        ),
     )
     parser.add_argument(
         "--fine-shift",
         type=float,
         metavar="PT",
         help=(
-            "enable the fine-detail audit gate and flag matched text whose x or y "
-            "moves by more than PT; does not replace the 5pt coarse summary"
+            "enable the fine-detail audit gate and flag matched text x/y or rectangle "
+            "geometry beyond PT; does not replace the 5pt coarse text summary"
         ),
     )
     parser.add_argument(
@@ -1500,8 +1809,8 @@ def main() -> int:
         action="store_true",
         help=(
             "exit nonzero on missing/extra/reflowed text, changed wraps, "
-            "a text/fill visibility mismatch, an active fine/coarse instance "
-            "shift, or a page-count mismatch"
+            "a text/fill visibility mismatch, an active fine/coarse text or "
+            "rectangle geometry shift, or a page-count mismatch"
         ),
     )
     parser.add_argument("--json", action="store_true", help="emit the deviation vectors as JSON")
@@ -1568,7 +1877,8 @@ def main() -> int:
             f"{fine_shift_summary}"
             f"visibility {vector['visibility']['mismatch_count']} | "
             f"visible fills {vector['visible_fills']['mismatch_count']} | "
-            f"rects {vector['rects']['gt_count']}/{vector['rects']['out_count']}"
+            f"rects {vector['rects']['gt_count']}/{vector['rects']['out_count']} "
+            f"(geometry {vector['rects']['geometry_mismatch_count']})"
         )
     print()
     print(render_reading(vectors))

--- a/scripts/generate_layout_baselines.py
+++ b/scripts/generate_layout_baselines.py
@@ -14,7 +14,8 @@ For every case in ``tests/golden_mocks/business/manifest.json`` this pipeline:
    to a whole point), including informational safe split/join topology groups,
    painted-text visibility mismatches caused by z-order or flat-background
    contrast, plus visible-fill occlusions where a later opaque, differently
-   coloured rectangle cuts into a thin rule.
+   coloured rectangle cuts into a thin rule, and matched axis-aligned
+   rectangle/line geometry deviations after same-paint operation splits merge.
 
 A trace that parses to zero pages is a hard failure, never an empty vector: on
 mutool 1.23.x that state used to look exactly like a perfect comparison
@@ -167,6 +168,10 @@ def build_baseline_document(
             vector.get("visible_fills", {"mismatch_count": 0})["mismatch_count"]
             for vector in pages
         ),
+        "rect_geometry_mismatches": sum(
+            vector.get("rects", {}).get("geometry_mismatch_count", 0)
+            for vector in pages
+        ),
     }
     return {
         "schema_version": SCHEMA_VERSION,
@@ -251,13 +256,18 @@ def main() -> int:
                     ]
                     for vector in record["pages"]
                 )
+                rect_geometry_mismatches = sum(
+                    vector.get("rects", {}).get("geometry_mismatch_count", 0)
+                    for vector in record["pages"]
+                )
                 print(
                     f"{record['id']}: {record['out_pages']}/{record['gt_pages']} pages, "
                     f"{sum(v['lines']['missing'] for v in record['pages'])} missing, "
                     f"{sum(v['instances']['large_shift_count'] for v in record['pages'])} "
                     "large shifts, "
                     f"{visibility_mismatches} text visibility mismatches, "
-                    f"{visible_fill_mismatches} visible fill mismatches"
+                    f"{visible_fill_mismatches} visible fill mismatches, "
+                    f"{rect_geometry_mismatches} rectangle geometry mismatches"
                 )
     except BaselineError as error:
         print(f"baseline generation failed: {error}", file=sys.stderr)

--- a/scripts/probe_harness.py
+++ b/scripts/probe_harness.py
@@ -395,6 +395,10 @@ def layout_identical_failures(report: dict) -> list[str]:
                 f"page {index}: {visibility['mismatch_count']} visibility mismatch(es)"
             )
         rects = vector["rects"]
+        if rects.get("geometry_mismatch_count", 0):
+            failures.append(
+                f"page {index}: {rects['geometry_mismatch_count']} rectangle geometry mismatch(es)"
+            )
         if rects["gt_count"] != rects["out_count"]:
             failures.append(f"page {index}: rects {rects['gt_count']} vs {rects['out_count']}")
     return failures
@@ -458,6 +462,10 @@ def variant_row(value: str, patched: int, report: dict) -> dict:
             vector.get("visibility", {"mismatch_count": 0})["mismatch_count"]
             for vector in vectors
         ),
+        "rect_geometry": sum(
+            vector.get("rects", {}).get("geometry_mismatch_count", 0)
+            for vector in vectors
+        ),
         "rects": "{}/{}".format(
             sum(vector["rects"]["gt_count"] for vector in vectors),
             sum(vector["rects"]["out_count"] for vector in vectors),
@@ -481,6 +489,7 @@ def render_table(spec: Spec, backend: str, control_verdict: str, rows: list[dict
         "worst width (%)",
         "large shifts",
         "visibility",
+        "rect geometry",
         "rects",
     )
     lines = [
@@ -510,6 +519,7 @@ def render_table(spec: Spec, backend: str, control_verdict: str, rows: list[dict
             f"{row['worst_width']:.1f}",
             str(row["large_shifts"]),
             str(row["visibility"]),
+            str(row["rect_geometry"]),
             row["rects"],
         )
         lines.append("| " + " | ".join(cells) + " |")

--- a/scripts/spatial_match.py
+++ b/scripts/spatial_match.py
@@ -1,8 +1,8 @@
 """Minimum-cost pairing for repeated visual elements.
 
 Text alone is not an identity: charts, legends, tables, and axes routinely
-repeat the same label.  Pair repeated instances by their two-dimensional
-positions so one displaced instance cannot disappear from a geometry report.
+repeat the same label. Pair repeated instances by their position or geometry
+feature vectors so one displaced instance cannot disappear from a report.
 """
 
 from __future__ import annotations
@@ -11,11 +11,11 @@ import math
 from collections.abc import Sequence
 
 
-Point = tuple[float, float]
+Vector = Sequence[float]
 
 
 def minimum_cost_pairs(
-    references: Sequence[Point], candidates: Sequence[Point]
+    references: Sequence[Vector], candidates: Sequence[Vector]
 ) -> list[tuple[int, int]]:
     """Return a minimum-total-distance one-to-one assignment.
 
@@ -29,10 +29,7 @@ def minimum_cost_pairs(
     swapped = len(references) > len(candidates)
     rows = candidates if swapped else references
     columns = references if swapped else candidates
-    costs = [
-        [math.hypot(row[0] - column[0], row[1] - column[1]) for column in columns]
-        for row in rows
-    ]
+    costs = [[math.dist(row, column) for column in columns] for row in rows]
 
     # Rectangular Hungarian algorithm, with rows <= columns.
     row_count = len(rows)

--- a/scripts/tests/test_check_layout_baselines.py
+++ b/scripts/tests/test_check_layout_baselines.py
@@ -47,7 +47,13 @@ def page_vector(**overrides: object) -> dict:
         "pitch": {"pairs": 9, "worst_delta": 0.3},
         "wraps": {"count": 0, "samples": []},
         "reflow": {"gt_lines": 0, "out_lines": 0, "samples": []},
-        "rects": {"gt_count": 4, "out_count": 4, "matched": 4, "mean_center_delta": 0.5},
+        "rects": {
+            "gt_count": 4,
+            "out_count": 4,
+            "matched": 4,
+            "mean_center_delta": 0.5,
+            "geometry_mismatch_count": 0,
+        },
         "noise_floor": 0.12,
     }
     for dotted_key, value in overrides.items():
@@ -199,6 +205,30 @@ class CountTests(unittest.TestCase):
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0]["metric"], "rects.census_gap")
         self.assertEqual(findings[0]["kind"], "regression")
+
+    def test_rect_geometry_mismatch_increase_is_a_regression(self) -> None:
+        stored = baseline_document()
+        fresh = copy.deepcopy(stored)
+        fresh["cases"][0]["pages"][0]["rects"]["geometry_mismatch_count"] = 1
+
+        findings = checker.compare_baselines(stored, fresh)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["kind"], "regression")
+        self.assertEqual(findings[0]["metric"], "rects.geometry_mismatch_count")
+
+    def test_older_baseline_without_rect_geometry_treats_new_finding_as_regression(
+        self,
+    ) -> None:
+        stored = baseline_document()
+        del stored["cases"][0]["pages"][0]["rects"]["geometry_mismatch_count"]
+        fresh = baseline_document()
+        fresh["cases"][0]["pages"][0]["rects"]["geometry_mismatch_count"] = 1
+
+        findings = checker.compare_baselines(stored, fresh)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["metric"], "rects.geometry_mismatch_count")
 
 
 class PageParityTests(unittest.TestCase):

--- a/scripts/tests/test_check_visual_pr.py
+++ b/scripts/tests/test_check_visual_pr.py
@@ -61,6 +61,7 @@ def visual_body(result_overrides=None, include_previews=True):
 - Layout audit page count: Pass
 - Layout audit text flow: Pass
 - Layout audit visible fills: Pass
+- Layout audit rectangle geometry: Pass
 - Layout audit large shifts: Pass
 - Layout audit fine shifts: Pass
 - New follow-up issues found in this audit: {follow_up_value}
@@ -96,6 +97,7 @@ def layout_report(
     fine_threshold=0.5,
     visibility=0,
     visible_fills=0,
+    rect_geometry=0,
 ):
     return {
         "pages": [
@@ -110,6 +112,7 @@ def layout_report(
                 },
                 "visibility": {"mismatch_count": visibility},
                 "visible_fills": {"mismatch_count": visible_fills},
+                "rects": {"geometry_mismatch_count": rect_geometry},
             }
         ],
         "gt_pages": gt_pages,
@@ -242,8 +245,8 @@ class PullRequestBodyTests(unittest.TestCase):
     def test_visual_audit_requires_layout_finding_disposition(self):
         required = (
             "- [x] Ran compare_layout.py --audit --fine-shift PT and dispositioned every "
-            "fine/large text-instance shift, painted-text visibility mismatch, and "
-            "visible-fill occlusion"
+            "fine/large text-instance shift, rectangle geometry deviation, painted-text "
+            "visibility mismatch, and visible-fill occlusion"
         )
         errors = validate_pr_body(
             visual_body().replace(required, required.replace("[x]", "[ ]")),
@@ -453,6 +456,25 @@ class LayoutAuditTests(unittest.TestCase):
             "Layout audit visible fills: #328",
         )
         self.assertEqual(validate_report(body, layout_report(visible_fills=1)), [])
+
+    def test_rect_geometry_failure_rejects_pass_disposition(self):
+        errors = validate_report(
+            visual_body(),
+            layout_report(rect_geometry=1),
+        )
+        self.assertTrue(
+            any(
+                "rectangle geometry" in error and "issue reference" in error
+                for error in errors
+            )
+        )
+
+    def test_rect_geometry_failure_accepts_remaining_position_issue(self):
+        body = visual_body({"Position/size": "Remaining: #328"}).replace(
+            "Layout audit rectangle geometry: Pass",
+            "Layout audit rectangle geometry: #328",
+        )
+        self.assertEqual(validate_report(body, layout_report(rect_geometry=1)), [])
 
     def test_failed_categories_accept_remaining_issue_references(self):
         body = visual_body(

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -110,6 +110,24 @@ def rect_op(
     )
 
 
+def line_op(
+    x0: float,
+    y0: float,
+    x1: float,
+    y1: float,
+    color: str = ".8 .8 .8",
+) -> str:
+    return "\n".join(
+        [
+            '<stroke_path linewidth="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" '
+            f'color="{color}" alpha="1" transform="1 0 0 1 0 0">',
+            f'<moveto x="{x0}" y="{y0}"/>',
+            f'<lineto x="{x1}" y="{y1}"/>',
+            "</stroke_path>",
+        ]
+    )
+
+
 def image_op() -> str:
     return (
         '<fill_image alpha="1" colorspace="DeviceRGB" ri="1" bp="1" op="0" opm="0" '
@@ -305,13 +323,14 @@ class ParseTraceTest(unittest.TestCase):
 
         self.assertEqual(lines, [])
 
-    def test_rect_bbox_uses_the_full_affine_transform(self) -> None:
+    def test_path_bbox_uses_the_full_affine_transform(self) -> None:
         page = """<fill_path transform="1 2 3 4 5 6">
           <moveto x="7" y="11"/>
           <lineto x="8" y="12"/>
         </fill_path>"""
         rect = compare_layout.parse_trace(trace_document(page))[0].rects[0]
         self.assertEqual((rect.x0, rect.y0, rect.x1, rect.y1), (45.0, 64.0, 49.0, 70.0))
+        self.assertEqual(rect.geometry_kind, "other")
 
     def test_rects_capture_device_bbox_and_kind(self) -> None:
         page = "\n".join(
@@ -324,6 +343,15 @@ class ParseTraceTest(unittest.TestCase):
         self.assertAlmostEqual(fill.x0, 69.36, places=2)
         self.assertAlmostEqual(fill.y1, 793.44, places=2)
         self.assertEqual({r.kind for r in rects}, {"fill", "stroke"})
+        self.assertEqual({r.geometry_kind for r in rects}, {"rectangle"})
+
+    def test_axis_aligned_stroke_line_is_geometry_comparable(self) -> None:
+        rect = compare_layout.parse_trace(
+            trace_document(line_op(74.183, 137.254, 339.165, 137.254))
+        )[0].rects[0]
+
+        self.assertEqual(rect.geometry_kind, "line")
+        self.assertEqual(rect.bbox, [74.183, 137.254, 339.165, 137.254])
 
 
 class MatchAndDiffTest(unittest.TestCase):
@@ -713,6 +741,149 @@ class MatchAndDiffTest(unittest.TestCase):
         self.assertEqual(vector["rects"]["gt_count"], 2)
         self.assertEqual(vector["rects"]["out_count"], 1)
 
+    def test_equal_center_rect_size_change_reports_geometry_and_fails_audit(self) -> None:
+        gt = rect_op(10.0, 20.0, 110.0, 40.0)
+        out = rect_op(0.0, 15.0, 120.0, 45.0)
+
+        vector = self.diff(gt, out, large_shift=5.0)
+        rects = vector["rects"]
+
+        self.assertEqual(rects["matched"], 1)
+        self.assertEqual(rects["geometry_mismatch_count"], 1)
+        self.assertAlmostEqual(rects["x"]["worst"], -10.0)
+        self.assertAlmostEqual(rects["y"]["worst"], -5.0)
+        self.assertAlmostEqual(rects["width"]["worst"], 20.0)
+        self.assertAlmostEqual(rects["height"]["worst"], 10.0)
+        self.assertAlmostEqual(rects["edges"]["left"]["worst"], -10.0)
+        self.assertAlmostEqual(rects["edges"]["top"]["worst"], -5.0)
+        self.assertAlmostEqual(rects["edges"]["right"]["worst"], 10.0)
+        self.assertAlmostEqual(rects["edges"]["bottom"]["worst"], 5.0)
+        self.assertEqual(rects["geometry_mismatch_samples"][0]["kind"], "fill")
+        self.assertEqual(
+            rects["geometry_mismatch_samples"][0]["gt_bbox"],
+            [10.0, 20.0, 110.0, 40.0],
+        )
+        self.assertEqual(
+            rects["geometry_mismatch_samples"][0]["out_bbox"],
+            [0.0, 15.0, 120.0, 45.0],
+        )
+        self.assertEqual(compare_layout.audit_failures([vector]), 1)
+
+    def test_translated_equal_size_rect_reports_position_and_edge_deltas(self) -> None:
+        gt = rect_op(10.0, 20.0, 110.0, 30.0, "stroke_path")
+        out = rect_op(18.0, 17.0, 118.0, 27.0, "stroke_path")
+
+        rects = self.diff(gt, out, large_shift=5.0)["rects"]
+
+        self.assertEqual(rects["geometry_mismatch_count"], 1)
+        self.assertAlmostEqual(rects["x"]["mean_abs"], 8.0)
+        self.assertAlmostEqual(rects["y"]["mean_abs"], 3.0)
+        self.assertAlmostEqual(rects["width"]["worst"], 0.0)
+        self.assertAlmostEqual(rects["height"]["worst"], 0.0)
+        self.assertAlmostEqual(rects["edges"]["left"]["worst"], 8.0)
+        self.assertAlmostEqual(rects["edges"]["right"]["worst"], 8.0)
+        self.assertAlmostEqual(rects["edges"]["top"]["worst"], -3.0)
+        self.assertAlmostEqual(rects["edges"]["bottom"]["worst"], -3.0)
+
+    def test_rect_matching_uses_size_when_centers_are_identical(self) -> None:
+        gt = "\n".join(
+            [rect_op(0.0, 0.0, 100.0, 10.0), rect_op(30.0, 0.0, 70.0, 10.0)]
+        )
+        out = "\n".join(
+            [rect_op(29.0, 0.0, 71.0, 10.0), rect_op(1.0, 0.0, 99.0, 10.0)]
+        )
+
+        rects = self.diff(gt, out, fine_shift=0.5)["rects"]
+
+        self.assertEqual(rects["matched"], 2)
+        self.assertEqual(rects["geometry_mismatch_count"], 2)
+        self.assertEqual(
+            [sample["gt_bbox"] for sample in rects["geometry_mismatch_samples"]],
+            [[0.0, 0.0, 100.0, 10.0], [30.0, 0.0, 70.0, 10.0]],
+        )
+        self.assertEqual(
+            [sample["out_bbox"] for sample in rects["geometry_mismatch_samples"]],
+            [[1.0, 0.0, 99.0, 10.0], [29.0, 0.0, 71.0, 10.0]],
+        )
+
+    def test_same_color_rect_operation_splitting_is_informational(self) -> None:
+        gt = rect_op(10.0, 20.0, 110.0, 21.0, color=".8 .2 .2")
+        out = "\n".join(
+            [
+                rect_op(10.0, 20.0, 60.0, 21.0, color=".8 .2 .2"),
+                rect_op(60.0, 20.0, 110.0, 21.0, color=".8 .2 .2"),
+            ]
+        )
+
+        vector = self.diff(gt, out, fine_shift=0.5)
+        rects = vector["rects"]
+
+        self.assertEqual((rects["gt_count"], rects["out_count"]), (1, 2))
+        self.assertEqual(
+            (rects["canonical_gt_count"], rects["canonical_out_count"]),
+            (1, 1),
+        )
+        self.assertEqual(rects["matched"], 1)
+        self.assertEqual(rects["geometry_mismatch_count"], 0)
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
+    def test_issue_1418_page_9_title_rule_is_a_rect_geometry_failure(self) -> None:
+        gt = line_op(74.183, 137.254, 339.165, 137.254)
+        out = line_op(74.215, 133.679, 327.632, 133.679)
+
+        vector = self.diff(gt, out, large_shift=5.0)
+        rects = vector["rects"]
+
+        self.assertEqual(rects["matched"], 1)
+        self.assertEqual(rects["geometry_mismatch_count"], 1)
+        sample = rects["geometry_mismatch_samples"][0]
+        self.assertAlmostEqual(sample["dy"], -3.575, places=3)
+        self.assertAlmostEqual(sample["dwidth"], -11.565, places=3)
+        self.assertAlmostEqual(sample["edges"]["right"], -11.533, places=3)
+        self.assertEqual(compare_layout.audit_failures([vector]), 1)
+        self.assertIn("rectangle geometry", compare_layout.render_reading([vector]))
+
+    def test_unequal_rect_groups_do_not_pair_distant_unrelated_shapes(self) -> None:
+        gt = "\n".join(
+            [
+                rect_op(10.0, 20.0, 110.0, 30.0),
+                rect_op(10.0, 50.0, 110.0, 60.0),
+            ]
+        )
+        out = rect_op(400.0, 400.0, 500.0, 410.0)
+
+        rects = self.diff(gt, out)["rects"]
+
+        self.assertEqual(rects["matched"], 0)
+        self.assertEqual((rects["unmatched_gt"], rects["unmatched_out"]), (2, 1))
+        self.assertEqual(rects["geometry_mismatch_count"], 0)
+
+    def test_non_rectangular_path_bounds_do_not_become_rect_geometry(self) -> None:
+        def triangle(x0: float, x1: float) -> str:
+            midpoint = (x0 + x1) / 2
+            return "\n".join(
+                [
+                    '<fill_path winding="nonzero" color=".8 .2 .2" alpha="1" '
+                    'transform="1 0 0 1 0 0">',
+                    f'<moveto x="{x0}" y="20"/>',
+                    f'<lineto x="{x1}" y="20"/>',
+                    f'<lineto x="{midpoint}" y="40"/>',
+                    "<closepath/>",
+                    "</fill_path>",
+                ]
+            )
+
+        vector = self.diff(triangle(10.0, 110.0), triangle(0.0, 120.0))
+        rects = vector["rects"]
+
+        self.assertEqual((rects["gt_count"], rects["out_count"]), (1, 1))
+        self.assertEqual(
+            (rects["canonical_gt_count"], rects["canonical_out_count"]),
+            (0, 0),
+        )
+        self.assertEqual(rects["geometry_mismatch_count"], 0)
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
     def test_later_different_fill_cutting_rule_reports_visible_fill_occlusion(
         self,
     ) -> None:
@@ -1086,6 +1257,27 @@ class ReadingTest(unittest.TestCase):
 
 
 class CompareLayoutCliTest(unittest.TestCase):
+    def test_rect_geometry_makes_json_audit_fail(self) -> None:
+        traces = [
+            trace_document(rect_op(10.0, 20.0, 110.0, 30.0)),
+            trace_document(rect_op(18.0, 20.0, 118.0, 30.0)),
+        ]
+        stdout = io.StringIO()
+        with (
+            patch.object(compare_layout, "run_mutool", side_effect=traces),
+            patch.object(
+                sys,
+                "argv",
+                ["compare_layout.py", "gt.pdf", "output.pdf", "--json", "--audit"],
+            ),
+            patch("sys.stdout", stdout),
+        ):
+            result = compare_layout.main()
+
+        report = json.loads(stdout.getvalue())
+        self.assertEqual(result, 1)
+        self.assertEqual(report["pages"][0]["rects"]["geometry_mismatch_count"], 1)
+
     def test_audit_exits_nonzero_for_issue_1475_visible_fill_occlusion(self) -> None:
         rose_rule = rect_op(
             50.0,

--- a/scripts/tests/test_generate_layout_baselines.py
+++ b/scripts/tests/test_generate_layout_baselines.py
@@ -182,6 +182,7 @@ class DocumentTests(unittest.TestCase):
                     "instances": {"large_shift_count": 1},
                     "visibility": {"mismatch_count": 2},
                     "visible_fills": {"mismatch_count": 3},
+                    "rects": {"geometry_mismatch_count": 4},
                 }
             ],
         }
@@ -201,6 +202,7 @@ class DocumentTests(unittest.TestCase):
         self.assertEqual(summary["large_shifts"], 1)
         self.assertEqual(summary["visibility_mismatches"], 2)
         self.assertEqual(summary["visible_fill_mismatches"], 3)
+        self.assertEqual(summary["rect_geometry_mismatches"], 4)
 
     def test_serialisation_is_deterministic(self) -> None:
         record = {

--- a/scripts/tests/test_probe_harness.py
+++ b/scripts/tests/test_probe_harness.py
@@ -78,6 +78,7 @@ def page_vector(
     worst_pitch: float = 0.0,
     worst_width: float = 0.0,
     rects: tuple[int, int] = (3, 3),
+    rect_geometry: int = 0,
 ) -> dict:
     """A differ page vector with the same shape compare_layout.py --json emits."""
     return {
@@ -115,6 +116,7 @@ def page_vector(
             "out_count": rects[1],
             "matched": min(rects),
             "mean_center_delta": 0.0,
+            "geometry_mismatch_count": rect_geometry,
         },
         "noise_floor": 0.12,
     }
@@ -691,6 +693,23 @@ class ControlGateTest(unittest.TestCase):
             with self.assertRaisesRegex(probe_harness.ProbeError, "visibility"):
                 probe_harness.verify_control(tmp / "base.pdf", tmp / "control.pdf", runner=runner)
 
+    def test_a_control_rect_geometry_mismatch_aborts_the_run(self):
+        with TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "base.pdf").write_bytes(b"%PDF a")
+            (tmp / "control.pdf").write_bytes(b"%PDF b")
+
+            def runner(argv):
+                return completed(
+                    argv,
+                    stdout=json.dumps(differ_report(page_vector(rect_geometry=1))),
+                )
+
+            with self.assertRaisesRegex(probe_harness.ProbeError, "rectangle geometry"):
+                probe_harness.verify_control(
+                    tmp / "base.pdf", tmp / "control.pdf", runner=runner
+                )
+
 
 class RowTest(unittest.TestCase):
     def test_multi_page_reports_sum_counts_and_keep_worst_magnitudes(self):
@@ -713,6 +732,7 @@ class RowTest(unittest.TestCase):
                 worst_dy=1.4,
                 worst_pitch=0.1,
                 rects=(4, 5),
+                rect_geometry=2,
             ),
         )
         row = probe_harness.variant_row("500", 1, report)
@@ -729,6 +749,7 @@ class RowTest(unittest.TestCase):
         self.assertAlmostEqual(row["worst_dy"], 1.4)
         self.assertAlmostEqual(row["worst_pitch"], 0.3)
         self.assertEqual(row["rects"], "7/8")
+        self.assertEqual(row["rect_geometry"], 2)
 
     def test_mean_baseline_uses_compared_fragments_for_split_join_groups(self):
         report = differ_report(

--- a/scripts/tests/test_spatial_match.py
+++ b/scripts/tests/test_spatial_match.py
@@ -26,6 +26,12 @@ class MinimumCostPairsTest(unittest.TestCase):
 
         self.assertEqual(minimum_cost_pairs(references, candidates), [(0, 0), (2, 1)])
 
+    def test_all_vector_dimensions_contribute_to_the_assignment(self) -> None:
+        references = [(0.0, 0.0, 100.0, 10.0), (0.0, 0.0, 40.0, 10.0)]
+        candidates = [(0.0, 0.0, 42.0, 10.0), (0.0, 0.0, 98.0, 10.0)]
+
+        self.assertEqual(minimum_cost_pairs(references, candidates), [(0, 1), (1, 0)])
+
     def test_empty_side_has_no_pairs(self) -> None:
         self.assertEqual(minimum_cost_pairs([], [(1.0, 1.0)]), [])
         self.assertEqual(minimum_cost_pairs([(1.0, 1.0)], []), [])

--- a/tests/golden_mocks/business/README.md
+++ b/tests/golden_mocks/business/README.md
@@ -137,9 +137,10 @@ The `Business Golden Contract` CI job runs both checks on every push and pull re
 `baselines/layout.json` stores the `compare_layout.py` deviation vector for
 every page of every case (matched/missing/extra lines, baseline dy statistics,
 line-width drift, pitch deltas, wrap and reflow counts, large instance shifts,
-painted-text visibility mismatches, visible-fill occlusions, and the rect
-census), measured against the native GT with the per-format noise floor
-(0.12pt Word/PowerPoint, 0.5pt Excel). Regenerate it with a local build:
+painted-text visibility mismatches, visible-fill occlusions, and path census
+plus axis-aligned rectangle/line geometry deltas), measured against the native
+GT with the per-format noise floor (0.12pt Word/PowerPoint, 0.5pt Excel).
+Regenerate it with a local build:
 
 ```sh
 cargo build -p office2pdf-cli


### PR DESCRIPTION
## Summary

- match axis-aligned fill rectangles and stroke rectangles/lines by center and extent instead of greedy center-only pairing
- report mean/worst x, y, width, height, and edge deltas with raw operation indices and representative samples
- merge touching same-paint operation splits while keeping raw path counts informational, and exclude arbitrary curve/glyph path bounds from rectangle geometry findings
- make material rectangle geometry participate in `--audit`, baseline regression checks, probe reports, and the visual-PR disposition contract

## Why

Center-only matching and a count-only rectangle report let size changes pass silently. The page 9 title rule tracked by #1418 was 11.565pt shorter and 3.575pt higher, but the layout audit did not report it.

## Verification

- `python3 -m unittest discover -s scripts/tests` (358 tests)
- focused affected-consumer suite after final wording update (231 tests)
- `python3 -m py_compile scripts/compare_layout.py scripts/spatial_match.py scripts/check_visual_pr.py scripts/check_layout_baselines.py scripts/generate_layout_baselines.py scripts/probe_harness.py`
- `cargo fmt --all -- --check`
- `git diff --check`
- mandatory documentation freshness audit: PASS
- real issue-attachment page 9 with `--json --audit --fine-shift 0.5`: 6/6 comparable primitives matched; exactly 1 rectangle-geometry finding, the #1418 title rule (`dy -3.575pt`, `dwidth -11.565pt`, right edge `-11.533pt`)

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Harness, report-schema, and audit-contract changes only; converter/rendering code and PDF output are unchanged.

Fixes #1419
Related: #1410
Related: #1418