### PR TITLE
fix(audit): distinguish text order from proven content loss

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,7 +300,8 @@ ligature swallowing letter-spacing so the run extracts as `o ffi c e 2 p d f`
 (#684 — measured 24 occurrences in the pre-fix output, against 0 of the
 `ofce2pdf` that issue's body reports). It reports a codepoint-class census and a normalized-content check
 separately — a class delta with matching content is an encoding difference, a
-content residual is real text loss. Costs milliseconds; run it on any fix that
+content residual needs review for extraction order or missing/extra text.
+Costs milliseconds; run it on any fix that
 touches text.
 
 The tool's `## Reading` section is the part to act on — it routes attention to

--- a/scripts/compare_text_layer.py
+++ b/scripts/compare_text_layer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Text-layer codepoint census: is the extracted text intact, independent of layout?
+"""Text-layer codepoint census: is the selectable and searchable text intact?
 
 Some defects are invisible in any raster and in any geometry comparison, because
 they change *what a reader can select and search for* rather than where ink
@@ -28,11 +28,11 @@ This tool answers two questions separately:
    Injected joiners, NBSPs, ligature codepoints and control characters show up
    as a class delta even when the rendered page is pixel-identical.
 2. **Content** — after undoing ligatures and collapsing whitespace, is the text
-   the same? A residual here is real text loss or gain, not a formatting
-   artefact.
+   sequence the same? A residual requires checking extraction order and
+   missing or extra text; sequence inequality alone does not prove text loss.
 
 Reporting them apart matters: a ligature changes the census without changing the
-content, while a dropped word changes both. Conflating them makes a cosmetic
+content, while a dropped word changes content. Conflating them makes a cosmetic
 difference look like data loss.
 
 Usage:
@@ -126,7 +126,7 @@ def census(text: str) -> dict[str, int]:
 
 
 def normalize(text: str) -> str:
-    """Undo ligatures and collapse whitespace, so only real content remains.
+    """Undo ligatures and collapse whitespace, retaining extraction order.
 
     Comparing normalized forms separates "the text is different" from "the text
     is encoded differently" — a distinction a raw diff cannot make.
@@ -182,8 +182,8 @@ def render_report(result: dict) -> str:
     else:
         lines.append(
             f"Normalized content DIFFERS: {result['content_length_gt']} chars in "
-            f"GT against {result['content_length_output']} in the output. This is "
-            "text gained or lost, not a formatting artefact."
+            f"GT against {result['content_length_output']} in the output. Review "
+            "extraction order and check for missing or extra text."
         )
 
     lines += ["", "## Reading", ""]
@@ -210,8 +210,8 @@ def render_report(result: dict) -> str:
         lines.append("Text layer is intact.")
     elif not (injected or ligatures or nbsp):
         lines.append(
-            "No class was injected, so the residual is genuine text loss or "
-            "gain — compare the extractions directly."
+            "No class was injected. Compare the extractions directly: a sequence "
+            "mismatch can reflect extraction order or missing or extra text."
         )
     return "\n".join(lines)
 
@@ -232,7 +232,7 @@ def main() -> int:
         print(json.dumps(result, indent=2, ensure_ascii=False))
     else:
         print(render_report(result))
-    # A census delta alone is not a failure; unexplained content loss is.
+    # A census delta alone is not a failure; a sequence mismatch needs review.
     return 0 if result["content_matches"] else 1
 
 

--- a/scripts/tests/test_compare_text_layer.py
+++ b/scripts/tests/test_compare_text_layer.py
@@ -4,13 +4,15 @@ The cases are the two real defects that motivated it (issues #664 and #684),
 plus the negatives that keep the tool from crying wolf.
 """
 
+import io
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from compare_text_layer import census, compare, normalize, render_report
+from compare_text_layer import census, compare, main, normalize, render_report
 
 
 class CensusTest(unittest.TestCase):
@@ -76,11 +78,25 @@ class ReportTest(unittest.TestCase):
     def test_clean_comparison_says_so_plainly(self):
         self.assertIn("intact", render_report(compare("abc", "abc")))
 
-    def test_content_loss_is_not_blamed_on_a_class(self):
-        # No class was injected, so the report must point at real loss rather
-        # than leaving the reader hunting for a formatting cause.
-        report = render_report(compare("alpha beta", "alpha"))
-        self.assertIn("genuine text loss", report)
+    def test_sequence_mismatch_requires_order_and_content_review(self):
+        # Reordered table columns can preserve every word (#1561). Neither
+        # that case nor an omitted word can be diagnosed from class deltas.
+        for output in ("right column left column", "left column"):
+            with self.subTest(output=output):
+                report = render_report(compare("left column right column", output))
+                self.assertIn("extraction order", report)
+                self.assertIn("missing or extra text", report)
+                self.assertNotIn("genuine text loss", report)
+
+    def test_reordered_columns_and_missing_words_still_fail_the_cli(self):
+        for output in ("right column left column", "left column"):
+            with self.subTest(output=output), patch(
+                "sys.argv", ["compare_text_layer.py", "gt.pdf", "out.pdf"]
+            ), patch(
+                "compare_text_layer.extract_text",
+                side_effect=["left column right column", output],
+            ), patch("sys.stdout", new_callable=io.StringIO):
+                self.assertEqual(main(), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Stop diagnosing text loss from extraction-sequence inequality alone. When PDF text columns are extracted in a different order, the checker now asks for extraction-order and missing/extra-text review. Update the tool documentation and agent guidance to match.

The public budget workbook demonstrates this: native and output contain the same normalized tokens, but default extraction orders their columns differently. The comparison still fails on a sequence mismatch; normalization, JSON fields, and exit behavior are unchanged.

## Related issue

Related: #1561

## Testing

- Red: both reordered-column and dropped-word report regressions failed before the change.
- `python3 -m unittest scripts.tests.test_compare_text_layer` — 15 tests passed, including CLI failures for reordered and missing text.
- `python3 -m unittest discover -s scripts/tests` — 390 tests passed.
- Replayed native Excel and fresh main output for `tests/fixtures/xlsx/issue_1181_fit_to_height.xlsx`: the report requests order/content review, retains the 3,355/3,355 character counts, and exits 1.
- `git diff --check` passed. README usage and converter behavior are unchanged.

## Visual impact

- [x] No rendered PDF change
- Reason: Only comparison diagnostics, their tests, and matching documentation change.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining converter or harness deviations each reference an open issue
