### PR TITLE
fix: compare composed fill coverage before flagging geometry

### DIFF
--- a/assets/bugfixes/README.md
+++ b/assets/bugfixes/README.md
@@ -53,6 +53,26 @@ difference, missing/extra/reflowed text, changed wraps, a painted-text visibilit
 mismatch, a visible-fill occlusion, or a text or rectangle geometry shift above
 the configured fine or large threshold.
 
+### Composed fill coverage
+
+Rectangle diagnostics retain raw matched dimensions and source-operation
+indices. For a raw fill geometry finding, the layout audit also compares the
+opaque flat-fill layer after rectangular clipping and paint-order composition.
+Only equivalent coverage makes that finding informational; a real difference
+or unmodeled coverage keeps the geometry finding active. Per-edge coverage
+separates an already-painted edge from an error elsewhere in the same fill.
+The fine/coarse gate is unchanged; coincident trace coordinates use the existing
+0.01pt epsilon, clamped to the active gate when it is finer. Each coordinate
+cluster is bounded to that full span.
+
+Images, shading, nonrectangular paths/clips, translucent paint, soft masks, and
+non-normal groups cannot establish flat-fill equivalence. A mask or tile marks
+the page's fill coverage unmodeled because its later graphics-state effect is
+not reconstructed. Later opaque fills may cover unknown image/path paint. Comparisons exceeding 100,000 partition cells also
+remain unmodeled. Text and strokes have their own audits; this fill-layer proof
+does not replace pixel inspection. Raw findings and unknown regions remain in
+the JSON report even when other edges match.
+
 ### Verified reference-exporter differences
 
 Do not change correct Office behavior merely to match a PDF made by another

--- a/scripts/compare_layout.py
+++ b/scripts/compare_layout.py
@@ -25,7 +25,10 @@ visible ink. It then matches lines by their text and reports typed deviations:
   and paint order rather than by the raw rectangle count;
 - a fill/stroke path census plus geometry-aware x/y/size/edge deltas for
   axis-aligned rectangles and straight lines. Touching same-paint operation
-  splits are merged before matching while raw counts stay visible.
+  splits are merged before matching. Raw fill geometry findings become
+  informational only when composed opaque flat-fill coverage is equivalent;
+  differing or unmodeled coverage retains the finding and names the affected
+  regions. Raw dimensions and per-edge coverage remain available.
 
 A noise floor (default 0.12pt — native Word exports quantise coordinates to a
 0.24pt grid; use 0.5 for Excel GT, whose Quartz export rounds every advance to
@@ -249,12 +252,20 @@ class Line:
         return self.x1 - self.x0
 
 
+@dataclass(frozen=True)
+class CoveragePaint:
+    bbox: tuple[float, float, float, float] | None
+    color: tuple[float, float, float] | None
+    known: bool
+
+
 @dataclass
 class PageLayout:
     lines: list[Line]
     rects: list[Rect]
     paints: list[Paint] = field(default_factory=list)
     media_box: tuple[float, float, float, float] | None = None
+    coverage_paints: list[CoveragePaint] | None = None
 
 
 def unescape(text: str) -> str:
@@ -852,6 +863,226 @@ def classify_line_visibility(line: Line, paints: list[Paint]) -> str:
     return "painted"
 
 
+COVERAGE_EVENT_RE = re.compile(
+    r"<(?P<path>fill_path|stroke_path|clip_path|clip_stroke_path)\b[^>]*>"
+    r".*?</(?P=path)>|"
+    r"<(?P<text>fill_text|ignore_text|clip_text|clip_stroke_text)\b[^>]*>"
+    r".*?</(?P=text)>|"
+    r"<(?:fill_image|fill_image_mask|clip_image_mask|fill_shade|pop_clip|group|mask|tile)"
+    r"\b[^>]*>|</(?:group|mask|tile)>",
+    re.S,
+)
+
+
+def collect_fill_coverage(
+    content: str, media_box: tuple[float, float, float, float] | None
+) -> list[CoveragePaint]:
+    """Collect the composed fill layer with conservative clip/opacity handling.
+
+    Text and strokes have separate audits and are not background fills. Images,
+    shading, nonrectangular paths, soft masks, and nonopaque paint cannot prove
+    flat-fill equivalence. Unknown paint remains bounded conservatively and
+    may itself be hidden by a later, fully known opaque rectangle.
+    """
+    paints: list[CoveragePaint] = []
+    clip = media_box
+    clip_known = True
+    clip_stack: list[tuple[tuple[float, float, float, float] | None, bool]] = []
+    # Mask/tile definitions can affect later paint outside their XML block.
+    # Do not infer their graphics-state lifetime from group nesting.
+    group_known = not bool(re.search(r"<(?:begin_|end_)?(?:mask|tile)\b", content))
+    group_stack: list[bool] = []
+    for event in COVERAGE_EVENT_RE.finditer(content):
+        operation = event.group()
+        tag_match = re.match(r"<(/?)(\w+)\b([^>]*)>", operation)
+        assert tag_match is not None
+        closing, tag, attrs = tag_match.groups()
+        if tag in {"group", "mask", "tile"}:
+            if closing:
+                group_known = group_stack.pop() if group_stack else False
+            else:
+                group_stack.append(group_known)
+                group_known = (
+                    group_known and tag == "group" and parse_alpha(attrs) == 1.0
+                    and 'blendmode="Normal"' in attrs and 'knockout="1"' not in attrs
+                )
+            continue
+        if tag == "pop_clip":
+            clip, clip_known = clip_stack.pop() if clip_stack else (media_box, False)
+            continue
+        if tag.startswith("clip_"):
+            clip_stack.append((clip, clip_known))
+            bbox = None
+            if tag == "clip_path":
+                matched = CLIP_PATH_RE.fullmatch(operation)
+                assert matched is not None
+                bbox = axis_aligned_rect_bbox(*matched.groups())
+            if bbox is None:
+                clip_known = False
+                # An image mask's transformed unit square is a conservative
+                # bound even though its internal alpha coverage is unknown.
+                if tag == "clip_image_mask":
+                    transform = parse_transform(attrs)
+                    if transform is not None:
+                        bbox = transformed_bbox(transform, [(0, 0), (1, 0), (1, 1), (0, 1)])
+            if bbox is not None:
+                clip = bbox if clip is None else intersect_bboxes(clip, bbox)
+            continue
+        if tag in {"fill_text", "ignore_text", "stroke_path"}:
+            continue
+        if parse_alpha(attrs) == 0.0:
+            continue
+        bbox = None
+        color = None
+        known = False
+        if tag == "fill_path":
+            matched = PATH_RE.fullmatch(operation)
+            assert matched is not None
+            _, path_attrs, path_body = matched.groups()
+            bbox = axis_aligned_rect_bbox(path_attrs, path_body)
+            color = parse_rgb(attrs)
+            known = bbox is not None and color is not None and parse_alpha(attrs) == 1.0
+            if bbox is None:
+                # A Bezier curve stays inside its control-point hull. Its
+                # complete vertex/control-point box bounds unknown fill ink
+                # without poisoning unrelated worksheet regions.
+                transform = parse_transform(path_attrs)
+                xs = [float(value) for value in re.findall(r'\bx(?:1|2)?="([-0-9.e]+)"', path_body)]
+                ys = [float(value) for value in re.findall(r'\by(?:1|2)?="([-0-9.e]+)"', path_body)]
+                if transform is not None and xs and len(xs) == len(ys):
+                    bbox = transformed_bbox(transform, list(zip(xs, ys)))
+        elif tag in {"fill_image", "fill_image_mask"}:
+            transform = parse_transform(attrs)
+            if transform is not None:
+                bbox = transformed_bbox(transform, [(0, 0), (1, 0), (1, 1), (0, 1)])
+        if bbox is None:
+            bbox = clip
+        elif clip is not None:
+            bbox = intersect_bboxes(bbox, clip)
+        if bbox is not None and (bbox[0] >= bbox[2] or bbox[1] >= bbox[3]):
+            continue
+        paints.append(CoveragePaint(bbox, color, known and clip_known and group_known))
+    return paints
+
+
+def compare_fill_coverage(
+    gt: PageLayout,
+    out: PageLayout,
+    sample: dict,
+    coordinate_epsilon_pt: float = RECT_COVERAGE_EPSILON_PT,
+) -> dict:
+    """Prove equivalence only when every resolved fill region agrees.
+
+    Keep the existing rectangle gate. Its raw finding can be explained only
+    by a full coverage proof; different or unmodeled coverage retains it.
+    Coincident edges use the existing trace epsilon, clamped by the caller
+    to the active fine/coarse gate so normalization cannot widen that gate.
+    """
+    if gt.coverage_paints is None or out.coverage_paints is None:
+        return {"status": "unmodeled", "reason": "fill trace unavailable"}
+    boxes = [sample["gt_bbox"], sample["out_bbox"]]
+    if any(min(box[2] - box[0], box[3] - box[1]) <= coordinate_epsilon_pt for box in boxes):
+        return {"status": "unmodeled", "reason": "primitive thinner than trace epsilon"}
+    region = (min(b[0] for b in boxes), min(b[1] for b in boxes),
+              max(b[2] for b in boxes), max(b[3] for b in boxes))
+    layers: list[list[CoveragePaint]] = []
+    for page in [gt, out]:
+        assert page.coverage_paints is not None
+        layers.append([
+            CoveragePaint(region if paint.bbox is None else intersect_bboxes(region, paint.bbox),
+                          paint.color, paint.known)
+            for paint in page.coverage_paints
+            if paint.bbox is None or bboxes_overlap(region, paint.bbox)
+        ])
+    def snap_coordinates(values: set[float]) -> dict[float, float]:
+        groups: list[list[float]] = []
+        for value in sorted(values):
+            if not groups or value - groups[-1][0] > coordinate_epsilon_pt:
+                groups.append([])
+            groups[-1].append(value)
+        return {value: statistics.median(group) for group in groups for value in group}
+
+    # Normalize coincident trace edges before partitioning. Skipping every
+    # thin partition cell could otherwise hide a broad defect subdivided by
+    # many unrelated edges. A cluster's full span is bounded by the epsilon;
+    # close-coordinate chains cannot collapse a material-width region.
+    x_map = snap_coordinates({x for box in boxes for x in (box[0], box[2])} | {
+        x for layer in layers for paint in layer for x in (paint.bbox[0], paint.bbox[2])
+    })
+    y_map = snap_coordinates({y for box in boxes for y in (box[1], box[3])} | {
+        y for layer in layers for paint in layer for y in (paint.bbox[1], paint.bbox[3])
+    })
+    boxes = [[x_map[b[0]], y_map[b[1]], x_map[b[2]], y_map[b[3]]] for b in boxes]
+    region = (x_map[region[0]], y_map[region[1]], x_map[region[2]], y_map[region[3]])
+    layers = [[
+        CoveragePaint((x_map[p.bbox[0]], y_map[p.bbox[1]], x_map[p.bbox[2]], y_map[p.bbox[3]]),
+                      p.color, p.known)
+        for p in layer
+    ] for layer in layers]
+    xs = sorted(set(x_map.values()))
+    ys = sorted(set(y_map.values()))
+    if (len(xs) - 1) * (len(ys) - 1) > 100_000:
+        return {"status": "unmodeled", "reason": "coverage partition exceeds 100000 cells"}
+
+    def visible_color(layer: list[CoveragePaint], x: float, y: float) -> tuple:
+        for paint in reversed(layer):
+            assert paint.bbox is not None
+            if paint.bbox[0] < x < paint.bbox[2] and paint.bbox[1] < y < paint.bbox[3]:
+                return paint.known, paint.color
+        return True, None
+
+    edge_regions = {
+        "left": (min(b[0] for b in boxes), region[1], max(b[0] for b in boxes), region[3]),
+        "right": (min(b[2] for b in boxes), region[1], max(b[2] for b in boxes), region[3]),
+        "top": (region[0], min(b[1] for b in boxes), region[2], max(b[1] for b in boxes)),
+        "bottom": (region[0], min(b[3] for b in boxes), region[2], max(b[3] for b in boxes)),
+    }
+    edge_status = {
+        edge: "equivalent" if min(box[2] - box[0], box[3] - box[1]) > coordinate_epsilon_pt
+        else "unchanged"
+        for edge, box in edge_regions.items()
+    }
+
+    def mark_edges(box: tuple[float, float, float, float], status: str) -> None:
+        for edge, edge_box in edge_regions.items():
+            if edge_status[edge] == "unchanged" or not bboxes_overlap(box, edge_box):
+                continue
+            if edge_status[edge] != "different":
+                edge_status[edge] = status
+
+    mismatches: list[list[float]] = []
+    unmodeled_samples: list[list[float]] = []
+    mismatch_area = 0.0
+    unknown_area = 0.0
+    for x0, x1 in zip(xs, xs[1:]):
+        for y0, y1 in zip(ys, ys[1:]):
+            colors = [visible_color(layer, (x0 + x1) / 2, (y0 + y1) / 2) for layer in layers]
+            area = (x1 - x0) * (y1 - y0)
+            if not all(known for known, _ in colors):
+                unknown_area += area
+                if len(unmodeled_samples) < RECT_SAMPLE_LIMIT:
+                    unmodeled_samples.append([x0, y0, x1, y1])
+                mark_edges((x0, y0, x1, y1), "unmodeled")
+                continue
+            first, second = colors[0][1], colors[1][1]
+            equal = first is second or (
+                first is not None and second is not None and color_delta(first, second) <= 1e-6
+            )
+            if not equal:
+                mismatch_area += area
+                mark_edges((x0, y0, x1, y1), "different")
+                if len(mismatches) < RECT_SAMPLE_LIMIT:
+                    mismatches.append([x0, y0, x1, y1])
+    return {
+        "status": "different" if mismatch_area else "unmodeled" if unknown_area else "equivalent",
+        "mismatch_area_pt2": mismatch_area,
+        "unmodeled_area_pt2": unknown_area,
+        "unmodeled_samples": unmodeled_samples,
+        "mismatch_samples": mismatches,
+        "raw_edge_coverage": edge_status,
+    }
+
+
 def parse_trace(trace_xml: str) -> list[PageLayout]:
     pages: list[PageLayout] = []
     for page_match in PAGE_RE.finditer(trace_xml):
@@ -1017,6 +1248,7 @@ def parse_trace(trace_xml: str) -> list[PageLayout]:
                 rects=rects,
                 paints=paints,
                 media_box=media_box,
+                coverage_paints=collect_fill_coverage(content, media_box),
             )
         )
     return pages
@@ -1746,10 +1978,19 @@ def diff_page(
         key=lambda sample: (-sample["max_abs_delta"], sample["gt_indices"])
     )
     rect_geometry_threshold = fine_shift if fine_shift is not None else large_shift
-    rect_geometry_mismatches = [
-        sample
-        for sample in rect_samples
+    raw_geometry_mismatches = [
+        sample for sample in rect_samples
         if sample["max_abs_delta"] > rect_geometry_threshold
+    ]
+    for sample in raw_geometry_mismatches:
+        if sample["kind"] == "fill":
+            sample["visible_coverage"] = compare_fill_coverage(
+                gt, out, sample,
+                coordinate_epsilon_pt=min(RECT_COVERAGE_EPSILON_PT, rect_geometry_threshold),
+            )
+    rect_geometry_mismatches = [
+        sample for sample in raw_geometry_mismatches
+        if sample.get("visible_coverage", {}).get("status") != "equivalent"
     ]
     rect_center_deltas = [
         max(abs(sample["center_dx"]), abs(sample["center_dy"]))
@@ -1827,6 +2068,14 @@ def diff_page(
             ),
             "mean_center_delta": stats(rect_center_deltas)["mean_abs"],
             "geometry_threshold": rect_geometry_threshold,
+            "raw_geometry_mismatch_count": len(raw_geometry_mismatches),
+            "raw_geometry_mismatch_samples": raw_geometry_mismatches[:RECT_SAMPLE_LIMIT],
+            "coverage_equivalent_count": len(raw_geometry_mismatches) - len(rect_geometry_mismatches),
+            "coverage_unmodeled_count": sum(
+                sample.get("visible_coverage", {}).get("status") == "unmodeled"
+                or sample.get("visible_coverage", {}).get("unmodeled_area_pt2", 0) > 0
+                for sample in raw_geometry_mismatches
+            ),
             "geometry_mismatch_count": len(rect_geometry_mismatches),
             "geometry_mismatch_samples": rect_geometry_mismatches[:RECT_SAMPLE_LIMIT],
             "samples": rect_samples[:RECT_SAMPLE_LIMIT],
@@ -1950,9 +2199,15 @@ def render_reading(vectors: list[dict]) -> str:
             )
         if vector["rects"]["geometry_mismatch_count"]:
             examples = "; ".join(
-                f"{item['kind']} GT {item['gt_bbox']} -> output {item['out_bbox']} "
-                f"(dx {item['dx']:+.2f}, dy {item['dy']:+.2f}, "
-                f"dw {item['dwidth']:+.2f}, dh {item['dheight']:+.2f}pt)"
+                (
+                    f"fill coverage {item['visible_coverage']['status']}: "
+                    f"{item['visible_coverage'].get('mismatch_samples', [])}; "
+                    f"raw edge coverage {item['visible_coverage'].get('raw_edge_coverage', {})}"
+                    if "visible_coverage" in item else
+                    f"{item['kind']} GT {item['gt_bbox']} -> output {item['out_bbox']} "
+                    f"(dx {item['dx']:+.2f}, dy {item['dy']:+.2f}, "
+                    f"dw {item['dwidth']:+.2f}, dh {item['dheight']:+.2f}pt)"
+                )
                 for item in vector["rects"]["geometry_mismatch_samples"]
             )
             page_notes.append(
@@ -1961,6 +2216,15 @@ def render_reading(vectors: list[dict]) -> str:
                 f"{examples}. Inspect the recorded source operation indices and corresponding "
                 "render cluster"
             )
+        equivalent = vector["rects"].get("coverage_equivalent_count", 0)
+        unmodeled = vector["rects"].get("coverage_unmodeled_count", 0)
+        if equivalent:
+            page_notes.append(
+                f"{equivalent} raw fill geometry finding(s) explained by equivalent composed "
+                "coverage; raw dimensions remain informational diagnostics"
+            )
+        if unmodeled:
+            page_notes.append(f"{unmodeled} fill coverage comparison(s) unmodeled; raw findings retained")
         if not page_notes:
             page_notes.append("no deviation past the noise floor")
         lines.append(f"- page {index}: " + "; ".join(page_notes))

--- a/scripts/tests/fixtures/issue-1608/README.md
+++ b/scripts/tests/fixtures/issue-1608/README.md
@@ -1,0 +1,33 @@
+# Composed fill coverage (#1608)
+
+These traces preserve page 2's paint, clip, and group operations from the public
+[Gift Budget workbook in #982](https://github.com/developer0hye/office2pdf/issues/982).
+Text operations were removed; this is a fill-layer fixture, not a renderable
+full-page document. Image operators retain placement metadata only.
+
+Source: [Gift Budget and Tracker1.xlsx](https://github.com/user-attachments/files/30941041/Gift.Budget.and.Tracker1.xlsx).
+SHA-256: `25f5dc75dab19ea12042979a61842314ddc226e3e45d447e36b2a2a104112613`.
+Native exporter: Microsoft Excel for Mac 16.112. Converter commit:
+`6d78f1aa26f7ac3f12b4602e77afdf8ff506d1da`, with the Excel bundled fonts.
+
+PDF SHA-256 values:
+
+- Native: `2aa03cafa6a156d553a2f1e03e0458257319ff6416a188f1132ce7817ecaeae1`.
+- Output: `81b93282a27291eb3ebf77ca02229a4d36e5dabc9916b742a083ce0130763c25`.
+
+Reproduce with `mutool draw -F trace -o trace.xml FILE.pdf`: keep page 2's
+operations matched by `compare_layout.COVERAGE_EVENT_RE`, omit `fill_text` and
+`ignore_text`, retain their surrounding clip push/pop operations, and preserve
+the page media box inside a trace document.
+
+The first rose band has a raw right-edge deficit of 0.82pt, but composed
+coverage proves that edge equivalent. Its left-side overpaint and lower-left
+ownership error remain visible (#1599), so its geometry finding stays active.
+The report names those actual differing regions instead of claiming the right
+extension is missing. Separate synthetic tests cover fully equivalent split
+fills, clipping, opaque occlusion, unknown images/opacity, and dense coordinate
+partitions that must not hide a material overlap.
+
+```sh
+python3 -m unittest discover -s scripts/tests -p 'test_compare_layout.py'
+```

--- a/scripts/tests/fixtures/issue-1608/native.xml
+++ b/scripts/tests/fixtures/issue-1608/native.xml
@@ -1,0 +1,1414 @@
+<document>
+<page number="2" mediabox="0 0 1191 842">
+<group bbox="0 0 1191 842" isolated="1" knockout="0" blendmode="Normal" alpha="1">
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="49.2" y="21.18"/>
+        <lineto x="1141.44" y="21.18"/>
+        <lineto x="1141.44" y="805.92"/>
+        <lineto x="49.2" y="805.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="49.2" y="21.18"/>
+        <lineto x="1141.44" y="21.18"/>
+        <lineto x="1141.44" y="805.92"/>
+        <lineto x="49.2" y="805.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="49.2" y="21.18"/>
+        <lineto x="1141.44" y="21.18"/>
+        <lineto x="1141.44" y="805.92"/>
+        <lineto x="49.2" y="805.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="63.14" y="781.32"/>
+            <lineto x="277.16" y="781.32"/>
+            <lineto x="277.16" y="740.32"/>
+            <lineto x="63.14" y="740.32"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".854902 .7137255 .7294118" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="276.34" y="781.32"/>
+            <lineto x="1125.86" y="781.32"/>
+            <lineto x="1125.86" y="740.32"/>
+            <lineto x="276.34" y="740.32"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="63.14" y="741.14"/>
+            <lineto x="277.16" y="741.14"/>
+            <lineto x="277.16" y="427.9"/>
+            <lineto x="63.14" y="427.9"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".854902 .7137255 .7294118" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="276.34" y="468.9"/>
+            <lineto x="1125.86" y="468.9"/>
+            <lineto x="1125.86" y="427.9"/>
+            <lineto x="276.34" y="427.9"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="63.14" y="428.72"/>
+            <lineto x="277.16" y="428.72"/>
+            <lineto x="277.16" y="363.12"/>
+            <lineto x="63.14" y="363.12"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".2392157 .1686275 .1764706" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="341.94" y="388.54"/>
+            <lineto x="408.36" y="388.54"/>
+            <lineto x="408.36" y="363.12"/>
+            <lineto x="341.94" y="363.12"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="63.14" y="363.94"/>
+            <lineto x="277.16" y="363.94"/>
+            <lineto x="277.16" y="338.52"/>
+            <lineto x="63.14" y="338.52"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".3647059 .2156863 .3294118" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="341.94" y="363.94"/>
+            <lineto x="408.36" y="363.94"/>
+            <lineto x="408.36" y="338.52"/>
+            <lineto x="341.94" y="338.52"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="63.14" y="339.34"/>
+            <lineto x="277.16" y="339.34"/>
+            <lineto x="277.16" y="313.92"/>
+            <lineto x="63.14" y="313.92"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".4784314 .3882353 .4117647" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="341.94" y="339.34"/>
+            <lineto x="408.36" y="339.34"/>
+            <lineto x="408.36" y="313.92"/>
+            <lineto x="341.94" y="313.92"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="63.14" y="314.74"/>
+            <lineto x="277.16" y="314.74"/>
+            <lineto x="277.16" y="289.32"/>
+            <lineto x="63.14" y="289.32"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".2392157 .1686275 .1764706" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="341.94" y="314.74"/>
+            <lineto x="408.36" y="314.74"/>
+            <lineto x="408.36" y="289.32"/>
+            <lineto x="341.94" y="289.32"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="63.14" y="290.14"/>
+            <lineto x="277.16" y="290.14"/>
+            <lineto x="277.16" y="264.72"/>
+            <lineto x="63.14" y="264.72"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".3647059 .2156863 .3294118" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="341.94" y="290.14"/>
+            <lineto x="408.36" y="290.14"/>
+            <lineto x="408.36" y="264.72"/>
+            <lineto x="341.94" y="264.72"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="473.96" y="388.54"/>
+        <lineto x="538.74" y="388.54"/>
+        <lineto x="538.74" y="427.90003"/>
+        <lineto x="473.96" y="427.90003"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="473.96" y="388.54"/>
+        <lineto x="538.74" y="388.54"/>
+        <lineto x="538.74" y="427.90003"/>
+        <lineto x="473.96" y="427.90003"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="388.54"/>
+        <lineto x="1134.06" y="388.54"/>
+        <lineto x="1134.06" y="427.90003"/>
+        <lineto x="55.76" y="427.90003"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="388.54"/>
+        <lineto x="1134.06" y="388.54"/>
+        <lineto x="1134.06" y="427.90003"/>
+        <lineto x="55.76" y="427.90003"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="388.54"/>
+        <lineto x="1134.06" y="388.54"/>
+        <lineto x="1134.06" y="427.90003"/>
+        <lineto x="55.76" y="427.90003"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="388.54"/>
+        <lineto x="1134.06" y="388.54"/>
+        <lineto x="1134.06" y="427.90003"/>
+        <lineto x="55.76" y="427.90003"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="736.36" y="388.54"/>
+        <lineto x="801.14" y="388.54"/>
+        <lineto x="801.14" y="427.90003"/>
+        <lineto x="736.36" y="427.90003"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="736.36" y="388.54"/>
+        <lineto x="801.14" y="388.54"/>
+        <lineto x="801.14" y="427.90003"/>
+        <lineto x="736.36" y="427.90003"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="245.04"/>
+        <lineto x="1134.06" y="245.04"/>
+        <lineto x="1134.06" y="787.88"/>
+        <lineto x="55.76" y="787.88"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="363.94"/>
+        <lineto x="1134.06" y="363.94"/>
+        <lineto x="1134.06" y="387.72"/>
+        <lineto x="55.76" y="387.72"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="363.94"/>
+        <lineto x="1134.06" y="363.94"/>
+        <lineto x="1134.06" y="387.72"/>
+        <lineto x="55.76" y="387.72"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="363.94"/>
+        <lineto x="1134.06" y="363.94"/>
+        <lineto x="1134.06" y="387.72"/>
+        <lineto x="55.76" y="387.72"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="363.94"/>
+        <lineto x="1134.06" y="363.94"/>
+        <lineto x="1134.06" y="387.72"/>
+        <lineto x="55.76" y="387.72"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="363.94"/>
+        <lineto x="1134.06" y="363.94"/>
+        <lineto x="1134.06" y="387.72"/>
+        <lineto x="55.76" y="387.72"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="363.94"/>
+        <lineto x="1134.06" y="363.94"/>
+        <lineto x="1134.06" y="387.72"/>
+        <lineto x="55.76" y="387.72"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="363.94"/>
+        <lineto x="1134.06" y="363.94"/>
+        <lineto x="1134.06" y="387.72"/>
+        <lineto x="55.76" y="387.72"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="363.94"/>
+        <lineto x="1134.06" y="363.94"/>
+        <lineto x="1134.06" y="387.72"/>
+        <lineto x="55.76" y="387.72"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="363.94"/>
+        <lineto x="1134.06" y="363.94"/>
+        <lineto x="1134.06" y="387.72"/>
+        <lineto x="55.76" y="387.72"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="363.94"/>
+        <lineto x="1134.06" y="363.94"/>
+        <lineto x="1134.06" y="387.72"/>
+        <lineto x="55.76" y="387.72"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="363.94"/>
+        <lineto x="1134.06" y="363.94"/>
+        <lineto x="1134.06" y="387.72"/>
+        <lineto x="55.76" y="387.72"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="363.94"/>
+        <lineto x="1134.06" y="363.94"/>
+        <lineto x="1134.06" y="387.72"/>
+        <lineto x="55.76" y="387.72"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="339.34"/>
+        <lineto x="1134.06" y="339.34"/>
+        <lineto x="1134.06" y="363.12"/>
+        <lineto x="55.76" y="363.12"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="339.34"/>
+        <lineto x="1134.06" y="339.34"/>
+        <lineto x="1134.06" y="363.12"/>
+        <lineto x="55.76" y="363.12"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="339.34"/>
+        <lineto x="1134.06" y="339.34"/>
+        <lineto x="1134.06" y="363.12"/>
+        <lineto x="55.76" y="363.12"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="339.34"/>
+        <lineto x="1134.06" y="339.34"/>
+        <lineto x="1134.06" y="363.12"/>
+        <lineto x="55.76" y="363.12"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="339.34"/>
+        <lineto x="1134.06" y="339.34"/>
+        <lineto x="1134.06" y="363.12"/>
+        <lineto x="55.76" y="363.12"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="339.34"/>
+        <lineto x="1134.06" y="339.34"/>
+        <lineto x="1134.06" y="363.12"/>
+        <lineto x="55.76" y="363.12"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="339.34"/>
+        <lineto x="1134.06" y="339.34"/>
+        <lineto x="1134.06" y="363.12"/>
+        <lineto x="55.76" y="363.12"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="339.34"/>
+        <lineto x="1134.06" y="339.34"/>
+        <lineto x="1134.06" y="363.12"/>
+        <lineto x="55.76" y="363.12"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="339.34"/>
+        <lineto x="1134.06" y="339.34"/>
+        <lineto x="1134.06" y="363.12"/>
+        <lineto x="55.76" y="363.12"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="339.34"/>
+        <lineto x="1134.06" y="339.34"/>
+        <lineto x="1134.06" y="363.12"/>
+        <lineto x="55.76" y="363.12"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="339.34"/>
+        <lineto x="1134.06" y="339.34"/>
+        <lineto x="1134.06" y="363.12"/>
+        <lineto x="55.76" y="363.12"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="339.34"/>
+        <lineto x="1134.06" y="339.34"/>
+        <lineto x="1134.06" y="363.12"/>
+        <lineto x="55.76" y="363.12"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="314.74"/>
+        <lineto x="1134.06" y="314.74"/>
+        <lineto x="1134.06" y="338.52"/>
+        <lineto x="55.76" y="338.52"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="314.74"/>
+        <lineto x="1134.06" y="314.74"/>
+        <lineto x="1134.06" y="338.52"/>
+        <lineto x="55.76" y="338.52"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="314.74"/>
+        <lineto x="1134.06" y="314.74"/>
+        <lineto x="1134.06" y="338.52"/>
+        <lineto x="55.76" y="338.52"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="314.74"/>
+        <lineto x="1134.06" y="314.74"/>
+        <lineto x="1134.06" y="338.52"/>
+        <lineto x="55.76" y="338.52"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="314.74"/>
+        <lineto x="1134.06" y="314.74"/>
+        <lineto x="1134.06" y="338.52"/>
+        <lineto x="55.76" y="338.52"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="314.74"/>
+        <lineto x="1134.06" y="314.74"/>
+        <lineto x="1134.06" y="338.52"/>
+        <lineto x="55.76" y="338.52"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="314.74"/>
+        <lineto x="1134.06" y="314.74"/>
+        <lineto x="1134.06" y="338.52"/>
+        <lineto x="55.76" y="338.52"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="314.74"/>
+        <lineto x="1134.06" y="314.74"/>
+        <lineto x="1134.06" y="338.52"/>
+        <lineto x="55.76" y="338.52"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="314.74"/>
+        <lineto x="1134.06" y="314.74"/>
+        <lineto x="1134.06" y="338.52"/>
+        <lineto x="55.76" y="338.52"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="314.74"/>
+        <lineto x="1134.06" y="314.74"/>
+        <lineto x="1134.06" y="338.52"/>
+        <lineto x="55.76" y="338.52"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="314.74"/>
+        <lineto x="1134.06" y="314.74"/>
+        <lineto x="1134.06" y="338.52"/>
+        <lineto x="55.76" y="338.52"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="314.74"/>
+        <lineto x="1134.06" y="314.74"/>
+        <lineto x="1134.06" y="338.52"/>
+        <lineto x="55.76" y="338.52"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="290.14"/>
+        <lineto x="1134.06" y="290.14"/>
+        <lineto x="1134.06" y="313.92"/>
+        <lineto x="55.76" y="313.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="290.14"/>
+        <lineto x="1134.06" y="290.14"/>
+        <lineto x="1134.06" y="313.92"/>
+        <lineto x="55.76" y="313.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="290.14"/>
+        <lineto x="1134.06" y="290.14"/>
+        <lineto x="1134.06" y="313.92"/>
+        <lineto x="55.76" y="313.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="290.14"/>
+        <lineto x="1134.06" y="290.14"/>
+        <lineto x="1134.06" y="313.92"/>
+        <lineto x="55.76" y="313.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="290.14"/>
+        <lineto x="1134.06" y="290.14"/>
+        <lineto x="1134.06" y="313.92"/>
+        <lineto x="55.76" y="313.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="290.14"/>
+        <lineto x="1134.06" y="290.14"/>
+        <lineto x="1134.06" y="313.92"/>
+        <lineto x="55.76" y="313.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="290.14"/>
+        <lineto x="1134.06" y="290.14"/>
+        <lineto x="1134.06" y="313.92"/>
+        <lineto x="55.76" y="313.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="290.14"/>
+        <lineto x="1134.06" y="290.14"/>
+        <lineto x="1134.06" y="313.92"/>
+        <lineto x="55.76" y="313.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="290.14"/>
+        <lineto x="1134.06" y="290.14"/>
+        <lineto x="1134.06" y="313.92"/>
+        <lineto x="55.76" y="313.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="290.14"/>
+        <lineto x="1134.06" y="290.14"/>
+        <lineto x="1134.06" y="313.92"/>
+        <lineto x="55.76" y="313.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="290.14"/>
+        <lineto x="1134.06" y="290.14"/>
+        <lineto x="1134.06" y="313.92"/>
+        <lineto x="55.76" y="313.92"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="265.54"/>
+        <lineto x="1134.06" y="265.54"/>
+        <lineto x="1134.06" y="289.32"/>
+        <lineto x="55.76" y="289.32"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="265.54"/>
+        <lineto x="1134.06" y="265.54"/>
+        <lineto x="1134.06" y="289.32"/>
+        <lineto x="55.76" y="289.32"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="265.54"/>
+        <lineto x="1134.06" y="265.54"/>
+        <lineto x="1134.06" y="289.32"/>
+        <lineto x="55.76" y="289.32"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="265.54"/>
+        <lineto x="1134.06" y="265.54"/>
+        <lineto x="1134.06" y="289.32"/>
+        <lineto x="55.76" y="289.32"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="265.54"/>
+        <lineto x="1134.06" y="265.54"/>
+        <lineto x="1134.06" y="289.32"/>
+        <lineto x="55.76" y="289.32"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="265.54"/>
+        <lineto x="1134.06" y="265.54"/>
+        <lineto x="1134.06" y="289.32"/>
+        <lineto x="55.76" y="289.32"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="265.54"/>
+        <lineto x="1134.06" y="265.54"/>
+        <lineto x="1134.06" y="289.32"/>
+        <lineto x="55.76" y="289.32"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="265.54"/>
+        <lineto x="1134.06" y="265.54"/>
+        <lineto x="1134.06" y="289.32"/>
+        <lineto x="55.76" y="289.32"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="265.54"/>
+        <lineto x="1134.06" y="265.54"/>
+        <lineto x="1134.06" y="289.32"/>
+        <lineto x="55.76" y="289.32"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="265.54"/>
+        <lineto x="1134.06" y="265.54"/>
+        <lineto x="1134.06" y="289.32"/>
+        <lineto x="55.76" y="289.32"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="55.76" y="265.54"/>
+        <lineto x="1134.06" y="265.54"/>
+        <lineto x="1134.06" y="289.32"/>
+        <lineto x="55.76" y="289.32"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="63.96" y="700.96"/>
+        <lineto x="259.94" y="700.96"/>
+        <lineto x="259.94" y="780.5"/>
+        <lineto x="63.96" y="780.5"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="63.96" y="700.96"/>
+        <lineto x="259.94" y="700.96"/>
+        <lineto x="259.94" y="780.5"/>
+        <lineto x="63.96" y="780.5"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="277.16" y="741.14"/>
+        <lineto x="1125.04" y="741.14"/>
+        <lineto x="1125.04" y="780.5"/>
+        <lineto x="277.16" y="780.5"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="63.96" y="468.9"/>
+        <lineto x="259.94" y="468.9"/>
+        <lineto x="259.94" y="700.14"/>
+        <lineto x="63.96" y="700.14"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="63.96" y="468.9"/>
+        <lineto x="259.94" y="468.9"/>
+        <lineto x="259.94" y="700.14"/>
+        <lineto x="63.96" y="700.14"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="63.96" y="468.9"/>
+        <lineto x="259.94" y="468.9"/>
+        <lineto x="259.94" y="700.14"/>
+        <lineto x="63.96" y="700.14"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="63.96" y="468.9"/>
+        <lineto x="259.94" y="468.9"/>
+        <lineto x="259.94" y="700.14"/>
+        <lineto x="63.96" y="700.14"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="63.96" y="468.9"/>
+        <lineto x="259.94" y="468.9"/>
+        <lineto x="259.94" y="700.14"/>
+        <lineto x="63.96" y="700.14"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="63.96" y="468.9"/>
+        <lineto x="259.94" y="468.9"/>
+        <lineto x="259.94" y="700.14"/>
+        <lineto x="63.96" y="700.14"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="63.96" y="468.9"/>
+        <lineto x="259.94" y="468.9"/>
+        <lineto x="259.94" y="700.14"/>
+        <lineto x="63.96" y="700.14"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="63.96" y="468.9"/>
+        <lineto x="259.94" y="468.9"/>
+        <lineto x="259.94" y="700.14"/>
+        <lineto x="63.96" y="700.14"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="63.96" y="468.9"/>
+        <lineto x="259.94" y="468.9"/>
+        <lineto x="259.94" y="700.14"/>
+        <lineto x="63.96" y="700.14"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="277.16" y="428.72"/>
+        <lineto x="1125.04" y="428.72"/>
+        <lineto x="1125.04" y="468.08003"/>
+        <lineto x="277.16" y="468.08003"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="54.94" y="245.04"/>
+        <lineto x="1134.0599" y="245.04"/>
+        <lineto x="1134.0599" y="788.69998"/>
+        <lineto x="54.94" y="788.69998"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color="1 1 1" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="289.4497" y="724.7297"/>
+            <lineto x="1122.552" y="724.7297"/>
+            <lineto x="1122.552" y="472.1917"/>
+            <lineto x="289.4497" y="472.1917"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<stroke_path linewidth="9360" miterlimit="10" linecap="0,0,0" linejoin="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".00006456693 0 0 .00006456693 318.2494 126.29028">
+            <moveto x="0" y="2831940"/>
+            <lineto x="12317176" y="2831940"/>
+            <moveto x="0" y="2527140"/>
+            <lineto x="12317176" y="2527140"/>
+            <moveto x="0" y="2209640"/>
+            <lineto x="12317176" y="2209640"/>
+            <moveto x="0" y="1892140"/>
+            <lineto x="12317176" y="1892140"/>
+            <moveto x="0" y="1574640"/>
+            <lineto x="12317176" y="1574640"/>
+            <moveto x="0" y="1257140"/>
+            <lineto x="12317176" y="1257140"/>
+            <moveto x="0" y="939640"/>
+            <lineto x="12317176" y="939640"/>
+            <moveto x="0" y="634840"/>
+            <lineto x="12317176" y="634840"/>
+            <moveto x="0" y="317340"/>
+            <lineto x="12317176" y="317340"/>
+            <moveto x="0" y="0"/>
+            <lineto x="12317176" y="0"/>
+        </stroke_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="318.16" y="512.36"/>
+        <lineto x="1113.56" y="512.36"/>
+        <lineto x="1113.56" y="715.72"/>
+        <lineto x="318.16" y="715.72"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".2392157 .1686275 .1764706" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="337.84" y="532.86"/>
+            <lineto x="364.9" y="532.86"/>
+            <lineto x="364.9" y="512.2023"/>
+            <lineto x="337.84" y="512.2023"/>
+            <closepath/>
+            <moveto x="669.12" y="563.2"/>
+            <lineto x="696.18" y="563.2"/>
+            <lineto x="696.18" y="512.2023"/>
+            <lineto x="669.12" y="512.2023"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="318.16" y="512.36"/>
+        <lineto x="1113.56" y="512.36"/>
+        <lineto x="1113.56" y="715.72"/>
+        <lineto x="318.16" y="715.72"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".4784314 .3882353 .4117647" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="735.54" y="512.2023"/>
+            <lineto x="762.6" y="512.2023"/>
+            <lineto x="762.6" y="563.2"/>
+            <lineto x="735.54" y="563.2"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="318.16" y="512.36"/>
+        <lineto x="1113.56" y="512.36"/>
+        <lineto x="1113.56" y="715.72"/>
+        <lineto x="318.16" y="715.72"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".3647059 .2156863 .3294118" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="537.1" y="532.86"/>
+            <lineto x="563.34" y="532.86"/>
+            <lineto x="563.34" y="512.2023"/>
+            <lineto x="537.1" y="512.2023"/>
+            <closepath/>
+            <moveto x="669.12" y="664.88"/>
+            <lineto x="696.18" y="664.88"/>
+            <lineto x="696.18" y="563.2"/>
+            <lineto x="669.12" y="563.2"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<stroke_path linewidth="9360" miterlimit="10" linecap="0,0,0" linejoin="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".00006456693 0 0 .00006456693 318.2494 329.79774">
+            <moveto x="0" y="0"/>
+            <lineto x="12317176" y="1"/>
+        </stroke_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="318.16" y="512.36"/>
+        <lineto x="1113.56" y="512.36"/>
+        <lineto x="1113.56" y="715.72"/>
+        <lineto x="318.16" y="715.72"/>
+        <closepath/>
+    </clip_path>
+<stroke_path linewidth="28440" miterlimit="10" linecap="1,1,1" linejoin="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color="0 .5333334 .5372549" ri="1" bp="1" op="0" opm="0" transform=".00006456693 0 0 .00006456693 351.3861 146.64112">
+            <moveto x="0" y="2364352"/>
+            <lineto x="1022100" y="2836695"/>
+            <lineto x="2050800" y="2836695"/>
+            <lineto x="3079500" y="2516752"/>
+            <lineto x="4108200" y="2836695"/>
+            <lineto x="5136900" y="0"/>
+            <lineto x="6152900" y="1729352"/>
+            <lineto x="7181600" y="2836695"/>
+            <lineto x="8210300" y="2836695"/>
+            <lineto x="9239000" y="2836695"/>
+            <lineto x="10267700" y="2836695"/>
+            <lineto x="11290744" y="2836695"/>
+        </stroke_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<clip_image_mask transform="5.74 0 0 5.74 348.5 296.02003" width="7" height="7"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" ri="0" bp="1" op="0" opm="0" transform="5.74 0 0 5.74 348.5 296.02003" width="7" height="7"/>
+<pop_clip/>
+<clip_image_mask transform="5.74 0 0 5.74 414.1 326.36003" width="7" height="7"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" ri="0" bp="1" op="0" opm="0" transform="5.74 0 0 5.74 414.1 326.36003" width="7" height="7"/>
+<pop_clip/>
+<clip_image_mask transform="5.74 0 0 5.74 480.52 326.36003" width="7" height="7"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" ri="0" bp="1" op="0" opm="0" transform="5.74 0 0 5.74 480.52 326.36003" width="7" height="7"/>
+<pop_clip/>
+<clip_image_mask transform="5.74 0 0 5.74 546.94 305.86" width="7" height="7"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" ri="0" bp="1" op="0" opm="0" transform="5.74 0 0 5.74 546.94 305.86" width="7" height="7"/>
+<pop_clip/>
+<clip_image_mask transform="5.74 0 0 5.74 613.36 326.36003" width="7" height="7"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" ri="0" bp="1" op="0" opm="0" transform="5.74 0 0 5.74 613.36 326.36003" width="7" height="7"/>
+<pop_clip/>
+<clip_image_mask transform="5.74 0 0 5.74 679.78 143.49999" width="7" height="7"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" ri="0" bp="1" op="0" opm="0" transform="5.74 0 0 5.74 679.78 143.49999" width="7" height="7"/>
+<pop_clip/>
+<clip_image_mask transform="5.74 0 0 5.74 745.38 255.02" width="7" height="7"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" ri="0" bp="1" op="0" opm="0" transform="5.74 0 0 5.74 745.38 255.02" width="7" height="7"/>
+<pop_clip/>
+<clip_image_mask transform="5.74 0 0 5.74 811.8 326.36003" width="7" height="7"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" ri="0" bp="1" op="0" opm="0" transform="5.74 0 0 5.74 811.8 326.36003" width="7" height="7"/>
+<pop_clip/>
+<clip_image_mask transform="5.74 0 0 5.74 878.22 326.36003" width="7" height="7"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" ri="0" bp="1" op="0" opm="0" transform="5.74 0 0 5.74 878.22 326.36003" width="7" height="7"/>
+<pop_clip/>
+<clip_image_mask transform="5.74 0 0 5.74 944.64 326.36003" width="7" height="7"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" ri="0" bp="1" op="0" opm="0" transform="5.74 0 0 5.74 944.64 326.36003" width="7" height="7"/>
+<pop_clip/>
+<clip_image_mask transform="5.74 0 0 5.74 1011.06 326.36003" width="7" height="7"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" ri="0" bp="1" op="0" opm="0" transform="5.74 0 0 5.74 1011.06 326.36003" width="7" height="7"/>
+<pop_clip/>
+<clip_image_mask transform="5.74 0 0 5.74 1077.48 326.36003" width="7" height="7"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" ri="0" bp="1" op="0" opm="0" transform="5.74 0 0 5.74 1077.48 326.36003" width="7" height="7"/>
+<pop_clip/>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".2392157 .1686275 .1764706" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="548.2121" y="486.6387"/>
+            <lineto x="563.9561" y="486.6387"/>
+            <lineto x="563.9561" y="482.2218"/>
+            <lineto x="548.2121" y="482.2218"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".4784314 .3882353 .4117647" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="631.7659" y="486.6387"/>
+            <lineto x="647.5099" y="486.6387"/>
+            <lineto x="647.5099" y="482.2218"/>
+            <lineto x="631.7659" y="482.2218"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color=".3647059 .2156863 .3294118" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="713.1958" y="486.6387"/>
+            <lineto x="728.9398" y="486.6387"/>
+            <lineto x="728.9398" y="482.2218"/>
+            <lineto x="713.1958" y="482.2218"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<stroke_path linewidth="28440" miterlimit="10" linecap="1,1,1" linejoin="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color="0 .5333334 .5372549" ri="1" bp="1" op="0" opm="0" transform=".00006456693 0 0 .00006456693 802.1616 357.5698">
+            <moveto x="0" y="0"/>
+            <lineto x="243840" y="1"/>
+        </stroke_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" color="0 .5333334 .5372549" ri="1" bp="1" op="0" opm="0" transform="1 0 0 -1 0 842">
+            <moveto x="810.98" y="484.89"/>
+            <curveto x1="810.98" y1="483.7578" x2="810.0622" y2="482.84" x3="808.93" y3="482.84"/>
+            <curveto x1="807.7978" y1="482.84" x2="806.88" y2="483.7578" x3="806.88" y3="484.89"/>
+            <curveto x1="806.88" y1="486.0222" x2="807.7978" y2="486.94" x3="808.93" y3="486.94"/>
+            <curveto x1="810.0622" y1="486.94" x2="810.98" y2="486.0222" x3="810.98" y3="484.89"/>
+            <closepath/>
+        </fill_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="288.64" y="473"/>
+        <lineto x="1121.76" y="473"/>
+        <lineto x="1121.76" y="724.74"/>
+        <lineto x="288.64" y="724.74"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+        <moveto x="63.90705" y="405.4294"/>
+        <lineto x="256.5644" y="405.4294"/>
+        <lineto x="256.5644" y="265.1681"/>
+        <lineto x="63.90705" y="265.1681"/>
+        <closepath/>
+    </clip_path>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 842">
+            <moveto x="62.32" y="264.72"/>
+            <lineto x="257.48" y="264.72"/>
+            <lineto x="257.48" y="406.58003"/>
+            <lineto x="62.32" y="406.58003"/>
+            <closepath/>
+        </clip_path>
+<clip_image_mask transform="192.6574 0 0 140.2613 63.90705 436.57063" width="429" height="286"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB IEC61966-2.1)" ri="0" bp="1" op="0" opm="0" transform="192.6574 0 0 140.2613 63.90705 436.57063" width="429" height="286"/>
+<pop_clip/>
+<pop_clip/>
+<pop_clip/>
+</group>
+</page>
+</document>

--- a/scripts/tests/fixtures/issue-1608/output.xml
+++ b/scripts/tests/fixtures/issue-1608/output.xml
@@ -1,0 +1,1085 @@
+<document>
+<page number="2" mediabox="0 0 1190.55 841.89">
+<group bbox="0 0 1190.55 841.89" isolated="1" knockout="0" blendmode="Normal" alpha="1">
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 60.679994">
+        <moveto x="0" y="0"/>
+        <lineto x="196.8" y="0"/>
+        <lineto x="196.8" y="80.36"/>
+        <lineto x="0" y="80.36"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 141.03998">
+        <moveto x="0" y="0"/>
+        <lineto x="196.8" y="0"/>
+        <lineto x="196.8" y="232.06"/>
+        <lineto x="0" y="232.06"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 373.1">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="40.18"/>
+        <lineto x="0" y="40.18"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 413.28">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="40.18"/>
+        <lineto x="0" y="40.18"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 453.46">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 478.06">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 502.66">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 527.26">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 551.86">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 373.1">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="40.18"/>
+        <lineto x="0" y="40.18"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 413.28">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="40.18"/>
+        <lineto x="0" y="40.18"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 453.46">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 478.06">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 502.66">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 527.26">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 551.86">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 373.1">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="40.18"/>
+        <lineto x="0" y="40.18"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 413.28">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="40.18"/>
+        <lineto x="0" y="40.18"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 453.46">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 478.06">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 502.66">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 527.26">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 551.86">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 60.679994">
+        <moveto x="0" y="0"/>
+        <lineto x="16.4" y="0"/>
+        <lineto x="16.4" y="40.18"/>
+        <lineto x="0" y="40.18"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 100.859989">
+        <moveto x="0" y="0"/>
+        <lineto x="16.4" y="0"/>
+        <lineto x="16.4" y="40.18"/>
+        <lineto x="0" y="40.18"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 141.03998">
+        <moveto x="0" y="0"/>
+        <lineto x="16.4" y="0"/>
+        <lineto x="16.4" y="232.06"/>
+        <lineto x="0" y="232.06"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 373.1">
+        <moveto x="0" y="0"/>
+        <lineto x="16.4" y="0"/>
+        <lineto x="16.4" y="40.18"/>
+        <lineto x="0" y="40.18"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 413.28">
+        <moveto x="0" y="0"/>
+        <lineto x="16.4" y="0"/>
+        <lineto x="16.4" y="40.18"/>
+        <lineto x="0" y="40.18"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 453.46">
+        <moveto x="0" y="0"/>
+        <lineto x="16.4" y="0"/>
+        <lineto x="16.4" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 478.06">
+        <moveto x="0" y="0"/>
+        <lineto x="16.4" y="0"/>
+        <lineto x="16.4" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 502.66">
+        <moveto x="0" y="0"/>
+        <lineto x="16.4" y="0"/>
+        <lineto x="16.4" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 527.26">
+        <moveto x="0" y="0"/>
+        <lineto x="16.4" y="0"/>
+        <lineto x="16.4" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 551.86">
+        <moveto x="0" y="0"/>
+        <lineto x="16.4" y="0"/>
+        <lineto x="16.4" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".85490199 .7137255 .7294118" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 276.34 60.679994">
+        <moveto x="0" y="0"/>
+        <lineto x="848.7" y="0"/>
+        <lineto x="848.7" y="40.18"/>
+        <lineto x="0" y="40.18"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".85490199 .7137255 .7294118" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 276.34 373.1">
+        <moveto x="0" y="0"/>
+        <lineto x="848.7" y="0"/>
+        <lineto x="848.7" y="40.18"/>
+        <lineto x="0" y="40.18"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".23921569 .16862746 .1764706" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 341.94 453.46">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".3647059 .21568628 .32941178" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 341.94 478.06">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".47843138 .3882353 .4117647" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 341.94 502.66">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".23921569 .16862746 .1764706" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 341.94 527.26">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".3647059 .21568628 .32941178" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 341.94 551.86">
+        <moveto x="0" y="0"/>
+        <lineto x="65.6" y="0"/>
+        <lineto x="65.6" y="24.6"/>
+        <lineto x="0" y="24.6"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 100.65503">
+        <moveto x="0" y="0"/>
+        <lineto x="17.22" y="0"/>
+        <lineto x="17.22" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 276.135 60.679994">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="41"/>
+        <lineto x="0" y="41"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".85490199 .7137255 .7294118" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 277.34 100.65503">
+        <moveto x="0" y="0"/>
+        <lineto x="848.52" y="0"/>
+        <lineto x="848.52" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".85490199 .7137255 .7294118" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 1124.835 60.679994">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="41"/>
+        <lineto x="0" y="41"/>
+        <closepath/>
+    </fill_path>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 841.89">
+        <moveto x="287.82" y="773.3896"/>
+        <lineto x="1311.3401" y="773.3896"/>
+        <lineto x="1311.3401" y="749.26046"/>
+        <lineto x="287.82" y="749.26046"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 140.83502">
+        <moveto x="0" y="0"/>
+        <lineto x="197.62" y="0"/>
+        <lineto x="197.62" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.735 60.679994">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="81.18"/>
+        <lineto x="0" y="81.18"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 140.83502">
+        <moveto x="0" y="0"/>
+        <lineto x="17.22" y="0"/>
+        <lineto x="17.22" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 276.135 101.859989">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="40"/>
+        <lineto x="0" y="40"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 372.895">
+        <moveto x="0" y="0"/>
+        <lineto x="197.62" y="0"/>
+        <lineto x="197.62" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.735 142.03998">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="231.88"/>
+        <lineto x="0" y="231.88"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 372.895">
+        <moveto x="0" y="0"/>
+        <lineto x="17.22" y="0"/>
+        <lineto x="17.22" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 276.135 142.03998">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="231.88"/>
+        <lineto x="0" y="231.88"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 413.075">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.535 374.1">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="40"/>
+        <lineto x="0" y="40"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 413.075">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.135 374.1">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="40"/>
+        <lineto x="0" y="40"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 413.075">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.735 374.1">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="40"/>
+        <lineto x="0" y="40"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 413.075">
+        <moveto x="0" y="0"/>
+        <lineto x="17.22" y="0"/>
+        <lineto x="17.22" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 276.135 374.1">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="40"/>
+        <lineto x="0" y="40"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".85490199 .7137255 .7294118" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 277.34 413.075">
+        <moveto x="0" y="0"/>
+        <lineto x="848.52" y="0"/>
+        <lineto x="848.52" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".85490199 .7137255 .7294118" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 1124.835 373.1">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="41"/>
+        <lineto x="0" y="41"/>
+        <closepath/>
+    </fill_path>
+<clip_path winding="nonzero" transform="1 0 0 -1 0 841.89">
+        <moveto x="287.82" y="460.96958"/>
+        <lineto x="1311.3401" y="460.96958"/>
+        <lineto x="1311.3401" y="436.84043"/>
+        <lineto x="287.82" y="436.84043"/>
+        <closepath/>
+    </clip_path>
+<pop_clip/>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 453.255">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.535 414.28">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="40"/>
+        <lineto x="0" y="40"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 453.255">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.135 414.28">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="40"/>
+        <lineto x="0" y="40"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 453.255">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.735 414.28">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="40"/>
+        <lineto x="0" y="40"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 453.255">
+        <moveto x="0" y="0"/>
+        <lineto x="17.22" y="0"/>
+        <lineto x="17.22" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 276.135 414.28">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="40"/>
+        <lineto x="0" y="40"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 477.855">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.535 454.46">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 477.855">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.135 454.46">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 477.855">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.735 454.46">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 477.855">
+        <moveto x="0" y="0"/>
+        <lineto x="17.22" y="0"/>
+        <lineto x="17.22" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 276.135 454.46">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".23921569 .16862746 .1764706" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 341.94 477.855">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".23921569 .16862746 .1764706" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 407.335 453.46">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="25.42"/>
+        <lineto x="0" y="25.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 502.455">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.535 479.06">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 502.455">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.135 479.06">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 502.455">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.735 479.06">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 502.455">
+        <moveto x="0" y="0"/>
+        <lineto x="17.22" y="0"/>
+        <lineto x="17.22" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 276.135 479.06">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".3647059 .21568628 .32941178" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 341.94 502.455">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".3647059 .21568628 .32941178" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 407.335 479.06">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 527.055">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.535 503.66">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 527.055">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.135 503.66">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 527.055">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.735 503.66">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 527.055">
+        <moveto x="0" y="0"/>
+        <lineto x="17.22" y="0"/>
+        <lineto x="17.22" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 276.135 503.66">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".47843138 .3882353 .4117647" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 341.94 527.055">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".47843138 .3882353 .4117647" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 407.335 503.66">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 551.655">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.535 528.26">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 551.655">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.135 528.26">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 551.655">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.735 528.26">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 551.655">
+        <moveto x="0" y="0"/>
+        <lineto x="17.22" y="0"/>
+        <lineto x="17.22" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 276.135 528.26">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".23921569 .16862746 .1764706" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 341.94 551.655">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".23921569 .16862746 .1764706" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 407.335 528.26">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 63.14 576.255">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.535 552.86">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 128.74 576.255">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.135 552.86">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 194.34 576.255">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.735 552.86">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 259.94 576.255">
+        <moveto x="0" y="0"/>
+        <lineto x="17.22" y="0"/>
+        <lineto x="17.22" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".972549 .9372549 .9411765" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 276.135 552.86">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".3647059 .21568628 .32941178" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 341.94 576.255">
+        <moveto x="0" y="0"/>
+        <lineto x="66.42" y="0"/>
+        <lineto x="66.42" y="1.025"/>
+        <lineto x="0" y="1.025"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".3647059 .21568628 .32941178" ri="1" bp="1" op="0" opm="0" transform="1 0 0 1 407.335 552.86">
+        <moveto x="0" y="0"/>
+        <lineto x="1.025" y="0"/>
+        <lineto x="1.025" y="24.42"/>
+        <lineto x="0" y="24.42"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="1 1 1" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 289.63468 117.97034">
+        <moveto x="0" y="0"/>
+        <lineto x="1015.97799" y="0"/>
+        <lineto x="1015.97799" y="307.97325"/>
+        <lineto x="0" y="307.97325"/>
+        <closepath/>
+    </fill_path>
+<stroke_path linewidth=".73700788" miterlimit="4" linecap="0,0,0" linejoin="0" colorspace="ICCBased(RGB,sRGB)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 317.7413 329.79866">
+        <moveto x="0" y="0"/>
+        <lineto x="970.7016" y="0"/>
+    </stroke_path>
+<stroke_path linewidth=".73700788" miterlimit="4" linecap="0,0,0" linejoin="0" colorspace="ICCBased(RGB,sRGB)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 317.7413 309.14">
+        <moveto x="0" y="0"/>
+        <lineto x="970.7016" y="0"/>
+    </stroke_path>
+<stroke_path linewidth=".73700788" miterlimit="4" linecap="0,0,0" linejoin="0" colorspace="ICCBased(RGB,sRGB)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 317.7413 289.45997">
+        <moveto x="0" y="0"/>
+        <lineto x="970.7016" y="0"/>
+    </stroke_path>
+<stroke_path linewidth=".73700788" miterlimit="4" linecap="0,0,0" linejoin="0" colorspace="ICCBased(RGB,sRGB)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 317.7413 268.95997">
+        <moveto x="0" y="0"/>
+        <lineto x="970.7016" y="0"/>
+    </stroke_path>
+<stroke_path linewidth=".73700788" miterlimit="4" linecap="0,0,0" linejoin="0" colorspace="ICCBased(RGB,sRGB)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 317.7413 248.46002">
+        <moveto x="0" y="0"/>
+        <lineto x="970.7016" y="0"/>
+    </stroke_path>
+<stroke_path linewidth=".73700788" miterlimit="4" linecap="0,0,0" linejoin="0" colorspace="ICCBased(RGB,sRGB)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 317.7413 227.96002">
+        <moveto x="0" y="0"/>
+        <lineto x="970.7016" y="0"/>
+    </stroke_path>
+<stroke_path linewidth=".73700788" miterlimit="4" linecap="0,0,0" linejoin="0" colorspace="ICCBased(RGB,sRGB)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 317.7413 207.46002">
+        <moveto x="0" y="0"/>
+        <lineto x="970.7016" y="0"/>
+    </stroke_path>
+<stroke_path linewidth=".73700788" miterlimit="4" linecap="0,0,0" linejoin="0" colorspace="ICCBased(RGB,sRGB)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 317.7413 186.96002">
+        <moveto x="0" y="0"/>
+        <lineto x="970.7016" y="0"/>
+    </stroke_path>
+<stroke_path linewidth=".73700788" miterlimit="4" linecap="0,0,0" linejoin="0" colorspace="ICCBased(RGB,sRGB)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 317.7413 167.28003">
+        <moveto x="0" y="0"/>
+        <lineto x="970.7016" y="0"/>
+    </stroke_path>
+<stroke_path linewidth=".73700788" miterlimit="4" linecap="0,0,0" linejoin="0" colorspace="ICCBased(RGB,sRGB)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 317.7413 146.78003">
+        <moveto x="0" y="0"/>
+        <lineto x="970.7016" y="0"/>
+    </stroke_path>
+<stroke_path linewidth=".73700788" miterlimit="4" linecap="0,0,0" linejoin="0" colorspace="ICCBased(RGB,sRGB)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 317.7413 126.29004">
+        <moveto x="0" y="0"/>
+        <lineto x="970.7016" y="0"/>
+    </stroke_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".23921569 .16862746 .1764706" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 337.6407 309.44776">
+        <moveto x="0" y="0"/>
+        <lineto x="32.35672" y="0"/>
+        <lineto x="32.35672" y="24.818123"/>
+        <lineto x="0" y="24.818123"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".3647059 .21568628 .32941178" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 536.6345 309.44776">
+        <moveto x="0" y="0"/>
+        <lineto x="32.35672" y="0"/>
+        <lineto x="32.35672" y="24.818123"/>
+        <lineto x="0" y="24.818123"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".23921569 .16862746 .1764706" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 669.29708 278.9215">
+        <moveto x="0" y="0"/>
+        <lineto x="32.35672" y="0"/>
+        <lineto x="32.35672" y="62.045309"/>
+        <lineto x="0" y="62.045309"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".3647059 .21568628 .32941178" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 669.29708 177.16724">
+        <moveto x="0" y="0"/>
+        <lineto x="32.35672" y="0"/>
+        <lineto x="32.35672" y="124.090618"/>
+        <lineto x="0" y="124.090618"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".47843138 .3882353 .4117647" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 735.6283 278.9215">
+        <moveto x="0" y="0"/>
+        <lineto x="32.35672" y="0"/>
+        <lineto x="32.35672" y="62.045309"/>
+        <lineto x="0" y="62.045309"/>
+        <closepath/>
+    </fill_path>
+<stroke_path linewidth="2.23937" miterlimit="4" linecap="1,1,1" linejoin="1" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 289.63468 117.97034">
+        <moveto x="74.72227" y="221.10004"/>
+        <lineto x="155.61406" y="258.32725"/>
+        <lineto x="236.50586" y="258.32725"/>
+        <lineto x="317.39768" y="233.50911"/>
+        <lineto x="398.28947" y="258.32725"/>
+        <lineto x="479.18128" y="34.964124"/>
+        <lineto x="560.07308" y="171.46379"/>
+        <lineto x="640.96487" y="258.32725"/>
+        <lineto x="721.8566" y="258.32725"/>
+        <lineto x="802.7485" y="258.32725"/>
+        <lineto x="883.64028" y="258.32725"/>
+        <lineto x="964.53207" y="258.32725"/>
+    </stroke_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 348.85694 297.2224">
+        <moveto x="0" y="2.5"/>
+        <curveto x1="0" y1="1.12054" x2="1.12054" y2="0" x3="2.5" y3="0"/>
+        <curveto x1="3.87946" y1="0" x2="5" y2="1.12054" x3="5" y3="2.5"/>
+        <curveto x1="5" y1="3.87946" x2="3.87946" y2="5" x3="2.5" y3="5"/>
+        <curveto x1="1.12054" y1="5" x2="0" y2="3.87946" x3="0" y3="2.5"/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 415.1882 327.74867">
+        <moveto x="0" y="2.5"/>
+        <curveto x1="0" y1="1.12054" x2="1.12054" y2="0" x3="2.5" y3="0"/>
+        <curveto x1="3.87946" y1="0" x2="5" y2="1.12054" x3="5" y3="2.5"/>
+        <curveto x1="5" y1="3.87946" x2="3.87946" y2="5" x3="2.5" y3="5"/>
+        <curveto x1="1.12054" y1="5" x2="0" y2="3.87946" x3="0" y3="2.5"/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 481.51948 327.74867">
+        <moveto x="0" y="2.5"/>
+        <curveto x1="0" y1="1.12054" x2="1.12054" y2="0" x3="2.5" y3="0"/>
+        <curveto x1="3.87946" y1="0" x2="5" y2="1.12054" x3="5" y3="2.5"/>
+        <curveto x1="5" y1="3.87946" x2="3.87946" y2="5" x3="2.5" y3="5"/>
+        <curveto x1="1.12054" y1="5" x2="0" y2="3.87946" x3="0" y3="2.5"/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 547.85079 307.39784">
+        <moveto x="0" y="2.5"/>
+        <curveto x1="0" y1="1.12054" x2="1.12054" y2="0" x3="2.5" y3="0"/>
+        <curveto x1="3.87946" y1="0" x2="5" y2="1.12054" x3="5" y3="2.5"/>
+        <curveto x1="5" y1="3.87946" x2="3.87946" y2="5" x3="2.5" y3="5"/>
+        <curveto x1="1.12054" y1="5" x2="0" y2="3.87946" x3="0" y3="2.5"/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 614.182 327.74867">
+        <moveto x="0" y="2.5"/>
+        <curveto x1="0" y1="1.12054" x2="1.12054" y2="0" x3="2.5" y3="0"/>
+        <curveto x1="3.87946" y1="0" x2="5" y2="1.12054" x3="5" y3="2.5"/>
+        <curveto x1="5" y1="3.87946" x2="3.87946" y2="5" x3="2.5" y3="5"/>
+        <curveto x1="1.12054" y1="5" x2="0" y2="3.87946" x3="0" y3="2.5"/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 680.5133 144.59095">
+        <moveto x="0" y="2.5"/>
+        <curveto x1="0" y1="1.12054" x2="1.12054" y2="0" x3="2.5" y3="0"/>
+        <curveto x1="3.87946" y1="0" x2="5" y2="1.12054" x3="5" y3="2.5"/>
+        <curveto x1="5" y1="3.87946" x2="3.87946" y2="5" x3="2.5" y3="5"/>
+        <curveto x1="1.12054" y1="5" x2="0" y2="3.87946" x3="0" y3="2.5"/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 746.8446 256.52064">
+        <moveto x="0" y="2.5"/>
+        <curveto x1="0" y1="1.12054" x2="1.12054" y2="0" x3="2.5" y3="0"/>
+        <curveto x1="3.87946" y1="0" x2="5" y2="1.12054" x3="5" y3="2.5"/>
+        <curveto x1="5" y1="3.87946" x2="3.87946" y2="5" x3="2.5" y3="5"/>
+        <curveto x1="1.12054" y1="5" x2="0" y2="3.87946" x3="0" y3="2.5"/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 813.17587 327.74867">
+        <moveto x="0" y="2.5"/>
+        <curveto x1="0" y1="1.12054" x2="1.12054" y2="0" x3="2.5" y3="0"/>
+        <curveto x1="3.87946" y1="0" x2="5" y2="1.12054" x3="5" y3="2.5"/>
+        <curveto x1="5" y1="3.87946" x2="3.87946" y2="5" x3="2.5" y3="5"/>
+        <curveto x1="1.12054" y1="5" x2="0" y2="3.87946" x3="0" y3="2.5"/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 879.50717 327.74867">
+        <moveto x="0" y="2.5"/>
+        <curveto x1="0" y1="1.12054" x2="1.12054" y2="0" x3="2.5" y3="0"/>
+        <curveto x1="3.87946" y1="0" x2="5" y2="1.12054" x3="5" y3="2.5"/>
+        <curveto x1="5" y1="3.87946" x2="3.87946" y2="5" x3="2.5" y3="5"/>
+        <curveto x1="1.12054" y1="5" x2="0" y2="3.87946" x3="0" y3="2.5"/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 945.8384 327.74867">
+        <moveto x="0" y="2.5"/>
+        <curveto x1="0" y1="1.12054" x2="1.12054" y2="0" x3="2.5" y3="0"/>
+        <curveto x1="3.87946" y1="0" x2="5" y2="1.12054" x3="5" y3="2.5"/>
+        <curveto x1="5" y1="3.87946" x2="3.87946" y2="5" x3="2.5" y3="5"/>
+        <curveto x1="1.12054" y1="5" x2="0" y2="3.87946" x3="0" y3="2.5"/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 1012.1697 327.74867">
+        <moveto x="0" y="2.5"/>
+        <curveto x1="0" y1="1.12054" x2="1.12054" y2="0" x3="2.5" y3="0"/>
+        <curveto x1="3.87946" y1="0" x2="5" y2="1.12054" x3="5" y3="2.5"/>
+        <curveto x1="5" y1="3.87946" x2="3.87946" y2="5" x3="2.5" y3="5"/>
+        <curveto x1="1.12054" y1="5" x2="0" y2="3.87946" x3="0" y3="2.5"/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 1078.501 327.74867">
+        <moveto x="0" y="2.5"/>
+        <curveto x1="0" y1="1.12054" x2="1.12054" y2="0" x3="2.5" y3="0"/>
+        <curveto x1="3.87946" y1="0" x2="5" y2="1.12054" x3="5" y3="2.5"/>
+        <curveto x1="5" y1="3.87946" x2="3.87946" y2="5" x3="2.5" y3="5"/>
+        <curveto x1="1.12054" y1="5" x2="0" y2="3.87946" x3="0" y3="2.5"/>
+    </fill_path>
+<stroke_path linewidth=".73700788" miterlimit="4" linecap="0,0,0" linejoin="0" colorspace="ICCBased(RGB,sRGB)" color=".8509804 .8509804 .8509804" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 317.7413 329.79866">
+        <moveto x="0" y="0"/>
+        <lineto x="970.7016" y="0"/>
+    </stroke_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".23921569 .16862746 .1764706" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 548.0481 355.99436">
+        <moveto x="0" y="0"/>
+        <lineto x="19.2" y="0"/>
+        <lineto x="19.2" y="4.860791"/>
+        <lineto x="0" y="4.860791"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".47843138 .3882353 .4117647" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 631.5935 355.99436">
+        <moveto x="0" y="0"/>
+        <lineto x="19.2" y="0"/>
+        <lineto x="19.2" y="4.860791"/>
+        <lineto x="0" y="4.860791"/>
+        <closepath/>
+    </fill_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color=".3647059 .21568628 .32941178" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 713.0165 355.99436">
+        <moveto x="0" y="0"/>
+        <lineto x="19.2" y="0"/>
+        <lineto x="19.2" y="4.860791"/>
+        <lineto x="0" y="4.860791"/>
+        <closepath/>
+    </fill_path>
+<stroke_path linewidth="2.23937" miterlimit="4" linecap="1,1,1" linejoin="1" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 801.97799 357.5202">
+        <moveto x="0" y="0"/>
+        <lineto x="19.2" y="0"/>
+    </stroke_path>
+<fill_path winding="nonzero" colorspace="ICCBased(RGB,sRGB)" color="0 .53333339 .5372549" ri="1" bp="1" op="0" opm="0" transform=".82 0 0 .82 807.7999 355.47019">
+        <moveto x="0" y="2.5"/>
+        <curveto x1="0" y1="1.12054" x2="1.12054" y2="0" x3="2.5" y3="0"/>
+        <curveto x1="3.87946" y1="0" x2="5" y2="1.12054" x3="5" y3="2.5"/>
+        <curveto x1="5" y1="3.87946" x2="3.87946" y2="5" x3="2.5" y3="5"/>
+        <curveto x1="1.12054" y1="5" x2="0" y2="3.87946" x3="0" y3="2.5"/>
+    </fill_path>
+<clip_image_mask transform="192.65738 0 0 140.26132 64.09206 437.27055" width="857" height="572"/>
+<fill_image alpha="1" colorspace="ICCBased(RGB,sRGB)" ri="1" bp="1" op="0" opm="0" transform="192.65738 0 0 140.26132 64.09206 437.27055" width="857" height="572"/>
+<pop_clip/>
+</group>
+</page>
+</document>

--- a/scripts/tests/test_compare_layout.py
+++ b/scripts/tests/test_compare_layout.py
@@ -796,13 +796,17 @@ class MatchAndDiffTest(unittest.TestCase):
         rects = self.diff(gt, out, fine_shift=0.5)["rects"]
 
         self.assertEqual(rects["matched"], 2)
-        self.assertEqual(rects["geometry_mismatch_count"], 2)
+        # Both raw pairs remain available, but the smaller same-color
+        # rectangle is hidden by the outer one. Only the outer edge moves.
+        self.assertEqual(rects["raw_geometry_mismatch_count"], 2)
+        self.assertEqual(rects["geometry_mismatch_count"], 1)
+        self.assertEqual(rects["coverage_equivalent_count"], 1)
         self.assertEqual(
-            [sample["gt_bbox"] for sample in rects["geometry_mismatch_samples"]],
+            [sample["gt_bbox"] for sample in rects["raw_geometry_mismatch_samples"]],
             [[0.0, 0.0, 100.0, 10.0], [30.0, 0.0, 70.0, 10.0]],
         )
         self.assertEqual(
-            [sample["out_bbox"] for sample in rects["geometry_mismatch_samples"]],
+            [sample["out_bbox"] for sample in rects["raw_geometry_mismatch_samples"]],
             [[1.0, 0.0, 99.0, 10.0], [29.0, 0.0, 71.0, 10.0]],
         )
 
@@ -826,6 +830,129 @@ class MatchAndDiffTest(unittest.TestCase):
         self.assertEqual(rects["matched"], 1)
         self.assertEqual(rects["geometry_mismatch_count"], 0)
         self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
+    def fill_coverage_probe(self, overpaint: bool = False) -> tuple[str, str]:
+        # The native lower-left corner is hidden by a later pale cell. The
+        # split output deliberately leaves that corner unpainted, so its blue
+        # primitive union is L-shaped although final visible coverage agrees.
+        blue = ".2 .3 .8"
+        pale = ".9 .9 .9"
+        cover = rect_op(50, 93, 55, 95, color=pale)
+        gt = "\n".join([rect_op(50, 54, 150, 94, color=blue), cover])
+        out = "\n".join([
+            rect_op(50, 54, 149, 93, color=blue), cover,
+            rect_op(50 if overpaint else 55, 92.75, 150, 94, color=blue),
+            rect_op(148.75, 54, 150, 94, color=blue),
+        ])
+        return gt, out
+
+    def test_composed_fill_coverage_resolves_raw_split_rectangle_deficit(self) -> None:
+        gt, out = self.fill_coverage_probe()
+        vector = self.diff(gt, out, fine_shift=0.5)
+        self.assertEqual(vector["rects"]["geometry_mismatch_count"], 0)
+        self.assertEqual(vector["rects"]["raw_geometry_mismatch_count"], 1)
+        self.assertEqual(vector["rects"]["coverage_equivalent_count"], 1)
+        self.assertEqual(compare_layout.audit_failures([vector]), 0)
+
+    def test_composed_fill_coverage_keeps_contrasting_overlap_finding(self) -> None:
+        gt, out = self.fill_coverage_probe(overpaint=True)
+        vector = self.diff(gt, out, fine_shift=0.5)
+        self.assertGreater(compare_layout.audit_failures([vector]), 0)
+        self.assertEqual(vector["rects"]["coverage_equivalent_count"], 0)
+
+    def test_clipping_cannot_make_a_hidden_extension_count_as_visible(self) -> None:
+        gt, out = self.fill_coverage_probe()
+        clip = rect_op(0, 0, 149, 200).replace("fill_path", "clip_path")
+        out = clip + "\n" + out + "\n<pop_clip/>"
+        vector = self.diff(gt, out, fine_shift=0.5)
+        self.assertGreater(vector["rects"]["geometry_mismatch_count"], 0)
+        self.assertEqual(vector["rects"]["coverage_equivalent_count"], 0)
+
+    def test_opaque_image_coverage_is_explicitly_unmodeled(self) -> None:
+        gt, out = self.fill_coverage_probe()
+        image = '<fill_image alpha="1" transform="100 0 0 40 50 54"/>'
+        vector = self.diff(gt + image, out + image, fine_shift=0.5)
+        self.assertGreater(vector["rects"]["geometry_mismatch_count"], 0)
+        self.assertGreater(vector["rects"]["coverage_unmodeled_count"], 0)
+
+    def test_visible_overlap_does_not_discredit_an_equivalent_right_edge(self) -> None:
+        gt, out = self.fill_coverage_probe()
+        out += rect_op(70, 60, 80, 80, color=".9 .9 .9")
+        vector = self.diff(gt, out, fine_shift=0.5)
+        coverage = vector["rects"]["raw_geometry_mismatch_samples"][0]["visible_coverage"]
+        self.assertEqual(coverage["status"], "different")
+        self.assertEqual(coverage["raw_edge_coverage"]["right"], "equivalent")
+        self.assertGreater(vector["rects"]["geometry_mismatch_count"], 0)
+
+    def test_equivalent_rectangular_clips_resolve_raw_geometry(self) -> None:
+        gt, out = self.fill_coverage_probe()
+        clip = rect_op(0, 0, 149, 200).replace("fill_path", "clip_path")
+        vector = self.diff(clip + gt + "<pop_clip/>", clip + out + "<pop_clip/>", fine_shift=0.5)
+        self.assertEqual(vector["rects"]["geometry_mismatch_count"], 0)
+        self.assertEqual(vector["rects"]["coverage_equivalent_count"], 1)
+
+    def test_translucent_fill_coverage_cannot_clear_a_raw_finding(self) -> None:
+        gt, out = self.fill_coverage_probe()
+        tint = rect_op(50, 54, 150, 94, alpha=0.5)
+        vector = self.diff(gt + tint, out + tint, fine_shift=0.5)
+        self.assertGreater(vector["rects"]["coverage_unmodeled_count"], 0)
+        self.assertGreater(vector["rects"]["geometry_mismatch_count"], 0)
+
+    def test_later_opaque_fills_can_resolve_an_unknown_underlay(self) -> None:
+        gt, out = self.fill_coverage_probe()
+        image = '<fill_image alpha="1" transform="100 0 0 40 50 54"/>'
+        vector = self.diff(image + gt, image + out, fine_shift=0.5)
+        self.assertEqual(vector["rects"]["geometry_mismatch_count"], 0)
+        self.assertEqual(vector["rects"]["coverage_unmodeled_count"], 0)
+
+    def test_issue_1608_native_band_right_edge_is_already_painted(self) -> None:
+        folder = Path(__file__).parent / "fixtures" / "issue-1608"
+        gt = compare_layout.parse_trace((folder / "native.xml").read_text())[0]
+        out = compare_layout.parse_trace((folder / "output.xml").read_text())[0]
+        vector = compare_layout.diff_page(gt, out, fine_shift=0.5)
+        samples = vector["rects"]["raw_geometry_mismatch_samples"]
+        band = next(item for item in samples if abs(item["gt_bbox"][0] - 276.34) < 0.001)
+        self.assertAlmostEqual(band["edges"]["right"], -0.82, places=4)
+        coverage = band["visible_coverage"]
+        self.assertEqual(coverage["raw_edge_coverage"]["right"], "equivalent")
+        # The left-side pale overpaint and lower-left color ownership remain
+        # real #1599 findings; the already-painted right edge is not a deficit.
+        self.assertEqual(coverage["status"], "different")
+        self.assertEqual(coverage["raw_edge_coverage"]["bottom"], "different")
+        self.assertEqual(coverage["unmodeled_area_pt2"], 0)
+        self.assertAlmostEqual(coverage["mismatch_area_pt2"], 33.095194, places=4)
+        self.assertGreater(vector["rects"]["geometry_mismatch_count"], 0)
+        self.assertIn("raw edge coverage", compare_layout.render_reading([vector]))
+
+    def test_dense_hidden_edges_cannot_partition_away_visible_overlap(self) -> None:
+        gt, out = self.fill_coverage_probe()
+        underlay = "\n".join(
+            rect_op(70 + i * 0.009, 54, 70 + i * 0.009 + 0.003, 94, color="0 0 0")
+            for i in range(120)
+        )
+        out += rect_op(70, 60, 71.08, 80, color=".9 .9 .9")
+        pages = [compare_layout.parse_trace(trace_document(underlay + body))[0]
+                 for body in [gt, out]]
+        coverage = compare_layout.compare_fill_coverage(
+            *pages, {"gt_bbox": [50, 54, 150, 94], "out_bbox": [50, 54, 149, 93]}
+        )
+        self.assertEqual(coverage["status"], "different")
+        self.assertGreater(coverage["mismatch_area_pt2"], 20)
+
+    def test_mask_or_tile_scope_cannot_be_proven_by_group_nesting(self) -> None:
+        gt, out = self.fill_coverage_probe()
+        for tag in ["mask", "tile"]:
+            with self.subTest(tag=tag):
+                prefix = f'<{tag} bbox="0 0 200 200"></{tag}>'
+                vector = self.diff(prefix + gt, prefix + out, fine_shift=0.5)
+                self.assertGreater(vector["rects"]["coverage_unmodeled_count"], 0)
+                self.assertGreater(vector["rects"]["geometry_mismatch_count"], 0)
+
+    def test_coverage_epsilon_never_overrides_a_finer_geometry_gate(self) -> None:
+        vector = self.diff(rect_op(50, 54, 150, 94), rect_op(50.005, 54, 150.005, 94),
+                           fine_shift=0.001)
+        self.assertEqual(vector["rects"]["geometry_mismatch_count"], 1)
+        self.assertEqual(vector["rects"]["coverage_equivalent_count"], 0)
 
     def test_boundary_bleed_completes_nominal_rectangle_coverage(self) -> None:
         gt = rect_op(50.0, 54.0, 474.0, 145.0, color=".85 .71 .73")


### PR DESCRIPTION
## Summary

The layout audit could call a rectangle too small when separate edge strips already painted the apparent deficit. Compare the composed opaque flat-fill layer before treating a raw fill geometry finding as visible error. Preserve raw dimensions and source indices, and report coverage per affected edge.

A fully equivalent fill becomes informational. Different or unmodeled coverage keeps the finding active. Rectangular clips and paint order participate in the proof; unknown images, nonrectangular paint/clips, opacity, masks, and tiles cannot provide an unsupported pass. Coordinate normalization uses at most the existing 0.01pt epsilon and is clamped to the active geometry threshold.

Related: #1608, #1599, #1605.

## Validation

- TDD: the equivalent split-fill regression fails on the previous implementation. A second red regression caught 0.005pt motion being cleared at a 0.001pt gate; the corrected implementation retains it.
- **223 harness tests passed**: 102 layout, 6 spatial matching, 37 render comparison, and 78 visual PR contract tests.
- Pinned public #982 paint/clip traces reproduce the rose band's raw -0.82pt right-edge delta. The report now proves that edge equivalent and locates the actual left-side/lower-left coverage errors instead. The #1599 fill-order and #1605 clipping findings remain active.
- Rechecked the original two-page workbook and three-page unscaled control at the unchanged 0.5pt gate. No raw finding on these defect-bearing pages was blanket-suppressed.
- Regression controls cover contrasting overlap, clipped/opaque/unknown paint, mask and tile scope, and dense hidden edges that must not partition away a material difference.
- Read-only documentation freshness audit: PASS.

The proof concerns the flat-fill layer; text, strokes, and pixel differences retain their separate audits. Comparisons beyond 100,000 partition cells remain explicitly unmodeled. Native fixture provenance and extraction commands are documented alongside the committed traces.

## File submission policy

- [x] Submitted fixtures are derived from the public #982 attachment and contain paint/clip operations with text removed.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: Internal audit-harness code, trace fixtures, and documentation only; no converter changes.
