### PR TITLE
chore: publish 0.6.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "office2pdf"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "comemo",
  "criterion",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "office2pdf-cli"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ No LibreOffice, no Chromium, no Docker — just a single binary powered by [Typs
 
 ```toml
 [dependencies]
-office2pdf = "0.6.7"
+office2pdf = "0.6.8"
 ```
 
 ### CLI
@@ -51,7 +51,7 @@ Every [GitHub release](https://github.com/developer0hye/office2pdf/releases) shi
 On Linux and macOS, download, extract, and place the binary on your `PATH`:
 
 ```sh
-VERSION=v0.6.7
+VERSION=v0.6.8
 TARGET=x86_64-unknown-linux-gnu  # pick your platform's target from the table above
 curl -L "https://github.com/developer0hye/office2pdf/releases/download/${VERSION}/office2pdf-${VERSION}-${TARGET}.tar.gz" | tar xz
 sudo install "office2pdf-${VERSION}-${TARGET}/office2pdf" /usr/local/bin/

--- a/crates/office2pdf-cli/Cargo.toml
+++ b/crates/office2pdf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf-cli"
-version = "0.6.7"
+version = "0.6.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ path = "src/main.rs"
 server = ["tiny_http"]
 
 [dependencies]
-office2pdf = { version = "0.6.7", path = "../office2pdf", features = ["pdf-ops"] }
+office2pdf = { version = "0.6.8", path = "../office2pdf", features = ["pdf-ops"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 rayon = "1"

--- a/crates/office2pdf/Cargo.toml
+++ b/crates/office2pdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "office2pdf"
-version = "0.6.7"
+version = "0.6.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- bump `office2pdf` and `office2pdf-cli` from 0.6.7 to 0.6.8
- align the CLI's `office2pdf` dependency requirement and both workspace entries in `Cargo.lock`
- update the README library and binary-install examples to v0.6.8

## Related issue

Release v0.6.8.

## Testing

- `CARGO_TARGET_DIR=/Users/yhkwon/Documents/office2pdf/target cargo metadata --offline --locked --no-deps --format-version 1 | jq ...` — `office2pdf 0.6.8`, `office2pdf-cli 0.6.8`, dependency `^0.6.8`
- `CARGO_TARGET_DIR=/Users/yhkwon/Documents/office2pdf/target cargo test --offline --locked --workspace` — passed: 2,834 core tests, 188 DOCX fixtures, 134 PPTX fixtures, 207 XLSX fixtures, CLI/package roundtrips, and doctests; only repository-declared ignores remain
- `git diff --check`
- proposed version preflight: GitHub Release, remote tag, `office2pdf` crate, and `office2pdf-cli` crate all confirm 0.6.8 is unused
- mandatory pre-commit documentation freshness audit: `PASS`

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: this PR changes package/release metadata and README install examples only; conversion and rendering code are unchanged.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining converter or harness deviations each reference an open issue
