### PR TITLE
docs: require security review before submitting files

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,20 @@
+---
+name: Report a bug or suggest an improvement
+about: Describe a problem or an improvement for office2pdf.
+---
+
+## File submission policy
+
+Before attaching files, read the [submission policy](https://github.com/developer0hye/office2pdf/blob/main/CONTRIBUTING.md).
+Complete a security review and obtain your organization's internal approval for
+public sharing where applicable. You are responsible for lawful disclosure;
+the project and maintainers disclaim related liability to the extent permitted
+by applicable law.
+
+- [ ] Any submitted files satisfy the submission policy, or no files are submitted.
+
+## Description
+
+<!-- Describe the problem or proposed improvement. For bugs, include the version,
+reproduction steps, expected behavior, and actual behavior. Use synthetic data
+in sample files whenever possible. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,13 @@
+## File submission policy
+
+Before attaching or committing files, read the [submission policy](https://github.com/developer0hye/office2pdf/blob/main/CONTRIBUTING.md).
+Complete a security review and obtain your organization's internal approval for
+public sharing where applicable. You are responsible for lawful disclosure;
+the project and maintainers disclaim related liability to the extent permitted
+by applicable law.
+
+- [ ] Any submitted sample files or attachments satisfy the submission policy, or none are submitted.
+
 ## Summary
 
 <!-- What changed and why? -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+## Submitting files safely
+
+This policy applies to files submitted to improve office2pdf through issues,
+pull requests, comments, or other project channels, including source documents,
+PDFs, screenshots, logs, and test fixtures.
+
+Before submitting any file:
+
+- Complete a security review. For files connected to your employer, client, or
+  another organization, you **must first discuss the submission internally with
+  the responsible security team or authorized reviewer and obtain approval for
+  public sharing**. A request from a maintainer does not replace this approval.
+- Confirm that you have the rights and permissions to share the file publicly
+  and allow its use for project development and testing. Follow applicable law,
+  contracts, confidentiality obligations, and your organization's policies.
+- Remove confidential information, personal data, credentials, and material you
+  are not authorized to disclose. Inspect metadata, comments, revision history,
+  hidden sheets, and embedded objects as well as visible content. Prefer a
+  minimal reproduction containing synthetic data.
+
+Do not submit a file until these requirements are satisfied. Public submissions
+may be copied, archived, or included in test fixtures; deleting an attachment
+later cannot guarantee removal of copies.
+
+## Responsibility for submitted materials
+
+You are responsible for the files you submit, the required approvals, and the
+lawfulness of their disclosure. To the extent permitted by applicable law,
+office2pdf and its maintainers accept no legal liability for claims, losses, or
+damages arising from the submission, disclosure, use, or redistribution of
+submitted materials, including unauthorized disclosure or infringement of
+third-party rights. This disclaimer does not exclude liability that applicable
+law does not allow to be excluded.

--- a/README.md
+++ b/README.md
@@ -227,6 +227,15 @@ XML they do not model — and saving rewrites only edited entries. The
 `office2pdf` rendering pipeline stays a derived projection for PDF
 preview/export; it is not the editable source of truth.
 
+## Contributing files
+
+Before attaching files to help improve office2pdf, complete a security review
+and obtain your organization's internal approval for public sharing where
+applicable. Submitters are responsible for authorized, lawful disclosure;
+office2pdf and its maintainers disclaim related liability to the extent
+permitted by applicable law. Read the [submission policy](CONTRIBUTING.md)
+before submitting documents, screenshots, logs, or test fixtures.
+
 ## License
 
 Licensed under [Apache License, Version 2.0](LICENSE).


### PR DESCRIPTION
## Summary

Require a security review before contributors submit files to improve office2pdf. Organizational files require internal discussion with the responsible security team or authorized reviewer and approval for public sharing.

The new contributor guide explains sharing permissions, removal of sensitive content, submitter responsibility, and a disclaimer of liability to the extent permitted by applicable law. The README and issue/PR templates surface the policy before files are submitted.

## Related issue

Requested by the repository owner; no existing matching issue found.

## Testing

- Verified Markdown link targets and issue template front matter.
- `git diff --check` passed.
- Required read-only documentation freshness audit: PASS.
- Runtime tests skipped under repository policy because only documentation and submission templates change.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Documentation and GitHub templates only.
