### PR TITLE
docs: clean up completed worktrees and branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,12 @@
 - If a dependency limitation or bug breaks PDF conversion, clone that library, fix and test it upstream, and open a PR. Follow its repository conventions and match the tone and scope of its recently merged PRs.
 - Before every commit, delegate a read-only freshness audit and wait for `PASS:`. Codex must use `documentation_freshness_reviewer`; Claude Code must use `documentation-freshness-reviewer`. Compare existing documentation, examples, and code comments with the current code and configuration; update or remove stale versions, commands, APIs, behavior, defaults, paths, architecture, limitations, and unverified claims in the same commit.
 
+## Worktree and Branch Cleanup
+
+- After a task is verified complete, its PR is merged, and CI passes on the exact merge commit on `main`, remove its worktree and delete its local and remote topic branches in the same turn. No additional confirmation is needed.
+- Before cleanup, check `git worktree list`, worktree status, merge ancestry, and open PRs. Preserve active work, uncommitted changes, and commits not merged into `main`.
+- Preserve required evidence and shared build data outside the worktree before deleting it. Use `git worktree remove` and `git branch -d`; do not force-delete unfinished work. Prune stale worktree and remote-tracking records afterward.
+
 ## Release Rules
 
 - Follow `RELEASING.md` end to end in one turn; a version bump or GitHub Release alone is not completion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@
 - **Use git worktrees** for all branch work. Do not use `git checkout`/`git switch` in the main repo.
   - Create: `git worktree add ../<repo-name>-<branch-name> -b <type>/<short-description>`
   - Work and push from inside the worktree.
-  - Do not delete worktrees immediately after task completion — remove only when starting new work or upon user confirmation.
+  - Once the task is verified complete, its PR is merged, and exact-merge CI passes on `main`, remove its worktree and local/remote topic branches in the same turn. Follow the preservation checks in `AGENTS.md`; no additional confirmation is needed.
 
 ## PR Merge Procedure
 
@@ -101,7 +101,7 @@ Follow all steps in order:
 4. Wait for CI to pass: `gh pr checks <number> --watch`. Abort if tests fail.
 5. Final code review via `gh pr diff <number>` — check for debug statements, hardcoded paths, credentials, unused imports.
 6. Merge: `gh pr merge <number> --merge`. **Never use `--delete-branch`** (worktree depends on the branch).
-7. Return to main repo, `git pull` to sync.
+7. Return to main repo, `git pull` to sync; verify completion and CI on the exact merge commit, then preserve required evidence and shared build data outside the worktree.
 8. Remove worktree: `git worktree remove ../<repo-name>-<branch-name>`
 9. Delete local branch: `git branch -d <branch-name>`
 10. Delete remote branch: `git push origin --delete <branch-name>`


### PR DESCRIPTION
Require completed worktrees and their local/remote topic branches to be removed once the task is verified, its PR is merged, and CI passes on the exact merge commit on main. Add the rule to AGENTS.md and replace CLAUDE.md's delayed-cleanup instruction so future runs apply the same policy.

Cleanup checks preserve active work, uncommitted changes, unmerged commits, required evidence, and shared build data. Stale worktree and remote-tracking records are pruned afterward.

Validation: documentation freshness review PASS; `git diff --check` passed. Runtime tests skipped because only agent instructions changed. README needs no update.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Only AGENTS.md and CLAUDE.md workflow instructions change.
