### PR TITLE
fix(audit): retain line matches across unequal counts

### DIFF
--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -1492,15 +1492,21 @@ def ambiguous_rect_pair_allowed(reference: Rect, candidate: Rect) -> bool:
     )
     if center_delta > RECT_AMBIGUOUS_MATCH_RADIUS_PT:
         return False
-    if min(reference.width, reference.height, candidate.width, candidate.height) <= 0:
-        return False
-    extent_ratio = max(
-        reference.width / candidate.width,
-        candidate.width / reference.width,
-        reference.height / candidate.height,
-        candidate.height / reference.height,
-    )
-    return extent_ratio <= RECT_AMBIGUOUS_MAX_EXTENT_RATIO
+    extent_ratios: list[float] = []
+    for reference_extent, candidate_extent in (
+        (reference.width, candidate.width),
+        (reference.height, candidate.height),
+    ):
+        # Stroked horizontal/vertical paths have one zero bounding extent.
+        # Compare their length while keeping perpendicular lines incompatible.
+        if reference_extent == candidate_extent == 0:
+            continue
+        if min(reference_extent, candidate_extent) <= 0:
+            return False
+        extent_ratios.append(
+            max(reference_extent / candidate_extent, candidate_extent / reference_extent)
+        )
+    return bool(extent_ratios) and max(extent_ratios) <= RECT_AMBIGUOUS_MAX_EXTENT_RATIO
 
 
 def match_rect_groups(

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -965,6 +965,51 @@ class MatchAndDiffTest(unittest.TestCase):
         self.assertEqual((rects["unmatched_gt"], rects["unmatched_out"]), (2, 1))
         self.assertEqual(rects["geometry_mismatch_count"], 0)
 
+    def test_unequal_rule_counts_keep_retained_horizontal_and_vertical_lines(self) -> None:
+        # Removing chart gridlines must not unmatch unchanged table rules
+        # merely because their stroked path bounds have a zero extent (#1558).
+        for vertical in (False, True):
+            for reverse in (False, True):
+                for shift in (0.0, 1.0):
+                    with self.subTest(vertical=vertical, reverse=reverse, shift=shift):
+                        def rule(position: float) -> str:
+                            if vertical:
+                                return line_op(position, 20.0, position, 120.0)
+                            return line_op(20.0, position, 120.0, position)
+
+                        gt = "\n".join([rule(40.0), rule(80.0), rule(160.0)])
+                        out = "\n".join([rule(40.0 + shift), rule(160.0 + shift)])
+                        if reverse:
+                            gt, out = out, gt
+                        rects = self.diff(gt, out, fine_shift=0.5)["rects"]
+
+                        self.assertEqual(rects["matched"], 2)
+                        self.assertEqual(
+                            (rects["unmatched_gt"], rects["unmatched_out"]),
+                            (0, 1) if reverse else (1, 0),
+                        )
+                        self.assertEqual(
+                            rects["geometry_mismatch_count"], 2 if shift else 0
+                        )
+
+    def test_unequal_rule_counts_reject_unrelated_line_extents_and_paint(self) -> None:
+        retained = line_op(300.0, 300.0, 400.0, 300.0)
+        gt = "\n".join([line_op(20.0, 40.0, 120.0, 40.0), retained])
+        for unrelated in (
+            line_op(45.0, 40.0, 95.0, 40.0),  # Same centre, half the length.
+            line_op(70.0, 0.0, 70.0, 100.0),  # Perpendicular line.
+            line_op(20.0, 100.0, 120.0, 100.0),  # Outside the match radius.
+            line_op(20.0, 40.0, 120.0, 40.0, color="1 0 0"),
+        ):
+            with self.subTest(unrelated=unrelated):
+                out = "\n".join([unrelated, retained, line_op(500, 500, 600, 500)])
+                rects = self.diff(gt, out, fine_shift=0.5)["rects"]
+                self.assertEqual(rects["matched"], 1)
+                self.assertEqual(
+                    (rects["unmatched_gt"], rects["unmatched_out"]), (1, 2)
+                )
+                self.assertEqual(rects["geometry_mismatch_count"], 0)
+
     def test_unequal_rect_groups_do_not_pair_area_fill_with_nearby_rule(self) -> None:
         gt = "\n".join(
             [


### PR DESCRIPTION
## Summary

Keep unchanged horizontal and vertical rules matched when two PDF traces contain different numbers of primitives. The unequal-count matcher rejected every zero-width or zero-height path, so removing chart gridlines made retained table rules appear unmatched.

Allow a shared zero extent and compare the remaining length. Preserve the distance and extent-ratio limits, paint buckets, and rejection of perpendicular lines and point-like geometry. Shifted retained rules still produce geometry findings.

## Related issue

Related: #1558

## Testing

- Red: the new trace regressions failed in all 12 subcases before the fix.
- `python3 -m unittest scripts.tests.test_compare_layout scripts.tests.test_spatial_match` — 96 tests passed.
- `python3 -m unittest discover -s scripts/tests` — 391 tests passed.
- Replayed the public budget workbook PDFs from #1271 through `compare_layout.py --audit --fine-shift 0.5 --json`: page 2 now matches all 831 retained primitives, reports 14 removed gridlines and zero extra primitives, with no geometry mismatch. Previously it matched 202 and reported 643/629 unmatched primitives. Page 1 remains unchanged; the comparison exits successfully.
- `git diff --check` passed. README needs no change; converter behavior and public APIs are unchanged.

## Visual impact

- [x] No rendered PDF change
- Reason: Only the trace comparison harness and its tests change.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining converter or harness deviations each reference an open issue
