### PR TITLE
fix: audit individual cells on shared text baselines

### DIFF
--- a/assets/bugfixes/README.md
+++ b/assets/bugfixes/README.md
@@ -42,6 +42,16 @@ python3 scripts/compare_layout.py --json --audit --fine-shift 0.5 gt.pdf after.p
   > assets/bugfixes/issue-<number>/layout-audit.json
 ```
 
+The layout audit retains whole-line text matching but compares independent
+cell/object anchors within a shared baseline. A separate text paint with at
+least one em of empty space identifies a fragment boundary; a boundary on
+either side is mapped to the same text offset on the other. This prevents a
+fixed first cell from hiding later cells' movement or visibility differences.
+Normal word spacing stays together, and the stricter split/join topology rules
+remain unchanged. Closely packed text without such a boundary still needs the
+pixel comparison and manual crop inspection.
+
+
 The command exits nonzero when material findings remain but still writes the
 report. Change both `after.jpg` and `layout-audit.json` in a raster-changing fix
 pull request; use the text-layer-only exception above when the current render is

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -9,9 +9,9 @@ visible ink. It then matches lines by their text and reports typed deviations:
 - matched / missing / extra lines, safe split/join topology differences for
   distant text objects, and wrap-point differences (text that is present but
   breaks at a different word) counted separately from real loss;
-- spatial-anchor dy statistics, per-line dx0, line-width drift, inter-line
-  pitch deltas between consecutive matched lines. Horizontal text uses its
-  true baseline; a rotated or skewed `fill_text` stays one visual run and uses
+- spatial-anchor dy statistics, dx0 and width drift for independently painted
+  cell/object fragments, and inter-line pitch deltas between matched lines.
+  Horizontal text uses its true baseline; a rotated or skewed `fill_text` stays one visual run and uses
   the minimum fully transformed glyph x/y as its comparable anchor;
 - painted visibility from the page media box, active rectangular clips, and
   trace order: text outside the visible bounds, covered by a later opaque
@@ -1115,6 +1115,62 @@ def split_distant_text_objects(line: Line) -> list[Line]:
     ]
 
 
+def matched_text_fragments(gt: Line, out: Line) -> list[tuple[Line, Line]]:
+    """Compare cell/object anchors without changing whole-line text matching.
+
+    A paint boundary with at least one em of empty space supplies an anchor.
+    Use boundaries from either exporter: the other may batch cells into one
+    paint or move a cell enough to narrow the gap. Equal normalized text maps
+    the cuts by character offset, independent of whitespace and paint batching.
+    Only shared glyph boundaries are usable, so a multi-character glyph is
+    never divided. The stricter split/join topology heuristic stays separate.
+    """
+    def offsets(line: Line) -> tuple[dict[int, int], set[int]]:
+        glyphs = line.visible_glyphs
+        indices = {0: 0}
+        cuts: set[int] = set()
+        offset = 0
+        for index, glyph in enumerate(glyphs):
+            if index:
+                previous = glyphs[index - 1]
+                gap = glyph.x - (previous.x + previous.advance)
+                if (
+                    previous.paint_index != glyph.paint_index
+                    and gap >= max(previous.size, glyph.size)
+                ):
+                    cuts.add(offset)
+            offset += len(glyph.unicode)
+            indices[offset] = index + 1
+        return indices, cuts
+
+    gt_indices, gt_cuts = offsets(gt)
+    out_indices, out_cuts = offsets(out)
+    cuts = sorted(
+        cut for cut in (gt_cuts | out_cuts) & gt_indices.keys() & out_indices.keys()
+        if 0 < cut < len(gt.key)
+    )
+    if not cuts:
+        return [(gt, out)]
+
+    boundaries = [0, *cuts, len(gt.key)]
+
+    def fragments(line: Line, indices: dict[int, int]) -> list[Line]:
+        glyphs = line.visible_glyphs
+        result: list[Line] = []
+        for start, end in zip(boundaries, boundaries[1:]):
+            group = glyphs[indices[start]:indices[end]]
+            result.append(
+                Line(
+                    y=statistics.median(glyph.y for glyph in group),
+                    glyphs=group,
+                    visibility=line.visibility,
+                )
+            )
+        return result
+
+    return list(zip(fragments(gt, gt_indices), fragments(out, out_indices)))
+
+
 def ordered_unique_segment_match(
     joined_line: Line, candidates: list[Line]
 ) -> tuple[list[Line], list[Line]] | None:
@@ -1614,13 +1670,14 @@ def diff_page(
     extra = [line for line in extra if line.visibility != "hidden"]
     topology_groups, topology, missing, extra = take_topology_equivalents(missing, extra)
     topology_matches = [pair for group in topology_groups for pair in group]
-    for gt_line, out_line in topology_matches:
-        # The original joined line can mix visible and occluded distant
-        # objects. Reclassify each synthetic segment so topology equivalence
-        # cannot suppress an independently real visibility mismatch.
+    line_matches = exact_matches + topology_matches
+    fragment_groups = [matched_text_fragments(a, b) for a, b in line_matches]
+    matches = [pair for group in fragment_groups for pair in group]
+    for gt_line, out_line in matches:
+        # A shared baseline can mix visible and occluded cells. Reclassify
+        # each fragment so visible neighbors cannot hide an occluded object.
         gt_line.visibility = classify_line_visibility(gt_line, gt.paints)
         out_line.visibility = classify_line_visibility(out_line, out.paints)
-    matches = exact_matches + topology_matches
     matches.sort(key=lambda pair: (pair[0].y, pair[0].x0))
     wraps, missing, extra = take_wrap_differences(missing, extra)
     reflow, missing, extra = take_reflows(missing, extra)
@@ -1635,7 +1692,10 @@ def diff_page(
     deviant_lines = sum(
         1
         for gt_line, out_line in exact_matches
-        if abs(out_line.y - gt_line.y) > noise_floor
+        if any(
+            abs(b.y - a.y) > noise_floor
+            for a, b in matched_text_fragments(gt_line, out_line)
+        )
     ) + sum(
         any(abs(out_line.y - gt_line.y) > noise_floor for gt_line, out_line in group)
         for group in topology_groups
@@ -1702,8 +1762,8 @@ def diff_page(
     )
 
     pitch_deltas: list[float] = []
-    matched_gt = {id(gt_line) for gt_line, _ in matches}
-    ordered = [pair for pair in matches]
+    matched_gt = {id(gt_line) for gt_line, _ in line_matches}
+    ordered = list(line_matches)
     ordered.sort(key=lambda pair: pair[0].y)
     for (gt_a, out_a), (gt_b, out_b) in zip(ordered, ordered[1:]):
         if id(gt_a) in matched_gt and id(gt_b) in matched_gt:

--- a/scripts/tests/fixtures/issue-1609/README.md
+++ b/scripts/tests/fixtures/issue-1609/README.md
@@ -1,0 +1,34 @@
+# Shared-baseline cell anchors (#1609)
+
+`native.xml` and `output.xml` contain unchanged `fill_text` operations from
+only the header and July rows of page 2 of the public workbook attached to
+[issue #982](https://github.com/developer0hye/office2pdf/issues/982).
+These are text-position fixtures; page fills and clips were omitted, so they
+do not reproduce the full page's visibility or appearance.
+
+Source: [Gift Budget and Tracker1.xlsx](https://github.com/user-attachments/files/30941041/Gift.Budget.and.Tracker1.xlsx).
+SHA-256: `25f5dc75dab19ea12042979a61842314ddc226e3e45d447e36b2a2a104112613`.
+Native exporter: Microsoft Excel for Mac 16.112. Converter commit:
+`6d78f1aa26f7ac3f12b4602e77afdf8ff506d1da`, using the Excel bundled fonts.
+
+PDF SHA-256 values:
+
+- Native: `2aa03cafa6a156d553a2f1e03e0458257319ff6416a188f1132ce7817ecaeae1`.
+- Output: `81b93282a27291eb3ebf77ca02229a4d36e5dabc9916b742a083ce0130763c25`.
+
+To reproduce the extraction, run `mutool draw -F trace -o trace.xml FILE.pdf`
+for each PDF. Parse page 2 with `compare_layout.parse_trace`, select the lines
+whose normalized keys contain `Month` or `July`, and retain the text operations
+whose offsets match those lines' `Glyph.paint_index` values. Preserve the page
+media box and wrap the operations in a trace document.
+
+At the unchanged 0.5pt fine threshold, these two rows expose six shifted cells.
+The full fitted page exposes 16; the previous combined-line audit reported zero.
+Pinned dx values include Month -0.54931pt, Purchased? -0.79040pt, Delivered?
+-0.79031pt, and July -0.76732pt. Their converter defect is tracked in #1600.
+
+Run the regression with:
+
+```sh
+python3 -m unittest discover -s scripts/tests -p 'test_compare_layout.py'
+```

--- a/scripts/tests/fixtures/issue-1609/native.xml
+++ b/scripts/tests/fixtures/issue-1609/native.xml
@@ -1,0 +1,214 @@
+<document>
+<page number="2" mediabox="0 0 1191 842">
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".2666667 .3294118 .4156863" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAI+SegoeUI" wmode="0" bidi="0" trm="12 0 0 12">
+                <g unicode="W" glyph="13" x="349" y="450" adv=".934"/>
+                <g unicode="h" glyph="21" x="360.0004" y="450" adv=".56600007"/>
+                <g unicode="o" glyph="27" x="367.00483" y="450" adv=".586"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".2666667 .3294118 .4156863" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAI+SegoeUI" wmode="0" bidi="0" trm="12 0 0 12">
+                <g unicode="O" glyph="11" x="433" y="450" adv=".754"/>
+                <g unicode="c" glyph="16" x="442" y="450" adv=".462"/>
+                <g unicode="c" glyph="16" x="448" y="450" adv=".462"/>
+                <g unicode="a" glyph="14" x="454" y="450" adv=".509"/>
+                <g unicode="s" glyph="30" x="460" y="450" adv=".42400003"/>
+                <g unicode="i" glyph="22" x="465.004" y="450" adv=".24200002"/>
+                <g unicode="o" glyph="27" x="468.004" y="450" adv=".586"/>
+                <g unicode="n" glyph="26" x="475" y="450" adv=".56600007"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".2666667 .3294118 .4156863" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAI+SegoeUI" wmode="0" bidi="0" trm="12 0 0 12">
+                <g unicode="M" glyph="9" x="520" y="450" adv=".89800009"/>
+                <g unicode="o" glyph="27" x="531.0004" y="450" adv=".586"/>
+                <g unicode="n" glyph="26" x="538.0048" y="450" adv=".56600007"/>
+                <g unicode="t" glyph="31" x="545.0092" y="450" adv=".33900003"/>
+                <g unicode="h" glyph="21" x="549.0136" y="450" adv=".56600007"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".2666667 .3294118 .4156863" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAI+SegoeUI" wmode="0" bidi="0" trm="12 0 0 12">
+                <g unicode="G" glyph="6" x="768" y="450" adv=".68600007"/>
+                <g unicode="i" glyph="22" x="776.0004" y="450" adv=".24200002"/>
+                <g unicode="f" glyph="19" x="778.9968" y="450" adv=".31300003"/>
+                <g unicode="t" glyph="31" x="783.0012" y="450" adv=".33900003"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".2666667 .3294118 .4156863" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAI+SegoeUI" wmode="0" bidi="0" trm="12 0 0 12">
+                <g unicode="L" glyph="8" x="829" y="450" adv=".47100003"/>
+                <g unicode="i" glyph="22" x="835" y="450" adv=".24200002"/>
+                <g unicode="n" glyph="26" x="838" y="450" adv=".56600007"/>
+                <g unicode="k" glyph="23" x="844.99606" y="450" adv=".497"/>
+                <g unicode=" " glyph="1" x="850.99606" y="450" adv=".27400003"/>
+                <g unicode="t" glyph="31" x="853.99606" y="450" adv=".33900003"/>
+                <g unicode="o" glyph="27" x="857.99209" y="450" adv=".586"/>
+                <g unicode=" " glyph="1" x="864.9881" y="450" adv=".27400003"/>
+                <g unicode="g" glyph="20" x="867.9881" y="450" adv=".58900007"/>
+                <g unicode="i" glyph="22" x="874.98416" y="450" adv=".24200002"/>
+                <g unicode="f" glyph="19" x="877.98416" y="450" adv=".31300003"/>
+                <g unicode="t" glyph="31" x="881.98019" y="450" adv=".33900003"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".2666667 .3294118 .4156863" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAI+SegoeUI" wmode="0" bidi="0" trm="12 0 0 12">
+                <g unicode="P" glyph="12" x="988" y="450" adv=".56"/>
+                <g unicode="u" glyph="32" x="994.9996" y="450" adv=".56600007"/>
+                <g unicode="r" glyph="29" x="1001.99917" y="450" adv=".34800003"/>
+                <g unicode="c" glyph="16" x="1005.9988" y="450" adv=".462"/>
+                <g unicode="h" glyph="21" x="1012.0024" y="450" adv=".56600007"/>
+                <g unicode="a" glyph="14" x="1019.00198" y="450" adv=".509"/>
+                <g unicode="s" glyph="30" x="1025.0055" y="450" adv=".42400003"/>
+                <g unicode="e" glyph="18" x="1030.0011" y="450" adv=".523"/>
+                <g unicode="d" glyph="17" x="1036.0046" y="450" adv=".58900007"/>
+                <g unicode="?" glyph="3" x="1043.0043" y="450" adv=".448"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".2666667 .3294118 .4156863" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAI+SegoeUI" wmode="0" bidi="0" trm="12 0 0 12">
+                <g unicode="W" glyph="13" x="1071" y="450" adv=".934"/>
+                <g unicode="r" glyph="29" x="1082.0004" y="450" adv=".34800003"/>
+                <g unicode="a" glyph="14" x="1086.0048" y="450" adv=".509"/>
+                <g unicode="p" glyph="28" x="1092.0011" y="450" adv=".588"/>
+                <g unicode="p" glyph="28" x="1099.0055" y="450" adv=".588"/>
+                <g unicode="e" glyph="18" x="1106.0099" y="450" adv=".523"/>
+                <g unicode="d" glyph="17" x="1112.0062" y="450" adv=".58900007"/>
+                <g unicode="?" glyph="3" x="1119.0106" y="450" adv=".448"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".2666667 .3294118 .4156863" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAI+SegoeUI" wmode="0" bidi="0" trm="12 0 0 12">
+                <g unicode="D" glyph="5" x="1151" y="450" adv=".70100006"/>
+                <g unicode="e" glyph="18" x="1159.0004" y="450" adv=".523"/>
+                <g unicode="l" glyph="24" x="1164.9967" y="450" adv=".24200002"/>
+                <g unicode="i" glyph="22" x="1167.9932" y="450" adv=".24200002"/>
+                <g unicode="v" glyph="33" x="1170.9896" y="450" adv=".47900004"/>
+                <g unicode="e" glyph="18" x="1176.9861" y="450" adv=".523"/>
+                <g unicode="r" glyph="29" x="1182.9824" y="450" adv=".34800003"/>
+                <g unicode="e" glyph="18" x="1186.9868" y="450" adv=".523"/>
+                <g unicode="d" glyph="17" x="1192.9832" y="450" adv=".58900007"/>
+                <g unicode="?" glyph="3" x="1199.9876" y="450" adv=".448"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".2666667 .3294118 .4156863" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAI+SegoeUI" wmode="0" bidi="0" trm="12 0 0 12">
+                <g unicode="N" glyph="10" x="1229" y="450" adv=".748"/>
+                <g unicode="o" glyph="27" x="1238" y="450" adv=".586"/>
+                <g unicode="t" glyph="31" x="1244.996" y="450" adv=".33900003"/>
+                <g unicode="e" glyph="18" x="1248.9921" y="450" adv=".523"/>
+                <g unicode="s" glyph="30" x="1254.9921" y="450" adv=".42400003"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".1490196 .1490196 .1490196" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAK+SegoeUI" wmode="0" bidi="0" trm="11 0 0 11">
+                <g unicode="A" glyph="12" x="349" y="351" adv=".64500007"/>
+                <g unicode="k" glyph="33" x="356.0004" y="351" adv=".497"/>
+                <g unicode="t" glyph="41" x="360.9988" y="351" adv=".33900003"/>
+                <g unicode="a" glyph="25" x="364.99623" y="351" adv=".509"/>
+                <g unicode="n" glyph="36" x="370.9956" y="351" adv=".56600007"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color="1 1 1" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAM+SegoeUI-Bold" wmode="0" bidi="0" trm="11 0 0 11">
+                <g unicode="H" glyph="3" x="435" y="351" adv=".76600006"/>
+                <g unicode="o" glyph="13" x="443.0003" y="351" adv=".611"/>
+                <g unicode="l" glyph="11" x="449.9996" y="351" adv=".284"/>
+                <g unicode="i" glyph="10" x="452.9949" y="351" adv=".284"/>
+                <g unicode="d" glyph="6" x="455.9902" y="351" adv=".619"/>
+                <g unicode="a" glyph="5" x="462.9895" y="351" adv=".53800007"/>
+                <g unicode="y" glyph="18" x="468.98783" y="351" adv=".53800007"/>
+                <g unicode="s" glyph="15" x="474.98616" y="351" adv=".44000004"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".1490196 .1490196 .1490196" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAK+SegoeUI" wmode="0" bidi="0" trm="11 0 0 11">
+                <g unicode="J" glyph="18" x="529" y="351" adv=".35700003"/>
+                <g unicode="u" glyph="42" x="532.9996" y="351" adv=".56600007"/>
+                <g unicode="l" glyph="34" x="539.00119" y="351" adv=".24200002"/>
+                <g unicode="y" glyph="44" x="541.99978" y="351" adv=".48400004"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".1490196 .1490196 .1490196" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAK+SegoeUI" wmode="0" bidi="0" trm="11 0 0 11">
+                <g unicode="$" glyph="2" x="609" y="351" adv=".53900006"/>
+                <g unicode="5" glyph="9" x="615.0005" y="351" adv=".53900006"/>
+                <g unicode="0" glyph="5" x="621.001" y="351" adv=".53900006"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".1490196 .1490196 .1490196" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAK+SegoeUI" wmode="0" bidi="0" trm="11 0 0 11">
+                <g unicode="$" glyph="2" x="689" y="351" adv=".53900006"/>
+                <g unicode="7" glyph="11" x="695.0005" y="351" adv=".53900006"/>
+                <g unicode="0" glyph="5" x="701.001" y="351" adv=".53900006"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".1490196 .1490196 .1490196" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAK+SegoeUI" wmode="0" bidi="0" trm="11 0 0 11">
+                <g unicode="H" glyph="16" x="747" y="351" adv=".71000006"/>
+                <g unicode="e" glyph="28" x="755.0003" y="351" adv=".523"/>
+                <g unicode="a" glyph="25" x="760.9986" y="351" adv=".509"/>
+                <g unicode="d" glyph="27" x="766.9969" y="351" adv=".58900007"/>
+                <g unicode="p" glyph="38" x="772.9952" y="351" adv=".588"/>
+                <g unicode="h" glyph="31" x="778.9935" y="351" adv=".56600007"/>
+                <g unicode="o" glyph="37" x="784.9918" y="351" adv=".586"/>
+                <g unicode="n" glyph="36" x="790.9901" y="351" adv=".56600007"/>
+                <g unicode="e" glyph="28" x="796.9884" y="351" adv=".523"/>
+                <g unicode="s" glyph="40" x="802.9867" y="351" adv=".42400003"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".1490196 .1490196 .1490196" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAK+SegoeUI" wmode="0" bidi="0" trm="11 0 0 11">
+                <g unicode="S" glyph="23" x="843" y="351" adv=".531"/>
+                <g unicode="e" glyph="28" x="849.0005" y="351" adv=".523"/>
+                <g unicode="l" glyph="34" x="855.001" y="351" adv=".24200002"/>
+                <g unicode="l" glyph="34" x="857.9985" y="351" adv=".24200002"/>
+                <g unicode="e" glyph="28" x="860.996" y="351" adv=".523"/>
+                <g unicode="r" glyph="39" x="866.99649" y="351" adv=".34800003"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".1490196 .1490196 .1490196" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAK+SegoeUI" wmode="0" bidi="0" trm="11 0 0 11">
+                <g unicode="O" glyph="22" x="921" y="351" adv=".754"/>
+                <g unicode="n" glyph="36" x="929.0003" y="351" adv=".56600007"/>
+                <g unicode="l" glyph="34" x="934.9986" y="351" adv=".24200002"/>
+                <g unicode="i" glyph="32" x="937.9939" y="351" adv=".24200002"/>
+                <g unicode="n" glyph="36" x="940.9892" y="351" adv=".56600007"/>
+                <g unicode="e" glyph="28" x="946.9875" y="351" adv=".523"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".1490196 .1490196 .1490196" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAK+SegoeUI" wmode="0" bidi="0" trm="11 0 0 11">
+                <g unicode="N" glyph="21" x="1010" y="351" adv=".748"/>
+                <g unicode="o" glyph="37" x="1018.0003" y="351" adv=".586"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".1490196 .1490196 .1490196" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAK+SegoeUI" wmode="0" bidi="0" trm="11 0 0 11">
+                <g unicode="N" glyph="21" x="1090" y="351" adv=".748"/>
+                <g unicode="o" glyph="37" x="1098.0003" y="351" adv=".586"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".1490196 .1490196 .1490196" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAK+SegoeUI" wmode="0" bidi="0" trm="11 0 0 11">
+                <g unicode="N" glyph="21" x="1170" y="351" adv=".748"/>
+                <g unicode="o" glyph="37" x="1178.0003" y="351" adv=".586"/>
+            </span>
+        </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".1490196 .1490196 .1490196" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 -.82 0 806.06">
+            <span font="AAAAAK+SegoeUI" wmode="0" bidi="0" trm="11 0 0 11">
+                <g unicode="D" glyph="14" x="1229" y="351" adv=".70100006"/>
+                <g unicode="o" glyph="37" x="1237.0003" y="351" adv=".586"/>
+                <g unicode="r" glyph="39" x="1242.9985" y="351" adv=".34800003"/>
+                <g unicode="m" glyph="35" x="1246.9949" y="351" adv=".86100009"/>
+                <g unicode=" " glyph="1" x="1255.9961" y="351" adv=".27400003"/>
+                <g unicode="s" glyph="40" x="1258.9915" y="351" adv=".42400003"/>
+                <g unicode="t" glyph="41" x="1263.9887" y="351" adv=".33900003"/>
+                <g unicode="u" glyph="42" x="1267.985" y="351" adv=".56600007"/>
+                <g unicode="f" glyph="29" x="1273.9833" y="351" adv=".31300003"/>
+                <g unicode="f" glyph="29" x="1276.9785" y="351" adv=".31300003"/>
+            </span>
+        </fill_text>
+</page>
+</document>

--- a/scripts/tests/fixtures/issue-1609/output.xml
+++ b/scripts/tests/fixtures/issue-1609/output.xml
@@ -1,0 +1,214 @@
+<document>
+<page number="2" mediabox="0 0 1190.55 841.89">
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".26666669 .32941178 .41568629" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 286.365 436.94">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.84 0 0 -9.84">
+            <g unicode="W" glyph="34" x="0" y="0" adv=".934"/>
+            <g unicode="h" glyph="17" x="9.19056" y="0" adv=".56600007"/>
+            <g unicode="o" glyph="10" x="14.76" y="0" adv=".586"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".26666669 .32941178 .41568629" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 354.9207 436.94">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.84 0 0 -9.84">
+            <g unicode="O" glyph="35" x="0" y="0" adv=".754"/>
+            <g unicode="c" glyph="16" x="7.505158" y="0" adv=".462"/>
+            <g unicode="c" glyph="16" x="12.137036" y="0" adv=".462"/>
+            <g unicode="a" glyph="13" x="16.768916" y="0" adv=".509"/>
+            <g unicode="s" glyph="14" x="21.863274" y="0" adv=".42400003"/>
+            <g unicode="i" glyph="7" x="26.121233" y="0" adv=".24200002"/>
+            <g unicode="o" glyph="10" x="28.588313" y="0" adv=".586"/>
+            <g unicode="n" glyph="19" x="34.44035" y="0" adv=".56600007"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".26666669 .32941178 .41568629" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 425.85069 436.94">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.84 0 0 -9.84">
+            <g unicode="M" glyph="36" x="0" y="0" adv=".89800009"/>
+            <g unicode="o" glyph="10" x="8.905189" y="0" adv=".586"/>
+            <g unicode="n" glyph="19" x="14.740296" y="0" adv=".56600007"/>
+            <g unicode="t" glyph="12" x="20.378603" y="0" adv=".33900003"/>
+            <g unicode="h" glyph="17" x="23.78323" y="0" adv=".56600007"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".26666669 .32941178 .41568629" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 629.50778 436.94">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.84 0 0 -9.84">
+            <g unicode="G" glyph="38" x="0" y="0" adv=".68600007"/>
+            <g unicode="i" glyph="7" x="6.779069" y="0" adv=".24200002"/>
+            <g unicode="f" glyph="23" x="9.189177" y="0" adv=".31300003"/>
+            <g unicode="t" glyph="12" x="12.297924" y="0" adv=".33900003"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".26666669 .32941178 .41568629" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 679.5278 436.94">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.84 0 0 -9.84">
+            <g unicode="L" glyph="39" x="0" y="0" adv=".47100003"/>
+            <g unicode="i" glyph="7" x="4.6561887" y="0" adv=".24200002"/>
+            <g unicode="n" glyph="19" x="7.059017" y="0" adv=".56600007"/>
+            <g unicode="k" glyph="40" x="12.650006" y="0" adv=".497"/>
+            <g unicode=" " glyph="9" x="17.562035" y="0" adv=".27400003"/>
+            <g unicode="t" glyph="12" x="20.279744" y="0" adv=".33900003"/>
+            <g unicode="o" glyph="10" x="23.637053" y="0" adv=".586"/>
+            <g unicode=" " glyph="9" x="29.424843" y="0" adv=".27400003"/>
+            <g unicode="g" glyph="22" x="32.14255" y="0" adv=".58900007"/>
+            <g unicode="i" glyph="7" x="37.95986" y="0" adv=".24200002"/>
+            <g unicode="f" glyph="23" x="40.36269" y="0" adv=".31300003"/>
+            <g unicode="t" glyph="12" x="43.46416" y="0" adv=".33900003"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".26666669 .32941178 .41568629" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 809.3696 436.94">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.84 0 0 -9.84">
+            <g unicode="P" glyph="43" x="0" y="0" adv=".56"/>
+            <g unicode="u" glyph="11" x="5.550795" y="0" adv=".56600007"/>
+            <g unicode="r" glyph="25" x="11.16063" y="0" adv=".34800003"/>
+            <g unicode="c" glyph="16" x="14.625345" y="0" adv=".462"/>
+            <g unicode="h" glyph="17" x="19.21182" y="0" adv=".56600007"/>
+            <g unicode="a" glyph="13" x="24.821658" y="0" adv=".509"/>
+            <g unicode="s" glyph="14" x="29.870614" y="0" adv=".42400003"/>
+            <g unicode="e" glyph="20" x="34.083169" y="0" adv=".523"/>
+            <g unicode="d" glyph="28" x="39.269884" y="0" adv=".58900007"/>
+            <g unicode="?" glyph="44" x="45.106039" y="0" adv=".448"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".26666669 .32941178 .41568629" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 877.83969 436.94">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.84 0 0 -9.84">
+            <g unicode="W" glyph="34" x="0" y="0" adv=".934"/>
+            <g unicode="r" glyph="25" x="9.080739" y="0" adv=".34800003"/>
+            <g unicode="a" glyph="13" x="12.395238" y="0" adv=".509"/>
+            <g unicode="p" glyph="31" x="17.293976" y="0" adv=".588"/>
+            <g unicode="p" glyph="31" x="22.970074" y="0" adv=".588"/>
+            <g unicode="e" glyph="20" x="28.646172" y="0" adv=".523"/>
+            <g unicode="d" glyph="28" x="33.68267" y="0" adv=".58900007"/>
+            <g unicode="?" glyph="44" x="39.36861" y="0" adv=".448"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".26666669 .32941178 .41568629" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 943.02969 436.94">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.84 0 0 -9.84">
+            <g unicode="D" glyph="4" x="0" y="0" adv=".70100006"/>
+            <g unicode="e" glyph="20" x="6.80317" y="0" adv=".523"/>
+            <g unicode="l" glyph="8" x="11.854819" y="0" adv=".24200002"/>
+            <g unicode="i" glyph="7" x="14.141429" y="0" adv=".24200002"/>
+            <g unicode="v" glyph="30" x="16.42804" y="0" adv=".47900004"/>
+            <g unicode="e" glyph="20" x="21.04673" y="0" adv=".523"/>
+            <g unicode="r" glyph="25" x="26.09838" y="0" adv=".34800003"/>
+            <g unicode="e" glyph="20" x="29.42803" y="0" adv=".523"/>
+            <g unicode="d" glyph="28" x="34.47968" y="0" adv=".58900007"/>
+            <g unicode="?" glyph="44" x="40.18077" y="0" adv=".448"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".26666669 .32941178 .41568629" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 1007.965 436.94">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.84 0 0 -9.84">
+            <g unicode="N" glyph="45" x="0" y="0" adv=".748"/>
+            <g unicode="o" glyph="10" x="7.288651" y="0" adv=".586"/>
+            <g unicode="t" glyph="12" x="12.983222" y="0" adv=".33900003"/>
+            <g unicode="e" glyph="20" x="16.24731" y="0" adv=".523"/>
+            <g unicode="s" glyph="14" x="21.32196" y="0" adv=".42400003"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".14901962 .14901962 .14901962" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 286.365 518.12">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.02 0 0 -9.02">
+            <g unicode="A" glyph="37" x="0" y="0" adv=".64500007"/>
+            <g unicode="k" glyph="40" x="5.8410236" y="0" adv=".497"/>
+            <g unicode="t" glyph="12" x="10.347086" y="0" adv=".33900003"/>
+            <g unicode="a" glyph="13" x="13.427989" y="0" adv=".509"/>
+            <g unicode="n" glyph="19" x="18.042292" y="0" adv=".56600007"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color="1 1 1" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 356.54087 518.12">
+        <span font="NJLQJQ+Selawik-Bold" wmode="0" bidi="0" trm="9.02 0 0 -9.02">
+            <g unicode="H" glyph="14" x="0" y="0" adv=".76600006"/>
+            <g unicode="o" glyph="15" x="6.9032008" y="0" adv=".611"/>
+            <g unicode="l" glyph="16" x="12.4083" y="0" adv=".284"/>
+            <g unicode="i" glyph="2" x="14.9638609" y="0" adv=".284"/>
+            <g unicode="d" glyph="6" x="17.51942" y="0" adv=".619"/>
+            <g unicode="a" glyph="7" x="23.09668" y="0" adv=".53800007"/>
+            <g unicode="y" glyph="8" x="27.94332" y="0" adv=".53800007"/>
+            <g unicode="s" glyph="9" x="32.789964" y="0" adv=".44000004"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".14901962 .14901962 .14901962" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 433.01268 518.12">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.02 0 0 -9.02">
+            <g unicode="J" glyph="46" x="0" y="0" adv=".35700003"/>
+            <g unicode="u" glyph="11" x="3.2705897" y="0" adv=".56600007"/>
+            <g unicode="l" glyph="8" x="8.426359" y="0" adv=".24200002"/>
+            <g unicode="y" glyph="18" x="10.659649" y="0" adv=".48400004"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".14901962 .14901962 .14901962" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 498.77384 518.12">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.02 0 0 -9.02">
+            <g unicode="$" glyph="47" x="0" y="0" adv=".53900006"/>
+            <g unicode="5" glyph="48" x="4.9194376" y="0" adv=".53900006"/>
+            <g unicode="0" glyph="3" x="9.838874" y="0" adv=".53900006"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".14901962 .14901962 .14901962" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 564.37387 518.12">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.02 0 0 -9.02">
+            <g unicode="$" glyph="47" x="0" y="0" adv=".53900006"/>
+            <g unicode="7" glyph="56" x="4.9194376" y="0" adv=".53900006"/>
+            <g unicode="0" glyph="3" x="9.838874" y="0" adv=".53900006"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".14901962 .14901962 .14901962" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 612.45138 518.12">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.02 0 0 -9.02">
+            <g unicode="H" glyph="55" x="0" y="0" adv=".71000006"/>
+            <g unicode="e" glyph="20" x="6.335778" y="0" adv=".523"/>
+            <g unicode="a" glyph="13" x="10.984816" y="0" adv=".509"/>
+            <g unicode="d" glyph="28" x="15.507574" y="0" adv=".58900007"/>
+            <g unicode="p" glyph="31" x="20.751933" y="0" adv=".588"/>
+            <g unicode="h" glyph="17" x="25.98727" y="0" adv=".56600007"/>
+            <g unicode="o" glyph="10" x="31.024168" y="0" adv=".586"/>
+            <g unicode="n" glyph="19" x="36.241464" y="0" adv=".56600007"/>
+            <g unicode="e" glyph="20" x="41.27836" y="0" adv=".523"/>
+            <g unicode="s" glyph="14" x="45.927396" y="0" adv=".42400003"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".14901962 .14901962 .14901962" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 691.5171 518.12">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.02 0 0 -9.02">
+            <g unicode="S" glyph="50" x="0" y="0" adv=".531"/>
+            <g unicode="e" glyph="20" x="5.0066325" y="0" adv=".523"/>
+            <g unicode="l" glyph="8" x="9.941104" y="0" adv=".24200002"/>
+            <g unicode="l" glyph="8" x="12.340956" y="0" adv=".24200002"/>
+            <g unicode="e" glyph="20" x="14.740808" y="0" adv=".523"/>
+            <g unicode="r" glyph="25" x="19.67528" y="0" adv=".34800003"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".14901962 .14901962 .14901962" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 755.5065 518.12">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.02 0 0 -9.02">
+            <g unicode="O" glyph="35" x="0" y="0" adv=".754"/>
+            <g unicode="n" glyph="19" x="6.789389" y="0" adv=".56600007"/>
+            <g unicode="l" glyph="8" x="11.8830189" y="0" adv=".24200002"/>
+            <g unicode="i" glyph="7" x="14.054168" y="0" adv=".24200002"/>
+            <g unicode="n" glyph="19" x="16.225316" y="0" adv=".56600007"/>
+            <g unicode="e" glyph="20" x="21.318943" y="0" adv=".523"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".14901962 .14901962 .14901962" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 828.2024 518.12">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.02 0 0 -9.02">
+            <g unicode="N" glyph="45" x="0" y="0" adv=".748"/>
+            <g unicode="o" glyph="10" x="6.559578" y="0" adv=".586"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".14901962 .14901962 .14901962" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 893.8024 518.12">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.02 0 0 -9.02">
+            <g unicode="N" glyph="45" x="0" y="0" adv=".748"/>
+            <g unicode="o" glyph="10" x="6.559578" y="0" adv=".586"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".14901962 .14901962 .14901962" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 959.4024 518.12">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.02 0 0 -9.02">
+            <g unicode="N" glyph="45" x="0" y="0" adv=".748"/>
+            <g unicode="o" glyph="10" x="6.559578" y="0" adv=".586"/>
+        </span>
+    </fill_text>
+<fill_text colorspace="ICCBased(RGB,sRGB)" color=".14901962 .14901962 .14901962" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 1007.965 518.12">
+        <span font="BIDZAI+Selawik-Regular" wmode="0" bidi="0" trm="9.02 0 0 -9.02">
+            <g unicode="D" glyph="4" x="0" y="0" adv=".70100006"/>
+            <g unicode="o" glyph="10" x="6.27444" y="0" adv=".586"/>
+            <g unicode="r" glyph="25" x="11.5115799" y="0" adv=".34800003"/>
+            <g unicode="m" glyph="15" x="14.601959" y="0" adv=".86100009"/>
+            <g unicode=" " glyph="9" x="22.3196" y="0" adv=".27400003"/>
+            <g unicode="s" glyph="14" x="24.7425" y="0" adv=".42400003"/>
+            <g unicode="t" glyph="12" x="28.5184" y="0" adv=".33900003"/>
+            <g unicode="u" glyph="11" x="31.5276" y="0" adv=".56600007"/>
+            <g unicode="f" glyph="23" x="36.58434" y="0" adv=".31300003"/>
+            <g unicode="f" glyph="23" x="39.35902" y="0" adv=".31300003"/>
+        </span>
+    </fill_text>
+</page>
+</document>

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -401,6 +401,97 @@ class MatchAndDiffTest(unittest.TestCase):
         self.assertEqual(vector["instances"]["fine_shifts"][0]["label"], "moved")
         self.assertEqual(compare_layout.audit_failures([vector]), 1)
 
+    def test_shared_baseline_keeps_each_cell_anchor(self) -> None:
+        gt = "\n".join([line_of("Name", 72, 100), line_of("Month", 200, 100)])
+        out = "\n".join([line_of("Name", 72, 100), line_of("Month", 199.25, 100)])
+
+        vector = self.diff(gt, out, fine_shift=0.5)
+
+        self.assertEqual(vector["lines"]["matched"], 1)
+        self.assertEqual(vector["instances"]["compared"], 2)
+        self.assertEqual(vector["instances"]["fine_shift_count"], 1)
+        shifted = vector["instances"]["fine_shifts"][0]
+        self.assertEqual(shifted["label"], "Month")
+        self.assertAlmostEqual(shifted["dx"], -0.75, places=4)
+        self.assertEqual(compare_layout.audit_failures([vector]), 1)
+
+    def test_middle_cell_shift_cannot_hide_between_fixed_endpoints(self) -> None:
+        gt = "\n".join(line_of(text, x, 100) for text, x in
+                       [("Name", 72), ("July", 200), ("Paid", 350)])
+        out = "\n".join(line_of(text, x, 100) for text, x in
+                        [("Name", 72), ("July", 194), ("Paid", 350)])
+
+        vector = self.diff(gt, out, fine_shift=0.5)
+
+        self.assertEqual(vector["instances"]["compared"], 3)
+        self.assertEqual(vector["instances"]["large_shift_count"], 1)
+        self.assertEqual(vector["instances"]["large_shifts"][0]["label"], "July")
+
+    def test_shared_baseline_cells_keep_independent_visibility(self) -> None:
+        text = "\n".join([line_of("Name", 72, 100), line_of("Month", 200, 100)])
+        cover = rect_op(195, 80, 240, 110)
+
+        vector = self.diff(text + "\n" + cover, cover + "\n" + text)
+
+        self.assertEqual(vector["visibility"]["mismatches"],
+                         [{"label": "Month", "gt": "hidden", "out": "painted"}])
+
+    def test_compact_cell_anchors_use_gaps_smaller_than_topology_gate(self) -> None:
+        # Native #982 headers have 18-22pt gaps at 9.84pt, below the
+        # conservative 24pt split/join threshold. Their anchors still matter.
+        gt = "\n".join([line_of("Paid?", 100, 100), line_of("Sent?", 147, 100)])
+        out = "\n".join([line_of("Paid?", 100, 100), line_of("Sent?", 146.25, 100)])
+        vector = self.diff(gt, out, fine_shift=0.5)
+        self.assertEqual(vector["instances"]["fine_shift_count"], 1)
+        self.assertEqual(vector["instances"]["fine_shifts"][0]["label"], "Sent?")
+
+    def test_cell_boundaries_survive_different_exporter_paint_operations(self) -> None:
+        gt = "\n".join([line_of("Name ", 72, 100), line_of("Month", 200, 100)])
+        out = text_op(
+            [(char, 72 + i * 6) for i, char in enumerate("Name")]
+            + [(char, 199.25 + i * 6) for i, char in enumerate("Month")],
+            baseline_y=100,
+        )
+        for reference, candidate in [(gt, out), (out, gt)]:
+            with self.subTest(reverse=reference == out):
+                vector = self.diff(reference, candidate, fine_shift=0.5)
+                self.assertEqual(vector["instances"]["compared"], 2)
+                self.assertEqual(vector["instances"]["fine_shift_count"], 1)
+                self.assertEqual(vector["instances"]["fine_shifts"][0]["label"], "Month")
+                self.assertEqual(vector["wraps"]["count"], 0)
+
+    def test_repeated_cells_keep_distinct_occurrence_labels(self) -> None:
+        gt = "\n".join(line_of("No", x, 100) for x in [100, 200, 300])
+        out = "\n".join(line_of("No", x, 100) for x in [100, 199.25, 300])
+        vector = self.diff(gt, out, fine_shift=0.5)
+        self.assertEqual(vector["instances"]["fine_shift_count"], 1)
+        self.assertEqual(vector["instances"]["fine_shifts"][0]["label"], "No [2/3]")
+
+    def test_normal_word_spacing_across_paint_operations_stays_one_instance(self) -> None:
+        page = "\n".join([line_of("Hello", 72, 100), line_of("world", 108, 100)])
+        vector = self.diff(page, page, fine_shift=0.5)
+        self.assertEqual(vector["instances"]["compared"], 1)
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
+    def test_issue_1609_pinned_native_table_rows_expose_cell_shifts(self) -> None:
+        fixture = Path(__file__).parent / "fixtures" / "issue-1609"
+        gt = compare_layout.parse_trace((fixture / "native.xml").read_text())[0]
+        out = compare_layout.parse_trace((fixture / "output.xml").read_text())[0]
+
+        vector = compare_layout.diff_page(gt, out, fine_shift=0.5)
+
+        self.assertEqual(vector["lines"]["matched"], 2)
+        self.assertEqual(vector["lines"]["missing"], 0)
+        self.assertEqual(vector["lines"]["extra"], 0)
+        shifts = {item["label"]: item for item in vector["instances"]["fine_shifts"]}
+        for label, dx in [("Month", -0.54931), ("Purchased?", -0.79040),
+                          ("Delivered?", -0.79031), ("July", -0.76732)]:
+            with self.subTest(cell=label):
+                self.assertIn(label, shifts)
+                self.assertAlmostEqual(shifts[label]["dx"], dx, places=4)
+        self.assertEqual(vector["instances"]["fine_shift_count"], 6)
+        self.assertEqual(compare_layout.audit_failures([vector]), 6)
+
     def test_coarse_audit_stays_clean_without_fine_shift_mode(self) -> None:
         gt = line_of("moved", 72, 120)
         out = line_of("moved", 72, 121.1)


### PR DESCRIPTION
## Summary

The layout audit merged cells sharing a baseline and measured only the first cell's origin. A fixed first cell could hide later cells moving beyond the configured threshold, or becoming occluded.

Keep whole-line matching for text flow, and compare spatially separate text fragments for geometry and painted visibility. Fragment boundaries from either exporter map through equal text, preserving trailing-space handling and differing paint-operation batching. Normal word spacing stays together; split/join topology rules are unchanged.

Related: #1609, #1600.

## Validation

- TDD: the unchanged implementation fails the new cell-anchor regressions, including the pinned native trace rows; the updated implementation passes all 98 layout tests.
- Spatial matcher: 6 tests passed. Render comparison: 37 tests passed. Visual PR contract: 78 tests passed.
- Reused the pinned native Excel and converter PDFs from public #982 without rerendering or changing the 0.5pt threshold. Fitted page 2 now exposes all 16 independently measured cell shifts, previously reported as zero. Month, Purchased?, Delivered?, and July match the recorded offsets. The two committed native trace rows expose six shifts.
- Validated the three-page unscaled control: fine-shift counts are 0, 39, and 2. This changes the audit's findings; converter defects remain tracked separately.
- Read-only documentation freshness audit: PASS.

The geometry heuristic requires a separate paint operation and an empty gap of at least one em on either side. Closely packed text without that boundary still needs pixel and crop inspection. The committed traces contain text operations only and are not full-page visibility fixtures.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Internal layout-audit code, trace regressions, and audit documentation only; no converter or PDF rendering changes.
