### PR TITLE
fix(build): unblock tinyvec 1.13.0 resolution

### DIFF
--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -36,6 +36,11 @@ zip = { version = "0.6", default-features = false, features = ["deflate"] }
 quick-xml = "0.38"
 umya-spreadsheet = "2"
 unicode-normalization = "0.1"
+# office2pdf is std-only, but transitive users currently select tinyvec's
+# broken 1.13.0 `alloc`-without-`std` path. Keep `std` unified until a patched
+# tinyvec release fixes Lokathor/tinyvec#225, then remove this workaround
+# (issue #1524).
+tinyvec = { version = "1", default-features = false, features = ["std"] }
 image = "0.25"
 tracing = "0.1"
 wasm-bindgen = { version = "0.2", optional = true }


### PR DESCRIPTION
## Summary

- explicitly enable `tinyvec`'s `std` feature in the published `office2pdf` manifest
- use Cargo feature unification to avoid tinyvec 1.13.0's broken `no_std + alloc` code path
- keep the workaround bounded and documented for removal after a patched upstream release

`tinyvec` is already in the dependency graph, and office2pdf is std-only, so this changes feature selection without adding a new compiled package. The permanent upstream fix is Lokathor/tinyvec#226 for Lokathor/tinyvec#225; that PR is independently validated but has not been merged or released yet.

## Related issue

Fixes #1524

## Failure reproduced first

A fresh main worktree with no `Cargo.lock` failed as expected:

```console
$ CARGO_TARGET_DIR=/private/tmp/office2pdf-1524-before-target cargo check --workspace
error: cannot find macro `vec` in this scope
  --> tinyvec-1.13.0/src/tinyvec.rs:710:21
error: could not compile `tinyvec` (lib) due to 1 previous error
```

## Testing

- `CARGO_TARGET_DIR=/private/tmp/office2pdf-1524-before-target cargo check --workspace`
- `CARGO_TARGET_DIR=/private/tmp/office2pdf-1524-before-target cargo test --workspace`
- `CARGO_TARGET_DIR=/private/tmp/office2pdf-1524-before-target cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/private/tmp/office2pdf-tinyvec-std-wasm-target cargo check --target wasm32-unknown-unknown -p office2pdf`
- `CARGO_TARGET_DIR=/private/tmp/office2pdf-tinyvec-std-wasm-target cargo check --target wasm32-unknown-unknown -p office2pdf --features wasm`
- `CARGO_TARGET_DIR=/private/tmp/office2pdf-tinyvec-std-wasm-target cargo check --target wasm32-unknown-unknown -p office2pdf --features wasm-cjk-font`
- `CARGO_TARGET_DIR=/private/tmp/office2pdf-1524-publish-target cargo publish --dry-run -p office2pdf --allow-dirty`
- packaged normalized manifest contains `tinyvec = "1"`, `features = ["std"]`, and `default-features = false`
- mandatory documentation freshness audit: `PASS:`

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: This only changes Cargo feature selection for an existing transitive dependency; parser, IR, rendering, and fixtures are unchanged.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining visual deviations each reference an open issue (none; no rendered change)
