### PR TITLE
fix(tooling): constrain ambiguous rectangle pairing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,9 @@ jobs:
       - name: Test visual PR validator
         run: python3 -m unittest discover -s scripts/tests -p 'test_check_visual_pr.py'
       - name: Test layout differ
-        run: python3 -m unittest discover -s scripts/tests -p 'test_compare_layout.py'
+        run: |
+          python3 -m unittest discover -s scripts/tests -p 'test_compare_layout.py'
+          python3 -m unittest discover -s scripts/tests -p 'test_spatial_match.py'
       - name: Test render comparison
         run: python3 -m unittest discover -s scripts/tests -p 'test_compare_render.py'
       - name: Test text-layer census

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -104,6 +104,13 @@ SAFE_TOPOLOGY_GAP_PT = 24.0
 # shape elsewhere on the page. Equal-cardinality groups remain fully paired so
 # a large translation is reported as geometry instead of disappearing.
 RECT_AMBIGUOUS_MATCH_RADIUS_PT = 24.0
+# When one side contains extra paint operations, a corresponding area may be
+# split slightly differently, but a several-times thinner/wider primitive is
+# not defensibly the same rectangle. Keep that operation unmatched instead of
+# manufacturing a large geometry delta.
+RECT_AMBIGUOUS_MAX_EXTENT_RATIO = 1.5
+RECT_RULE_MAX_THICKNESS_PT = 2.0
+RECT_RULE_MIN_LENGTH_PT = 4.0
 RECT_SAMPLE_LIMIT = 5
 OPAQUE_ALPHA = 0.98
 INVISIBLE_ALPHA = 0.02
@@ -1327,6 +1334,106 @@ def rect_feature(rect: Rect) -> tuple[float, float, float, float]:
     return (rect.center[0], rect.center[1], rect.width / 2, rect.height / 2)
 
 
+def rect_match_topology(rect: Rect) -> str:
+    """Separate thin boundary operations from painted areas."""
+    if rect.geometry_kind != "rectangle":
+        return rect.geometry_kind
+    if (
+        rect.height <= RECT_RULE_MAX_THICKNESS_PT
+        and rect.width >= RECT_RULE_MIN_LENGTH_PT
+    ):
+        return "horizontal-rule"
+    if (
+        rect.width <= RECT_RULE_MAX_THICKNESS_PT
+        and rect.height >= RECT_RULE_MIN_LENGTH_PT
+    ):
+        return "vertical-rule"
+    return "area"
+
+
+def same_rect_match_bucket(first: Rect, second: Rect) -> bool:
+    return same_rect_paint(first, second) and rect_match_topology(
+        first
+    ) == rect_match_topology(second)
+
+
+def ambiguous_rect_pair_allowed(reference: Rect, candidate: Rect) -> bool:
+    center_delta = max(
+        abs(candidate.center[0] - reference.center[0]),
+        abs(candidate.center[1] - reference.center[1]),
+    )
+    if center_delta > RECT_AMBIGUOUS_MATCH_RADIUS_PT:
+        return False
+    if min(reference.width, reference.height, candidate.width, candidate.height) <= 0:
+        return False
+    extent_ratio = max(
+        reference.width / candidate.width,
+        candidate.width / reference.width,
+        reference.height / candidate.height,
+        candidate.height / reference.height,
+    )
+    return extent_ratio <= RECT_AMBIGUOUS_MAX_EXTENT_RATIO
+
+
+def match_rect_groups(
+    references: list[CanonicalRect], candidates: list[CanonicalRect]
+) -> list[tuple[CanonicalRect, CanonicalRect]]:
+    """Match rectangles without forcing unequal groups across paint/topology."""
+    if len(references) == len(candidates):
+        return [
+            (references[reference_index], candidates[candidate_index])
+            for reference_index, candidate_index in minimum_cost_pairs(
+                [rect_feature(group.rect) for group in references],
+                [rect_feature(group.rect) for group in candidates],
+            )
+        ]
+
+    matches: list[tuple[CanonicalRect, CanonicalRect]] = []
+    remaining_references = list(references)
+    remaining_candidates = list(candidates)
+    while remaining_references:
+        seed = remaining_references[0]
+        reference_bucket = [
+            group
+            for group in remaining_references
+            if same_rect_match_bucket(seed.rect, group.rect)
+        ]
+        candidate_bucket = [
+            group
+            for group in remaining_candidates
+            if same_rect_match_bucket(seed.rect, group.rect)
+        ]
+        remaining_references = [
+            group
+            for group in remaining_references
+            if not same_rect_match_bucket(seed.rect, group.rect)
+        ]
+        remaining_candidates = [
+            group
+            for group in remaining_candidates
+            if not same_rect_match_bucket(seed.rect, group.rect)
+        ]
+        if not candidate_bucket:
+            continue
+
+        allowed_pairs = [
+            [
+                ambiguous_rect_pair_allowed(reference.rect, candidate.rect)
+                for candidate in candidate_bucket
+            ]
+            for reference in reference_bucket
+        ]
+        matches.extend(
+            (reference_bucket[reference_index], candidate_bucket[candidate_index])
+            for reference_index, candidate_index in minimum_cost_pairs(
+                [rect_feature(group.rect) for group in reference_bucket],
+                [rect_feature(group.rect) for group in candidate_bucket],
+                allowed_pairs=allowed_pairs,
+            )
+        )
+    return matches
+
+
 def rect_sample(gt_group: CanonicalRect, out_group: CanonicalRect) -> dict:
     gt_rect = gt_group.rect
     out_rect = out_group.rect
@@ -1496,23 +1603,7 @@ def diff_page(
             for group in canonical_out_rects
             if (group.rect.kind, group.rect.geometry_kind) == (kind, geometry_kind)
         ]
-        has_equal_cardinality = len(references) == len(candidates)
-        for reference_index, candidate_index in minimum_cost_pairs(
-            [rect_feature(group.rect) for group in references],
-            [rect_feature(group.rect) for group in candidates],
-        ):
-            reference = references[reference_index]
-            candidate = candidates[candidate_index]
-            center_delta = max(
-                abs(candidate.rect.center[0] - reference.rect.center[0]),
-                abs(candidate.rect.center[1] - reference.rect.center[1]),
-            )
-            if (
-                not has_equal_cardinality
-                and center_delta > RECT_AMBIGUOUS_MATCH_RADIUS_PT
-            ):
-                continue
-            rect_matches.append((reference, candidate))
+        rect_matches.extend(match_rect_groups(references, candidates))
 
     rect_samples = [
         rect_sample(reference, candidate) for reference, candidate in rect_matches

--- a/scripts/spatial_match.py
+++ b/scripts/spatial_match.py
@@ -15,25 +15,86 @@ Vector = Sequence[float]
 
 
 def minimum_cost_pairs(
-    references: Sequence[Vector], candidates: Sequence[Vector]
+    references: Sequence[Vector],
+    candidates: Sequence[Vector],
+    *,
+    allowed_pairs: Sequence[Sequence[bool]] | None = None,
 ) -> list[tuple[int, int]]:
     """Return a minimum-total-distance one-to-one assignment.
 
     The Hungarian algorithm handles rectangular groups and remains cheap for
     pages containing many identical table values. Returned indexes always
-    address ``references`` first and ``candidates`` second.
+    address ``references`` first and ``candidates`` second. When
+    ``allowed_pairs`` is supplied, the result first maximises the number of
+    allowed matches, then minimises their total distance; either side may keep
+    unmatched items.
     """
     if not references or not candidates:
         return []
+
+    if allowed_pairs is not None:
+        if len(allowed_pairs) != len(references) or any(
+            len(row) != len(candidates) for row in allowed_pairs
+        ):
+            raise ValueError("allowed_pairs must match the reference/candidate matrix")
+        real_costs = [
+            [math.dist(reference, candidate) for candidate in candidates]
+            for reference in references
+        ]
+        feasible_costs = [
+            real_costs[reference_index][candidate_index]
+            for reference_index, row in enumerate(allowed_pairs)
+            for candidate_index, allowed in enumerate(row)
+            if allowed
+        ]
+        if not feasible_costs:
+            return []
+
+        # One private dummy column per reference lets the assignment leave any
+        # reference unmatched. A dummy costs more than every possible change
+        # across a maximum-cardinality real assignment, so cardinality wins
+        # first; the Euclidean costs break ties between equally large matches.
+        maximum_pair_count = min(len(references), len(candidates))
+        unmatched_cost = (max(feasible_costs) + 1.0) * (maximum_pair_count + 1)
+        forbidden_cost = unmatched_cost * (len(references) + 1)
+        costs = [
+            [
+                real_costs[reference_index][candidate_index]
+                if allowed
+                else forbidden_cost
+                for candidate_index, allowed in enumerate(row)
+            ]
+            + [unmatched_cost] * len(references)
+            for reference_index, row in enumerate(allowed_pairs)
+        ]
+        pairs = _minimum_cost_pairs_from_costs(costs)
+        return [
+            (reference_index, candidate_index)
+            for reference_index, candidate_index in pairs
+            if candidate_index < len(candidates)
+            and allowed_pairs[reference_index][candidate_index]
+        ]
 
     swapped = len(references) > len(candidates)
     rows = candidates if swapped else references
     columns = references if swapped else candidates
     costs = [[math.dist(row, column) for column in columns] for row in rows]
+    pairs = _minimum_cost_pairs_from_costs(costs)
+    if swapped:
+        pairs = [(column_index, row_index) for row_index, column_index in pairs]
+    return sorted(pairs)
+
+
+def _minimum_cost_pairs_from_costs(
+    costs: Sequence[Sequence[float]],
+) -> list[tuple[int, int]]:
+    """Run rectangular Hungarian assignment for a rows-by-columns cost matrix."""
 
     # Rectangular Hungarian algorithm, with rows <= columns.
-    row_count = len(rows)
-    column_count = len(columns)
+    row_count = len(costs)
+    column_count = len(costs[0])
+    if row_count > column_count:
+        raise ValueError("Hungarian cost matrix must have rows <= columns")
     u = [0.0] * (row_count + 1)
     v = [0.0] * (column_count + 1)
     column_to_row = [0] * (column_count + 1)
@@ -84,6 +145,4 @@ def minimum_cost_pairs(
         for column_index, row_index in enumerate(column_to_row[1:], start=1)
         if row_index
     ]
-    if swapped:
-        pairs = [(column_index, row_index) for row_index, column_index in pairs]
     return sorted(pairs)

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -858,6 +858,54 @@ class MatchAndDiffTest(unittest.TestCase):
         self.assertEqual((rects["unmatched_gt"], rects["unmatched_out"]), (2, 1))
         self.assertEqual(rects["geometry_mismatch_count"], 0)
 
+    def test_unequal_rect_groups_do_not_pair_area_fill_with_nearby_rule(self) -> None:
+        gt = "\n".join(
+            [
+                rect_op(0.0, 0.0, 200.0, 25.0, color=".9 .9 .9"),
+                rect_op(300.0, 50.0, 366.0, 75.0, color=".2 .2 .2"),
+            ]
+        )
+        out = "\n".join(
+            [
+                # Its centre is within the ambiguity radius of the first GT
+                # fill, but this thin band is not the same painted area.
+                rect_op(65.0, 0.5, 135.0, 1.75, color=".9 .9 .9"),
+                rect_op(300.1, 50.1, 366.1, 75.1, color=".2 .2 .2"),
+                # Matching geometry alone cannot override different paint.
+                rect_op(0.0, 0.0, 200.0, 25.0, color=".4 .4 .4"),
+                rect_op(500.0, 500.0, 600.0, 510.0, color=".9 .9 .9"),
+            ]
+        )
+
+        rects = self.diff(gt, out, fine_shift=0.5)["rects"]
+
+        self.assertEqual(rects["matched"], 1)
+        self.assertEqual((rects["unmatched_gt"], rects["unmatched_out"]), (1, 3))
+        self.assertEqual(rects["geometry_mismatch_count"], 0)
+
+    def test_unequal_rect_groups_reject_incompatible_area_extents(self) -> None:
+        gt = "\n".join(
+            [
+                rect_op(0.0, 0.0, 200.0, 25.0, color=".9 .9 .9"),
+                rect_op(300.0, 50.0, 366.0, 75.0, color=".2 .2 .2"),
+            ]
+        )
+        out = "\n".join(
+            [
+                # The centres are close, but doubling the height means this is
+                # not defensibly the same painted area.
+                rect_op(5.0, -12.5, 195.0, 37.5, color=".9 .9 .9"),
+                rect_op(300.1, 50.1, 366.1, 75.1, color=".2 .2 .2"),
+                rect_op(500.0, 500.0, 600.0, 510.0, color=".9 .9 .9"),
+            ]
+        )
+
+        rects = self.diff(gt, out, fine_shift=0.5)["rects"]
+
+        self.assertEqual(rects["matched"], 1)
+        self.assertEqual((rects["unmatched_gt"], rects["unmatched_out"]), (1, 2))
+        self.assertEqual(rects["geometry_mismatch_count"], 0)
+
     def test_non_rectangular_path_bounds_do_not_become_rect_geometry(self) -> None:
         def triangle(x0: float, x1: float) -> str:
             midpoint = (x0 + x1) / 2

--- a/scripts/tests/test_spatial_match.py
+++ b/scripts/tests/test_spatial_match.py
@@ -36,6 +36,32 @@ class MinimumCostPairsTest(unittest.TestCase):
         self.assertEqual(minimum_cost_pairs([], [(1.0, 1.0)]), [])
         self.assertEqual(minimum_cost_pairs([(1.0, 1.0)], []), [])
 
+    def test_allowed_pairs_leave_incompatible_items_unmatched(self) -> None:
+        references = [(0.0, 0.0), (10.0, 0.0)]
+        candidates = [(1.0, 0.0), (9.0, 0.0)]
+
+        self.assertEqual(
+            minimum_cost_pairs(
+                references,
+                candidates,
+                allowed_pairs=[[False, False], [False, True]],
+            ),
+            [(1, 1)],
+        )
+
+    def test_allowed_pairs_maximise_cardinality_before_distance(self) -> None:
+        references = [(0.0, 0.0), (100.0, 0.0)]
+        candidates = [(1.0, 0.0), (2.0, 0.0)]
+
+        self.assertEqual(
+            minimum_cost_pairs(
+                references,
+                candidates,
+                allowed_pairs=[[True, True], [True, False]],
+            ),
+            [(0, 1), (1, 0)],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- constrain rectangle matching on unequal primitive groups by paint, topology, centre distance, and compatible extents
- let the Hungarian assignment leave incompatible items unmatched while preserving maximum-cardinality, minimum-distance matching
- run the spatial matcher unit suite in the visual-contract CI job
- retain the 12 defensible chart/table pairs in the #1210 page-2 reproduction while removing 5 unrelated forced pairs

## Related issue

Fixes #1534

## Testing

- `python3 -m unittest discover -s scripts/tests` (384 passed)
- exact Visual PR Contract Python suites and `bash -n scripts/issue_loop.sh`
- `python3 -m py_compile scripts/compare_layout.py scripts/spatial_match.py scripts/tests/test_compare_layout.py scripts/tests/test_spatial_match.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`
- compared the #1210 two-page native/output PDFs with `--noise-floor 0.5 --fine-shift 0.5 --json`: page 1 remains unchanged at 2 matched geometry findings tracked by #1533; page 2 changes from 17 matches/17 findings to 12 defensible matches/12 findings, with the 5 unrelated pairs moved to the unmatched census
- checked constrained matching against a brute-force optimum for 3,200 deterministic random matrices

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: this changes only the trace-analysis matcher and its CI coverage; converter/parser/rendering code and generated PDFs are unchanged.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining converter or harness deviations each reference an open issue
