### PR TITLE
fix(layout): ignore sub-epsilon coverage slivers

### DIFF
--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -1355,11 +1355,14 @@ def rect_component_covers_bbox(
     allowed_missing_area = allowed_edge * allowed_edge
     missing_area = 0.0
     for x0, x1 in zip(xs, xs[1:]):
-        if x1 <= x0:
+        # Trace coordinates that represent the same painted edge can differ by
+        # a few ulps. Do not turn that serialization noise into a tall, empty
+        # coverage cell merely because the other axis is material.
+        if x1 - x0 <= RECT_COVERAGE_EPSILON_PT:
             continue
         x_midpoint = (x0 + x1) / 2
         for y0, y1 in zip(ys, ys[1:]):
-            if y1 <= y0:
+            if y1 - y0 <= RECT_COVERAGE_EPSILON_PT:
                 continue
             y_midpoint = (y0 + y1) / 2
             if any(

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -847,6 +847,36 @@ class MatchAndDiffTest(unittest.TestCase):
         self.assertEqual(rects["matched"], 1)
         self.assertEqual(rects["geometry_mismatch_count"], 0)
 
+    def test_boundary_bleed_ignores_sub_epsilon_coordinate_sliver(self) -> None:
+        gt = rect_op(341.94, 453.46, 408.36, 478.88, color=".85 .71 .73")
+        out = "\n".join(
+            [
+                rect_op(
+                    341.94, 453.46, 407.54, 478.06, color=".85 .71 .73"
+                ),
+                rect_op(
+                    341.94, 477.855, 408.36, 478.88, color=".85 .71 .73"
+                ),
+                rect_op(
+                    407.335,
+                    453.46,
+                    408.35999999999996,
+                    478.88,
+                    color=".85 .71 .73",
+                ),
+            ]
+        )
+
+        vector = self.diff(gt, out, noise_floor=0.5, fine_shift=0.5)
+        rects = vector["rects"]
+
+        self.assertEqual(
+            (rects["canonical_gt_count"], rects["canonical_out_count"]),
+            (1, 1),
+        )
+        self.assertEqual(rects["matched"], 1)
+        self.assertEqual(rects["geometry_mismatch_count"], 0)
+
     def test_boundary_bleed_accepts_one_noise_floor_corner_gap(self) -> None:
         gt = rect_op(50.0, 144.0, 474.0, 418.0, color=".97 .94 .94")
         out = "\n".join(


### PR DESCRIPTION
## Summary

- ignore coverage-grid cells whose width or height is already beneath the existing 0.01pt coordinate epsilon
- preserve strict rejection of material L-shaped and corner gaps
- pin the exact floating-point endpoints observed while validating the fitted A3 fill geometry

## Related issue

Fixes #1540

## Testing

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_compare_layout.MatchAndDiffTest.test_boundary_bleed_ignores_sub_epsilon_coordinate_sliver`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (389 passed)
- documentation freshness audit: PASS

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: This changes only how the read-only layout audit canonicalizes sub-epsilon trace-coordinate slivers; converter output is untouched.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining converter or harness deviations each reference an open issue