### PR TITLE
fix(scripts): stop the issue loop reading its own telemetry as a limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,8 @@ jobs:
         run: python3 -m unittest discover -s scripts/tests -p 'test_measure_excel_row_height.py'
       - name: Test issue-loop viewer
         run: python3 -m unittest discover -s scripts/tests -p 'test_issue_loop_watch.py'
+      - name: Test issue-loop usage-limit detector
+        run: python3 -m unittest discover -s scripts/tests -p 'test_issue_loop.py'
       - name: Check issue-loop script syntax
         run: bash -n scripts/issue_loop.sh
       - name: Validate visual PR contract

--- a/scripts/issue_loop.sh
+++ b/scripts/issue_loop.sh
@@ -12,6 +12,8 @@
 #   scripts/issue_loop.sh --once          # exit as soon as the queue is empty
 #   scripts/issue_loop.sh --max-issues 1  # trial: stop after one agent run
 #
+#   scripts/issue_loop.sh --usage-limit-reason LOG  # why a run counted as rate-limited
+#
 # Stop it gracefully with `touch target/issue-loop-logs/STOP` (finishes the current
 # issue first) or Ctrl+C. Per-run reports land in target/issue-loop-logs/.
 #
@@ -37,8 +39,9 @@ EXPECT_USER=""                    # optional: require this gh login before touch
 CARGO_TARGET_DIR_OVERRIDE=""      # optional: share one build dir across the agents' worktrees
 ONCE=0
 MAX_ISSUES=0
+USAGE_LIMIT_LOG=""                # diagnostic: report why one run counted as rate-limited
 
-usage() { sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0; }
+usage() { awk 'NR > 1 { if (!/^#/) exit; sub(/^# ?/, ""); print }' "${BASH_SOURCE[0]}"; exit 0; }
 
 while (( $# )); do
   case "$1" in
@@ -54,11 +57,77 @@ while (( $# )); do
     --expect-user) shift; EXPECT_USER="${1:-}" ;;
     --cargo-target-dir) shift; CARGO_TARGET_DIR_OVERRIDE="${1:-}" ;;
     --min-free-gb) shift; MIN_FREE_GB="${1:-0}" ;;
+    --usage-limit-reason) shift; USAGE_LIMIT_LOG="${1:-}" ;;
     -h|--help) usage ;;
     *) echo "unknown argument: $1 (try --help)" >&2; exit 2 ;;
   esac
   shift
 done
+
+# Prints a short reason when a run really hit a usage limit, and nothing when it
+# did not. Only the CLI's own result/error text and its non-JSON output can carry
+# that message. Reading the raw log instead matches the telemetry around it: a
+# --verbose stream-json init event lists the `usage-credits` slash command, and
+# every turn emits a `rate_limit_event` whose status is normally `allowed_warning`.
+usage_limit_reason() {
+  python3 - "$1" <<'USAGE_LIMIT_PY'
+import json
+import re
+import sys
+
+MESSAGE = re.compile(
+    r"usage limit reached|reached your .{0,60}?limit|cc_cli_limit_message",
+    re.IGNORECASE,
+)
+
+
+def report(text: str, source: str) -> None:
+    found = MESSAGE.search(text)
+    if found:
+        print("%s: %s" % (source, found.group(0).strip()))
+        raise SystemExit(0)
+
+
+try:
+    raw = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+except OSError:
+    raise SystemExit(1)          # a run that never opened its log is not a limit
+
+try:
+    events = [json.loads(raw)]   # --output-format json: one object, no telemetry
+except ValueError:
+    events = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except ValueError:
+            report(line, "cli output")
+
+for event in events:
+    if not isinstance(event, dict):
+        continue
+    if event.get("type") == "rate_limit_event":
+        # `allowed` and `allowed_warning` are the states of a run that was served.
+        status = (event.get("rate_limit_info") or {}).get("status", "")
+        if status and not status.startswith("allowed"):
+            print("rate_limit_event status=%s" % status)
+            raise SystemExit(0)
+        continue
+    for key in ("result", "error", "message"):
+        value = event.get(key)
+        if isinstance(value, str):
+            report(value, key)
+raise SystemExit(1)
+USAGE_LIMIT_PY
+}
+
+if [[ -n "$USAGE_LIMIT_LOG" ]]; then
+  usage_limit_reason "$USAGE_LIMIT_LOG"
+  exit $?
+fi
 
 STOP_FILE="$LOG_DIR/STOP"
 mkdir -p "$LOG_DIR"
@@ -177,11 +246,13 @@ while true; do
   rc=$?
   processed=$((processed + 1))
 
-  # Both wordings seen in practice: "usage limit reached" and
-  # "You've reached your <model> limit. Run /usage-credits to continue".
-  if grep -qiE "usage limit|limit reached|reached your .{0,40}limit|usage-credits|rate.?limit" "$log"; then
+  # A false positive costs the whole run: the check below returns to the top of
+  # the loop without ever reading the issue's state, so a finished agent's work
+  # goes uncounted and the loop sleeps an hour before repeating it.
+  limit_reason="$(usage_limit_reason "$log" || true)"
+  if [[ -n "$limit_reason" ]]; then
     processed=$((processed - 1))
-    echo "usage limit reached — sleeping $((USAGE_LIMIT_SLEEP / 60))m, then retrying this issue."
+    echo "usage limit reached ($limit_reason) — sleeping $((USAGE_LIMIT_SLEEP / 60))m, then retrying this issue."
     sleep "$USAGE_LIMIT_SLEEP"
     continue
   fi

--- a/scripts/tests/test_issue_loop.py
+++ b/scripts/tests/test_issue_loop.py
@@ -1,0 +1,152 @@
+"""Tests for the unattended issue loop's usage-limit detector.
+
+A false positive here is expensive in a way only a test cheaply guards: the loop
+discards the run it just finished and sleeps an hour before retrying, so one
+over-broad substring costs an issue's worth of unattended progress. On
+2026-09-08 the detector grepped the raw run log and matched the CLI's own
+telemetry — a `rate_limit_event` whose status was `allowed_warning`, and the
+init event's list of slash commands, which contains `usage-credits`. It threw
+away a successful 79-turn run while the seven-day usage window sat at 58%.
+
+The detector is exercised through `--usage-limit-reason`, the same entry point
+the loop itself calls, so these tests survive a rewrite of how it is implemented.
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "issue_loop.sh"
+
+
+def init_event() -> str:
+    """The CLI's session header. Its slash-command list contains `usage-credits`."""
+    return json.dumps(
+        {
+            "type": "system",
+            "subtype": "init",
+            "model": "claude-opus-5",
+            "slash_commands": ["security-review", "usage-credits", "extra-usage", "usage"],
+        }
+    )
+
+
+def rate_limit_event(status: str, utilization: float = 0.58) -> str:
+    return json.dumps(
+        {
+            "type": "rate_limit_event",
+            "rate_limit_info": {
+                "status": status,
+                "rateLimitType": "seven_day",
+                "utilization": utilization,
+                "isUsingOverage": False,
+            },
+        }
+    )
+
+
+def result_event(text: str, subtype: str = "success") -> str:
+    return json.dumps(
+        {
+            "type": "result",
+            "subtype": subtype,
+            "is_error": False,
+            "num_turns": 79,
+            "result": text,
+        }
+    )
+
+
+class UsageLimitReasonTest(unittest.TestCase):
+    def detect(self, log_text: str) -> subprocess.CompletedProcess:
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "issue-1381-20260908-203328.json"
+            log.write_text(log_text, encoding="utf-8")
+            return self.run_detector(str(log))
+
+    def run_detector(self, path: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", str(SCRIPT), "--usage-limit-reason", path],
+            capture_output=True,
+            text=True,
+        )
+
+    def assertNoLimit(self, done: subprocess.CompletedProcess) -> None:
+        self.assertEqual(done.stdout.strip(), "", done.stderr)
+        self.assertEqual(done.returncode, 1, done.stderr)
+
+    def assertLimit(self, done: subprocess.CompletedProcess) -> None:
+        self.assertNotEqual(done.stdout.strip(), "", done.stderr)
+        self.assertEqual(done.returncode, 0, done.stderr)
+
+    def test_telemetry_of_a_successful_verbose_run_is_not_a_limit(self):
+        # The regression: every line here is normal --verbose stream-json output.
+        log = "\n".join(
+            [
+                init_event(),
+                rate_limit_event("allowed_warning"),
+                rate_limit_event("allowed"),
+                result_event("Merged PR #1661 and closed the issue."),
+            ]
+        )
+        self.assertNoLimit(self.detect(log))
+
+    def test_a_rejected_rate_limit_event_is_a_limit(self):
+        log = "\n".join(
+            [
+                init_event(),
+                rate_limit_event("allowed_warning"),
+                rate_limit_event("rejected", utilization=1.0),
+                result_event("You've reached your Fable limit."),
+            ]
+        )
+        self.assertLimit(self.detect(log))
+
+    def test_a_refused_run_reports_the_limit_from_its_result_text(self):
+        # --output-format json emits one object and no telemetry, so the message
+        # itself is the only evidence the loop gets.
+        self.assertLimit(
+            self.detect(
+                result_event(
+                    "You've reached your Fable limit. Switch to another model, or "
+                    "manage usage credits at claude.ai/settings/usage"
+                    "?from=cc_cli_limit_message, to continue."
+                )
+            )
+        )
+
+    def test_a_plain_text_cli_failure_is_a_limit(self):
+        # A hard stop can kill the CLI before it emits any JSON at all.
+        self.assertLimit(self.detect("Claude AI usage limit reached|1789362000\n"))
+
+    def test_an_agents_prose_about_rate_limiting_is_not_a_limit(self):
+        # Triangulation: an agent that fixes retry code writes these words into
+        # its own summary. Both phrases matched the pre-2026-09-08 pattern.
+        self.assertNoLimit(
+            self.detect(
+                "\n".join(
+                    [
+                        init_event(),
+                        result_event(
+                            "Added backoff for the API's rate limit and documented "
+                            "/usage-credits in the runbook."
+                        ),
+                    ]
+                )
+            )
+        )
+
+    def test_an_empty_log_is_not_a_limit(self):
+        self.assertNoLimit(self.detect(""))
+
+    def test_a_missing_log_is_not_a_limit(self):
+        # The loop must not die on a run that never opened its log file.
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertNoLimit(self.run_detector(str(Path(tmp) / "absent.json")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## File submission policy

Before attaching or committing files, read the [submission policy](https://github.com/developer0hye/office2pdf/blob/main/CONTRIBUTING.md).
Complete a security review and obtain your organization's internal approval for
public sharing where applicable. You are responsible for lawful disclosure;
the project and maintainers disclaim related liability to the extent permitted
by applicable law.

- [x] Any submitted sample files or attachments satisfy the submission policy, or none are submitted.

## Summary

`scripts/issue_loop.sh` decided a run had been rate-limited by grepping the whole run log for `usage limit|limit reached|reached your .{0,40}limit|usage-credits|rate.?limit`. That is safe only under `--output-format json`, which emits one result object. Under `--verbose --output-format stream-json` the same log also carries the CLI's own telemetry, and two parts of it match: the init event lists the available slash commands, one of which is `usage-credits`, and every turn emits a `rate_limit_event` whose status on a served request is `allowed` or `allowed_warning`.

The cost is the whole run rather than a wasted grep. The branch `continue`s to the top of the loop before the issue-state and merged-PR checks, so a finished agent's work is never counted and the loop sleeps an hour before repeating the same issue. Observed on 2026-09-08: a successful 79-turn run was discarded and the loop slept while its own telemetry reported `five_hour: 0.09`, `seven_day: 0.58`, `status: allowed_warning`. The hourly logs that day contain a genuine limit as well, so both classes had to keep working.

Key changes:

- `usage_limit_reason()` (`scripts/issue_loop.sh`): decides from what only the CLI can write — its `result` and `error` strings, its non-JSON output lines (a hard stop can kill the process before any JSON), and a `rate_limit_event` whose status does not start with `allowed`. A real limit reads `rejected`. It handles both output formats and a missing log.
- `--usage-limit-reason LOG`: prints that verdict for one log and exits 0 when a limit is found, 1 when not. It explains a stall after the fact, and it is the entry point the test drives, so the tests survive a rewrite of the detector. It is handled before the tool and gh-auth preflight, so an archived log can be re-read anywhere.
- `usage()`: scans to the first non-comment line instead of a hardcoded `sed -n '2,20p'` range. The range had drifted and `--help` was printing a stray `set -u`; the header block can now grow without that recurring.

Validated against the 25 archived run logs on the machine that hit this: 11 real limits (8 hourly refusals, 3 mid-run rejections) and 14 clean runs, each classified the way the run actually ended.

## Related issue

None. The defect is in the unattended harness itself, not in a tracked converter issue.

## Testing

- `python3 -m unittest discover -s scripts/tests -p 'test_issue_loop.py'` — 7 new tests: telemetry of a successful `--verbose` run is not a limit (the regression), a `rejected` rate_limit_event is, a refused run's `result` text is, a plain-text CLI failure is, an agent's own prose about rate limiting and `/usage-credits` is not (both phrases matched the old pattern), and an empty or missing log is not.
- `bash -n scripts/issue_loop.sh` — the existing CI syntax gate.
- `bash scripts/issue_loop.sh --help` — ends at the Requirements line, no stray `set -u`.
- `bash scripts/issue_loop.sh --usage-limit-reason LOG` over 25 archived run logs — 11 limits, 14 clean, matching what each run did.
- New CI step `Test issue-loop usage-limit detector`, beside the existing issue-loop viewer test.

## Visual impact

- [x] No rendered PDF change
- [ ] Rendered PDF change or visual evidence added
- Reason: The change is confined to the unattended issue-loop harness and its tests. No converter code path, fixture, or rendered output is touched.

## Checklist

- [x] Commits include a `Signed-off-by` line
- [x] PR scope contains one root cause
- [x] Remaining converter or harness deviations each reference an open issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bo9RBDBPEs2JFg2fEPmKJf
