### PR TITLE
fix(ci): parse scientific AE metrics

### DIFF
--- a/scripts/check_visual_pr.py
+++ b/scripts/check_visual_pr.py
@@ -534,11 +534,14 @@ def decoded_pixel_delta(before: Path, after: Path) -> int:
         text=True,
     )
     metric_output = result.stderr.strip() or result.stdout.strip()
-    metric_match = re.search(r"(?:^|\s)(\d+)(?:\s|$)", metric_output)
+    metric_match = re.search(
+        r"(?:^|\s)(\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)(?:\s|$)",
+        metric_output,
+    )
     if result.returncode not in {0, 1} or not metric_match:
         detail = metric_output or f"exit status {result.returncode}"
         raise RuntimeError(f"ImageMagick could not compare the evidence: {detail}")
-    return int(metric_match.group(1))
+    return int(float(metric_match.group(1)))
 
 
 def validate_reference_exporter_differences(

--- a/scripts/tests/test_check_visual_pr.py
+++ b/scripts/tests/test_check_visual_pr.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from scripts.check_visual_pr import (
     AUDIT_ROWS,
     INSPECTION_ITEMS,
+    decoded_pixel_delta,
     read_jpeg_info,
     validate_evidence,
     validate_layout_audit,
@@ -466,6 +467,19 @@ class PullRequestBodyTests(unittest.TestCase):
 
 
 class ReferenceExporterDifferenceTests(unittest.TestCase):
+    def test_decoded_pixel_delta_accepts_scientific_notation(self):
+        with (
+            patch("scripts.check_visual_pr.shutil.which", return_value="/usr/bin/magick"),
+            patch("scripts.check_visual_pr.subprocess.run") as run,
+        ):
+            run.return_value.returncode = 1
+            run.return_value.stderr = "6.83993e+06 (0.759992)"
+            run.return_value.stdout = ""
+
+            delta = decoded_pixel_delta(Path("gt.jpg"), Path("native.jpg"))
+
+        self.assertEqual(delta, 6_839_930)
+
     def prepare_evidence(self, root: Path) -> tuple[str, dict[str, object]]:
         issue_dir = root / "assets/bugfixes/issue-186"
         issue_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary

- accept ImageMagick AE metrics written in decimal or scientific notation
- preserve the existing success/error status checks and zero-versus-nonzero evidence gate
- add a focused regression for the real `6.83993e+06 (0.759992)` output that blocked #1520

## Related issue

Fixes #1526. Unblocks #1520.

## Testing

- red: `python3 -m unittest scripts.tests.test_check_visual_pr.ReferenceExporterDifferenceTests.test_decoded_pixel_delta_accepts_scientific_notation` — reproduced `ImageMagick could not compare the evidence`
- green: the same focused command — 1 passed
- `python3 -m unittest scripts.tests.test_check_visual_pr` — 78 passed
- `python3 -m py_compile scripts/check_visual_pr.py scripts/tests/test_check_visual_pr.py`
- working-tree validation against #1520 native evidence — `Visual pull request contract is complete.` for a 6.84-million-pixel GT/native difference
- `git diff --check`
- mandatory pre-commit documentation freshness audit: `PASS`

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: This changes only CI evidence-metric parsing and its unit test; conversion and rendering code are untouched.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining converter or harness deviations each reference an open issue